### PR TITLE
Canvas zoom now accounts for height as well

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -609,7 +609,7 @@ Canvas.prototype.zoom = function(newScale, center) {
   var outer = vbox.outer;
 
   if (newScale === 'fit-viewport') {
-    newScale = Math.min(1, outer.width / vbox.inner.width);
+    newScale = Math.min(1, outer.width / vbox.inner.width, outer.height / vbox.inner.height);
   }
 
   if (center === 'auto') {


### PR DESCRIPTION
Currently the 'fit-viewport' option for the canvas.zoom function only takes into account the diagrams width which leads to the bottom of a tall diagram to get cut off.

This fix also accounts for the diagrams height and scales it down to fit the available height as well.
