### PR TITLE
impr(zoomscroll): normalize zoom factor

### DIFF
--- a/lib/navigation/zoomscroll/ZoomScroll.js
+++ b/lib/navigation/zoomscroll/ZoomScroll.js
@@ -20,7 +20,7 @@ function ZoomScroll(events, canvas) {
   function zoom(direction, position) {
 
     var currentZoom = canvas.zoom();
-    var factor = 1 + (direction / ZOOM_OFFSET);
+    var factor = Math.pow(1 + Math.abs(direction / ZOOM_OFFSET) , direction > 0 ? 1 : -1);
 
     canvas.zoom(cap(currentZoom * factor), position);
   }


### PR DESCRIPTION
This PR improves the zoomscroll functionality by normalizing the zoom factor. When the user zooms out and then zooms in again, the zoom level is the same as before. With the previous solution, the diagram would be slightly zoomed out.