### PR TITLE
chore(test): Add .defined matcher

### DIFF
--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -12,3 +12,4 @@ TestHelper.insertCSS('diagram-js-testing.css',
 // add suite specific matchers
 global.chai.use(require('./matchers/BoundsMatchers'));
 global.chai.use(require('./matchers/ConnectionMatchers'));
+global.chai.use(require('./matchers/DefinedMatchers'));

--- a/test/matchers/DefinedMatchers.js
+++ b/test/matchers/DefinedMatchers.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = function (chai, utils) {
+  var Assertion = chai.Assertion;
+
+  utils.addProperty(Assertion.prototype, 'defined', function () {
+    var negate = utils.flag(this, 'negate'),
+      theAssert = new Assertion(this._obj);
+
+    if (negate) {
+      theAssert.to.be.undefined;
+    } else {
+      theAssert.to.not.be.undefined;
+    }
+  });
+};

--- a/test/matchers/DefinedMatchersSpec.js
+++ b/test/matchers/DefinedMatchersSpec.js
@@ -1,0 +1,15 @@
+'use strict';
+
+describe('matchers/DefinedMatchers', function () {
+  it('should define matcher .defined', function () {
+    expect((typeof expect("something").to.be.defined)).to.not.equal('undefined');
+  });
+
+  it('should .be.defined', function () {
+    expect("something").to.be.defined;
+  });
+
+  it('should .not.be.defined', function () {
+    expect(undefined).to.not.be.defined;
+  });
+});


### PR DESCRIPTION
Some tests (spec/features/modeling/DeleteElementsSpec.js is one example)
expects some value .to.be.defined or .to.not.be.defined.
But Chai does not have a .defined assertion. It's called .undefined.

Since .defined is undefined, the assertion is a no-op and won't detect
broken code.

I have tested this by commenting out the WHEN statement in
DeleteElementsSpec.js. Without this fix, the test will then silently
continue. With this fix the error is detected as expected.