### PR TITLE
Declare `modeling` dependency on used by Move.js

### DIFF
--- a/lib/features/move/index.js
+++ b/lib/features/move/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   __depends__: [
     require('../interaction-events'),
+    require('../modeling'),
     require('../selection'),
     require('../outline'),
     require('../rules'),


### PR DESCRIPTION
I am still trying to understand the project but it seems that this dependency is missing in the declarations as `modeling` is used inside Move.js

I hope this helps. Congratulations on your diagram framework. It looks very impressive even if very intimidating !