### PR TITLE
Zoom scroll fix 416

### DIFF
--- a/lib/navigation/zoomscroll/ZoomScroll.js
+++ b/lib/navigation/zoomscroll/ZoomScroll.js
@@ -12,9 +12,14 @@ var getStepRange = require('./ZoomUtil').getStepRange,
 
 var log10 = require('../../util/Math').log10;
 
+var assign = require('lodash/object/assign');
 
 var RANGE = { min: 0.2, max: 4 },
     NUM_STEPS = 10;
+
+var DEFAULT_OPTIONS = {
+    disabled: false
+};
 
 /**
  * An implementation of zooming and scrolling within the {@link Canvas}.
@@ -24,13 +29,19 @@ var RANGE = { min: 0.2, max: 4 },
  */
 function ZoomScroll(eventBus, canvas, config) {
 
+  this.options = assign({}, DEFAULT_OPTIONS, config.zoomScroll || {});
+
+  // console.log("Config:");
+  // console.log(config.zoomScroll);
+  // console.log(this.options);
+
   this._canvas = canvas;
-  this._config = config;
+  this._container = canvas._container;
 
   var self = this;
 
   eventBus.on('canvas.init', function(e) {
-    self._init(canvas._container);
+    self._init();
   });
 }
 
@@ -82,53 +93,70 @@ ZoomScroll.prototype.stepZoom = function stepZoom(direction, position) {
 };
 
 
-ZoomScroll.prototype._init = function(element) {
+ZoomScroll.prototype.setEnabled = function setEnabled(enabled) {
 
-  if(this._config.disableZoomScroll) return;
+    // console.log("called setEnabled(" + enabled + ")");
 
-  var self = this;
+    var element = this._container;
+    var self = this;
 
-  domEvent.bind(element, 'wheel', function(event) {
+    function bindWheel(event) {
 
-    event.preventDefault();
+        event.preventDefault();
 
-    // mouse-event: SELECTION_KEY
-    // mouse-event: AND_KEY
-    var isVerticalScroll = hasPrimaryModifier(event),
-        isHorizontalScroll = hasSecondaryModifier(event);
+        // mouse-event: SELECTION_KEY
+        // mouse-event: AND_KEY
+        var isVerticalScroll = hasPrimaryModifier(event),
+            isHorizontalScroll = hasSecondaryModifier(event);
 
-    var factor;
+        var factor;
 
-    if (isVerticalScroll || isHorizontalScroll) {
+        if (isVerticalScroll || isHorizontalScroll) {
 
-      if (isMac) {
-        factor = event.deltaMode === 0 ? 1.25 : 50;
-      } else {
-        factor = event.deltaMode === 0 ? 1/40 : 1/2;
-      }
+          if (isMac) {
+            factor = event.deltaMode === 0 ? 1.25 : 50;
+          } else {
+            factor = event.deltaMode === 0 ? 1/40 : 1/2;
+          }
 
-      var delta = {};
+          var delta = {};
 
-      if (isHorizontalScroll) {
-        delta.dx = (factor * (event.deltaX || event.deltaY));
-      } else {
-        delta.dy = (factor * event.deltaY);
-      }
-      self.scroll(delta);
-    } else {
-      factor = (event.deltaMode === 0 ? 1/40 : 1/2);
+          if (isHorizontalScroll) {
+            delta.dx = (factor * (event.deltaX || event.deltaY));
+          } else {
+            delta.dy = (factor * event.deltaY);
+          }
+          self.scroll(delta);
+        } else {
+          factor = (event.deltaMode === 0 ? 1/40 : 1/2);
 
-      var elementRect = element.getBoundingClientRect();
+          var elementRect = element.getBoundingClientRect();
 
-      var offset =  {
-        x: event.clientX - elementRect.left,
-        y: event.clientY - elementRect.top
-      };
+          var offset =  {
+            x: event.clientX - elementRect.left,
+            y: event.clientY - elementRect.top
+          };
 
-      // zoom in relative to diagram {x,y} coordinates
-      self.zoom(event.deltaY * factor / (-5), offset);
+          // zoom in relative to diagram {x,y} coordinates
+          self.zoom(event.deltaY * factor / (-5), offset);
+        }
     }
-  });
+
+    if(enabled) {
+        // bin wheel to dom
+        domEvent.bind(element, 'wheel', bindWheel, true);
+    } else {
+        domEvent.unbind(element, 'wheel', bindWheel, true);
+    }
+};
+
+
+ZoomScroll.prototype._init = function() {
+
+  var disabled = this.options.disabled;
+
+  this.setEnabled(!disabled);
+
 };
 
 

--- a/lib/navigation/zoomscroll/ZoomScroll.js
+++ b/lib/navigation/zoomscroll/ZoomScroll.js
@@ -22,9 +22,10 @@ var RANGE = { min: 0.2, max: 4 },
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
  */
-function ZoomScroll(eventBus, canvas) {
+function ZoomScroll(eventBus, canvas, config) {
 
   this._canvas = canvas;
+  this._config = config;
 
   var self = this;
 
@@ -82,6 +83,9 @@ ZoomScroll.prototype.stepZoom = function stepZoom(direction, position) {
 
 
 ZoomScroll.prototype._init = function(element) {
+
+  if(this._config.disableZoomScroll) return;
+
   var self = this;
 
   domEvent.bind(element, 'wheel', function(event) {
@@ -128,6 +132,6 @@ ZoomScroll.prototype._init = function(element) {
 };
 
 
-ZoomScroll.$inject = [ 'eventBus', 'canvas' ];
+ZoomScroll.$inject = [ 'eventBus', 'canvas', 'config' ];
 
 module.exports = ZoomScroll;


### PR DESCRIPTION
Issue: https://github.com/bpmn-io/bpmn-js/issues/416

You can now disable zoomScroll via config:

```javascript
var renderer = new BpmnModeler({ container: canvas, zoomScroll: { disabled: true } });
```

and enable it programmatically:

```javascript
renderer.invoke(function(zoomScroll){
   console.log("Invoked ZoomScroll")
   zoomScroll.setEnabled(true);
});
```

what does not work:
if zoom scroll is enabled i cant disable it via invoke. unbinding the domEvent does not work.