### PR TITLE
chore(command): set dependency to EventBus only

### DIFF
--- a/lib/command/index.js
+++ b/lib/command/index.js
@@ -1,4 +1,4 @@
 module.exports = {
-  __depends__: [ require('../core') ],
+  __depends__: [ require('../core/EventBus') ],
   commandStack: [ 'type', require('./CommandStack') ]
 };


### PR DESCRIPTION
The command module requires the whole core. This includes diagram-js specific things like Canvas and GraphicsFactory.

In order to make the Command and EventBus module independent from diagram-js, this PR changes the dependency of the command module to the EventBus only.