### PR TITLE
fix(CommandStack): Given array, dirty elements should exclude undefined

### DIFF
--- a/lib/command/CommandStack.js
+++ b/lib/command/CommandStack.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var unique = require('lodash/array/unique'),
+    filter = require('lodash/collection/filter'),
     isArray = require('lodash/lang/isArray'),
     assign = require('lodash/object/assign');
 
@@ -432,7 +433,13 @@ CommandStack.prototype._markDirty = function(elements) {
     return;
   }
 
-  elements = isArray(elements) ? elements : [ elements ];
+  if (isArray(elements)) {
+      elements = filter(elements, function (element) {
+         return !!element;
+      });
+  } else {
+    elements = [ elements ];
+  }
 
   execution.dirty = execution.dirty.concat(elements);
 };

--- a/test/spec/command/CommandStackSpec.js
+++ b/test/spec/command/CommandStackSpec.js
@@ -667,6 +667,40 @@ describe('command/CommandStack', function() {
       expect(events).to.eql([ [ s1, s2 ] ]);
     }));
 
+    it('should update only non-undefined dirty shapes after change', inject(function(commandStack, eventBus) {
+
+      // given
+      var BadInnerHandler = function () {
+
+        this.execute = function (context) {
+          return [ context.s1, undefined, context.s2 ];
+        };
+
+        this.revert = function (context) {
+          return [ context.s1, undefined, context.s2 ];
+        };
+      };
+
+      commandStack.registerHandler('outer-command', OuterHandler);
+      commandStack.registerHandler('inner-command', BadInnerHandler);
+
+      var s1 = {}, s2 = {}, context = { s1: s1, s2: s2 };
+
+      var events = [];
+
+      function logEvent(e) {
+        events.push(e.elements);
+      }
+
+      eventBus.on('elements.changed', logEvent);
+
+      // when
+      commandStack.execute('outer-command', context);
+
+      // then
+      expect(events).to.eql([ [ s1, s2 ] ]);
+    }));
+
   });
 
 


### PR DESCRIPTION
This commit will prevent undefined elements to being concated to
CommandStack's dirty collection.

If the command handler returned a single item and that item would be
a undefined reference, CommandStack will prevent it from being tracked
as dirty.

However, if a command handler returns an array containing a undefined
element, the array will simply be concated to the dirty collection
without filter the undefined element.

The above can be reproduced in the current version of bpmn-js (v0.14.1)

  1. Create a gateway
  2. Create a second element (task for example)
  3. Create a sequence flow connection from the gateway to the task
  4. Make the sequence flow default
  5. Remove the sequence flow connection
  6. Create a sequence flow connection from the gateway to the task (new)
  7. Make the sequence flow default

The 7th step will produce an exception as the UpdatePropertiesHandler
will return undefined as the first sequence flow no longer exists, but
the gateway's default property was not cleared in step 5.