### PR TITLE
fix(overlays): prevent display of overlays outside parent container

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -37,6 +37,7 @@ function createContainer(options) {
 
   assign(parent.style, {
     position: 'relative',
+    overflow: 'hidden',
     width: ensurePx(options.width),
     height: ensurePx(options.height)
   });


### PR DESCRIPTION
Without overflow:hidden in the container element, the html overlay elements are rendered outside the parent container
![bpmnioclipping](https://cloud.githubusercontent.com/assets/8982136/6409194/52d9921e-be60-11e4-9045-dc9edd73eda6.PNG)
