### PR TITLE
Symbols caused problems with Browserify

### DIFF
--- a/lib/draw/BaseRenderer.js
+++ b/lib/draw/BaseRenderer.js
@@ -19,7 +19,7 @@ function BaseRenderer(eventBus, renderPriority) {
         visuals = context.gfx;
 
     if (self.canRender(element)) {
-      if (type === 'render.shape') {
+      if (type === 'render.shape') {
         return self.drawShape(visuals, element);
       } else {
         return self.drawConnection(visuals, element);
@@ -29,7 +29,7 @@ function BaseRenderer(eventBus, renderPriority) {
 
   eventBus.on([ 'render.getShapePath', 'render.getConnectionPath'], renderPriority, function(evt, element) {
     if (self.canRender(element)) {
-      if (evt.type === 'render.getShapePath') {
+      if (evt.type === 'render.getShapePath') {
         return self.getShapePath(element);
       } else {
         return self.getConnectionPath(element);


### PR DESCRIPTION
Exchange a symbol " " with an actual space. The output files of browserify caused problems because they could not handle the symbol.