### PR TITLE
Add ability to clear the diagram

### DIFF
--- a/lib/Diagram.js
+++ b/lib/Diagram.js
@@ -191,3 +191,10 @@ module.exports = Diagram;
 Diagram.prototype.destroy = function() {
   this.get('eventBus').fire('diagram.destroy');
 };
+
+/**
+ * Clear the diagram, removing all contents.
+ */
+Diagram.prototype.clear = function() {
+  this.get('eventBus').fire('diagram.clear');
+};

--- a/lib/command/CommandStack.js
+++ b/lib/command/CommandStack.js
@@ -117,6 +117,8 @@ function CommandStack(eventBus, injector) {
   this._eventBus = eventBus;
 
   this._uid = 1;
+
+  eventBus.on([ 'diagram.destroy', 'diagram.clear' ], this.clear, this);
 }
 
 CommandStack.$inject = [ 'eventBus', 'injector' ];

--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -6,7 +6,8 @@ var isNumber = require('lodash/lang/isNumber'),
     every = require('lodash/collection/every'),
     debounce = require('lodash/function/debounce');
 
-var Collections = require('../util/Collections');
+var Collections = require('../util/Collections'),
+    Elements = require('../util/Elements');
 
 var Snap = require('../../vendor/snapsvg');
 
@@ -75,6 +76,7 @@ var REQUIRED_MODEL_ATTRS = {
  * @param {ElementRegistry} elementRegistry
  */
 function Canvas(config, eventBus, graphicsFactory, elementRegistry) {
+
   this._eventBus = eventBus;
   this._elementRegistry = elementRegistry;
   this._graphicsFactory = graphicsFactory;
@@ -89,6 +91,8 @@ module.exports = Canvas;
 
 Canvas.prototype._init = function(config) {
 
+  var eventBus = this._eventBus;
+
   // Creates a <svg> element that is wrapped into a <div>.
   // This way we are always able to correctly figure out the size of the svg element
   // by querying the parent node.
@@ -102,20 +106,19 @@ Canvas.prototype._init = function(config) {
   // </div>
 
   // html container
-  var eventBus = this._eventBus,
+  var container = this._container = createContainer(config),
+      svg = this._svg = Snap.createSnapAt('100%', '100%', container),
+      viewport = this._viewport = createGroup(svg, 'viewport');
 
-      container = createContainer(config),
-      svg = Snap.createSnapAt('100%', '100%', container),
-      viewport = createGroup(svg, 'viewport'),
-
-      self = this;
-
-  this._container = container;
-  this._svg = svg;
-  this._viewport = viewport;
   this._layers = {};
 
-  eventBus.on('diagram.init', function(event) {
+  // debounce canvas.viewbox.changed events
+  // for smoother diagram interaction
+  if (config.deferUpdate !== false) {
+    this._viewboxChanged = debounce(this._viewboxChanged, 300);
+  }
+
+  eventBus.on('diagram.init', function() {
 
     /**
      * An event indicating that the canvas is ready to be drawn on.
@@ -128,29 +131,58 @@ Canvas.prototype._init = function(config) {
      * @property {Snap<SVGSVGElement>} svg the created svg element
      * @property {Snap<SVGGroup>} viewport the direct parent of diagram elements and shapes
      */
-    eventBus.fire('canvas.init', { svg: svg, viewport: viewport });
+    eventBus.fire('canvas.init', {
+      svg: svg,
+      viewport: viewport
+    });
+
+  }, this);
+
+  eventBus.on('diagram.destroy', 500, this._destroy, this);
+  eventBus.on('diagram.clear', 500, this._clear, this);
+};
+
+Canvas.prototype._destroy = function(emit) {
+  this._eventBus.fire('canvas.destroy', {
+    svg: this._svg,
+    viewport: this._viewport
   });
 
-  eventBus.on('diagram.destroy', function() {
+  var parent = this._container.parentNode;
 
-    var parent = self._container.parentNode;
-
-    if (parent) {
-      parent.removeChild(container);
-    }
-
-    eventBus.fire('canvas.destroy', { svg: self._svg, viewport: self._viewport });
-
-    self._svg.remove();
-
-    self._svg = self._container = self._layers = self._viewport = null;
-  });
-
-  // debounce canvas.viewbox.changed events
-  // for smoother diagram interaction
-  if (config.deferUpdate !== false) {
-    this._viewboxChanged = debounce(this._viewboxChanged, 300);
+  if (parent) {
+    parent.removeChild(this._container);
   }
+
+  delete this._svg;
+  delete this._container;
+  delete this._layers;
+  delete this._rootElement;
+  delete this._viewport;
+};
+
+Canvas.prototype._clear = function() {
+
+  var self = this;
+
+  var allElements = this._elementRegistry.getAll();
+
+  // remove all elements
+  allElements.forEach(function(element) {
+    var type = Elements.getType(element);
+
+    if (type === 'root') {
+      self.setRootElement(null, true);
+    } else {
+      self._removeElement(element, type);
+    }
+  });
+
+  // clean up elements in dom
+  this._graphicsFactory.updateContainments(allElements);
+
+  // force recomputation of view box
+  delete this._cachedViewbox;
 };
 
 /**
@@ -324,32 +356,36 @@ Canvas.prototype.getRootElement = function() {
  */
 Canvas.prototype.setRootElement = function(element, override) {
 
-  this._ensureValid('root', element);
+  if (element) {
+    this._ensureValid('root', element);
+  }
 
-  var oldRoot = this._rootElement,
+  var currentRoot = this._rootElement,
       elementRegistry = this._elementRegistry,
       eventBus = this._eventBus;
 
-  if (oldRoot) {
+  if (currentRoot) {
     if (!override) {
       throw new Error('rootElement already set, need to specify override');
     }
 
     // simulate element remove event sequence
-    eventBus.fire('root.remove', { element: oldRoot });
-    eventBus.fire('root.removed', { element: oldRoot });
+    eventBus.fire('root.remove', { element: currentRoot });
+    eventBus.fire('root.removed', { element: currentRoot });
 
-    elementRegistry.remove(oldRoot);
+    elementRegistry.remove(currentRoot);
   }
 
-  var gfx = this.getDefaultLayer();
+  if (element) {
+    var gfx = this.getDefaultLayer();
 
-  // resemble element add event sequence
-  eventBus.fire('root.add', { element: element });
+    // resemble element add event sequence
+    eventBus.fire('root.add', { element: element });
 
-  elementRegistry.add(element, gfx, this._svg);
+    elementRegistry.add(element, gfx, this._svg);
 
-  eventBus.fire('root.added', { element: element, gfx: gfx });
+    eventBus.fire('root.added', { element: element, gfx: gfx });
+  }
 
   this._rootElement = element;
 
@@ -556,36 +592,6 @@ Canvas.prototype.removeConnection = function(connection) {
    * @property {Object} gfx the graphical representation of the connection
    */
   return this._removeElement(connection, 'connection');
-};
-
-
-/**
- * Sends a shape to the front.
- *
- * This method takes parent / child relationships between shapes into account
- * and makes sure that children are properly handled, too.
- *
- * @param {djs.model.Shape} shape descriptor of the shape to be sent to front
- * @param {boolean} [bubble=true] whether to send parent shapes to front, too
- */
-Canvas.prototype.sendToFront = function(shape, bubble) {
-
-  if (bubble !== false) {
-    bubble = true;
-  }
-
-  if (bubble && shape.parent) {
-    this.sendToFront(shape.parent);
-  }
-
-  forEach(shape.children, function(child) {
-    this.sendToFront(child, false);
-  }, this);
-
-  var gfx = this.getGraphics(shape),
-      gfxParent = gfx.parent();
-
-  gfx.remove().appendTo(gfxParent);
 };
 
 

--- a/lib/core/EventBus.js
+++ b/lib/core/EventBus.js
@@ -98,15 +98,9 @@ var slice = Array.prototype.slice;
 function EventBus() {
   this._listeners = {};
 
-  // cleanup on destroy
-
-  var self = this;
-
-  // destroy on lowest priority to allow
+  // cleanup on destroy on lowest priority to allow
   // message passing until the bitter end
-  this.on('diagram.destroy', 1, function() {
-    self._listeners = null;
-  });
+  this.on('diagram.destroy', 1, this._destroy, this);
 }
 
 module.exports = EventBus;
@@ -327,6 +321,10 @@ EventBus.prototype.handleError = function(error) {
   return this.fire('error', { error: error }) === false;
 };
 
+
+EventBus.prototype._destroy = function() {
+  this._listeners = {};
+};
 
 EventBus.prototype._invokeListeners = function(event, args, listeners) {
 

--- a/lib/features/bendpoints/BendpointMove.js
+++ b/lib/features/bendpoints/BendpointMove.js
@@ -176,6 +176,7 @@ function BendpointMove(injector, eventBus, canvas, dragging, graphicsFactory, ru
   ], function(e) {
 
     var context = e.context,
+        hover = context.hover,
         connection = context.connection;
 
     // remove dragger gfx
@@ -183,8 +184,11 @@ function BendpointMove(injector, eventBus, canvas, dragging, graphicsFactory, ru
     context.newWaypoints = connection.waypoints.slice();
     connection.waypoints = context.originalWaypoints;
     canvas.removeMarker(connection, MARKER_CONNECT_UPDATING);
-    canvas.removeMarker(context.hover, MARKER_OK);
-    canvas.removeMarker(context.hover, MARKER_NOT_OK);
+
+    if (hover) {
+      canvas.removeMarker(hover, MARKER_OK);
+      canvas.removeMarker(hover, MARKER_NOT_OK);
+    }
   });
 
   eventBus.on('bendpoint.move.end', function(e) {

--- a/lib/features/change-support/ChangeSupport.js
+++ b/lib/features/change-support/ChangeSupport.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var getElementType = require('../../util/Elements').getType;
+
 /**
  * Adds change support to the diagram, including
  *
@@ -18,8 +20,7 @@ function ChangeSupport(eventBus, canvas, elementRegistry, graphicsFactory) {
 
   eventBus.on('element.changed', function(event) {
 
-    var element = event.element,
-        type;
+    var element = event.element;
 
     if (!event.gfx) {
       event.gfx = elementRegistry.getGraphics(element);
@@ -30,15 +31,7 @@ function ChangeSupport(eventBus, canvas, elementRegistry, graphicsFactory) {
       return;
     }
 
-
-    // element may be root
-    if (canvas.getRootElement() === element) {
-      type = 'root';
-    } else {
-      type = element.waypoints ? 'connection' : 'shape';
-    }
-
-    eventBus.fire(type + '.changed', event);
+    eventBus.fire(getElementType(element) + '.changed', event);
   });
 
   eventBus.on('elements.changed', function(event) {

--- a/lib/util/Elements.js
+++ b/lib/util/Elements.js
@@ -276,3 +276,19 @@ module.exports.getBBox = getBBox;
 module.exports.getEnclosedElements = getEnclosedElements;
 
 module.exports.getClosure = getClosure;
+
+
+function getElementType(element) {
+
+  if ('waypoints' in element) {
+    return 'connection';
+  }
+
+  if ('x' in element) {
+    return 'shape';
+  }
+
+  return 'root';
+}
+
+module.exports.getType = getElementType;

--- a/test/helper/index.js
+++ b/test/helper/index.js
@@ -74,7 +74,13 @@ function bootstrapDiagram(options, locals) {
       _locals = _locals();
     }
 
-    _options = merge({ canvas: { container: testContainer } }, OPTIONS, _options);
+    _options = merge({
+      canvas: {
+        container: testContainer,
+        deferUpdate: false
+      },
+    }, OPTIONS, _options);
+
 
     var mockModule = {};
 

--- a/test/helper/index.js
+++ b/test/helper/index.js
@@ -84,6 +84,9 @@ function bootstrapDiagram(options, locals) {
 
     _options.modules = unique([].concat(_options.modules || [], [ mockModule ]));
 
+    // remove previous instance
+    cleanup();
+
     DIAGRAM_JS = new Diagram(_options);
   };
 }
@@ -121,6 +124,13 @@ function inject(fn) {
   };
 }
 
+function cleanup() {
+  if (!DIAGRAM_JS) {
+    return;
+  }
+
+  DIAGRAM_JS.destroy();
+}
 
 module.exports.bootstrapDiagram = (window || global).bootstrapDiagram = bootstrapDiagram;
 module.exports.inject = (window || global).inject = inject;

--- a/test/spec/command/CommandStackSpec.js
+++ b/test/spec/command/CommandStackSpec.js
@@ -670,7 +670,7 @@ describe('command/CommandStack', function() {
   });
 
 
-  describe('stack information ', function() {
+  describe('stack information', function() {
 
     var Handler = function(eventBus) {
 
@@ -743,6 +743,32 @@ describe('command/CommandStack', function() {
         expect(commandStack.canRedo()).to.be.false;
       }));
     });
+
+  });
+
+
+  describe('diagram life-cycle integration', function() {
+
+    function verifyClearOn(eventName) {
+
+      return function(eventBus, commandStack) {
+
+        // given
+        commandStack._stack.push('FOO');
+        commandStack._stackIdx = 10;
+
+        // when
+        eventBus.fire(eventName);
+
+        // then
+        expect(commandStack._stack).to.be.empty;
+        expect(commandStack._stackIdx).to.eql(-1);
+      };
+    }
+
+    it('should clear on diagram.destroy', inject(verifyClearOn('diagram.destroy')));
+
+    it('should clear on diagram.clear', inject(verifyClearOn('diagram.clear')));
 
   });
 

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -47,13 +47,41 @@ describe('Canvas', function() {
 
     beforeEach(createDiagram());
 
-    it('should remove created elements', inject(function(eventBus, canvas) {
+
+    it('should detach diagram container', inject(function(eventBus, canvas) {
 
       // when
       eventBus.fire('diagram.destroy');
 
       // then
       expect(container.childNodes.length).to.equal(0);
+    }));
+
+  });
+
+
+  describe('clear', function() {
+
+    beforeEach(createDiagram());
+
+
+    it('should remove elements', inject(function(canvas, elementRegistry) {
+
+      // given
+      canvas.setRootElement({ id: 'FOO' });
+
+      canvas.addShape({ id: 'a', x: 10, y: 20, width: 50, height: 50 });
+      canvas.addShape({ id: 'b', x: 100, y: 20, width: 50, height: 50 });
+
+      // when
+      canvas._clear();
+
+      // then
+      expect(canvas._rootElement).not.to.exist;
+
+      expect(elementRegistry.getAll()).to.be.empty;
+
+      expect(canvas._cachedViewbox).not.to.exist;
     }));
 
   });
@@ -456,6 +484,21 @@ describe('Canvas', function() {
     }));
 
 
+    it('should unset root element with override flag', inject(function(canvas, elementRegistry) {
+
+      // given
+      canvas.setRootElement({ id: 'root' });
+
+      // when
+      canvas.setRootElement(null, true);
+
+      // then
+      expect(canvas._rootElement).to.equal(null);
+
+      expect(elementRegistry.getAll()).to.be.empty;
+    }));
+
+
     it('should use explicitly defined root element', inject(function(canvas, elementRegistry) {
 
       // given
@@ -466,31 +509,6 @@ describe('Canvas', function() {
 
       // then
       expect(shape.parent).to.equal(rootElement);
-    }));
-
-  });
-
-
-  describe('update behavior', function() {
-
-    beforeEach(function() {
-      container = TestContainer.get(this);
-    });
-    beforeEach(createDiagram());
-
-    var a, b, c;
-
-    beforeEach(inject(function(canvas) {
-      a = canvas.addShape({ id: 'a', x: 10, y: 20, width: 50, height: 50 });
-      b = canvas.addShape({ id: 'b', x: 20, y: 30, width: 50, height: 50 });
-      c = canvas.addShape({ id: 'c', x: 30, y: 40, width: 50, height: 50 });
-    }));
-
-    it('should update shape z-index', inject(function(canvas, eventBus) {
-
-      // when
-
-      // then
     }));
 
   });


### PR DESCRIPTION
* Components can hook into diagram.clear event
* Clear and destroy work properly

Required for bpmn-io/bpmn-js#237.