### PR TITLE
feat(modeling): Model can be read-only

### DIFF
--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -44,8 +44,15 @@ ContextPad.prototype._init = function() {
 
   var self = this;
 
-  eventBus.on('selection.changed', function(e) {
+  eventBus.on('readOnly.changed', function (e) {
+    self._readOnly = e.readOnly;
 
+    if (e.readOnly && self.isOpen()) {
+      self.close();
+    }
+  });
+
+  eventBus.on('selection.changed', function(e) {
     var selection = e.newSelection;
 
     if (selection.length === 1) {
@@ -159,7 +166,7 @@ ContextPad.prototype.trigger = function(action, event, autoActivate) {
  * @param {Boolean} force if true, force reopening the context pad
  */
 ContextPad.prototype.open = function(element, force) {
-  if (!force && this.isOpen(element)) {
+  if ((!force && this.isOpen(element)) || this._readOnly) {
     return;
   }
 

--- a/lib/features/dragging/Dragging.js
+++ b/lib/features/dragging/Dragging.js
@@ -126,6 +126,9 @@ function Dragging(eventBus, canvas, selection) {
   // it is visually _active_ only when a context.active flag is set to true.
   var context;
 
+  // tracks read-only state of model
+  var readOnly;
+
   /* convert a global event into local coordinates */
   function toLocalPoint(globalPosition) {
 
@@ -396,6 +399,10 @@ function Dragging(eventBus, canvas, selection) {
    */
   function init(event, relativeTo, prefix, options) {
 
+    if (readOnly) {
+      return;
+    }
+
     // only one drag operation may be active, at a time
     if (context) {
       cancel(false);
@@ -480,6 +487,14 @@ function Dragging(eventBus, canvas, selection) {
 
   // cancel on diagram destruction
   eventBus.on('diagram.destroy', cancel);
+
+  // cancel when modeling is disabled
+  eventBus.on('readOnly.changed', function (e) {
+    readOnly = e.readOnly
+    if (e.readOnly) {
+      cancel();
+    }
+  });
 
 
   // API

--- a/lib/features/editor-actions/EditorActions.js
+++ b/lib/features/editor-actions/EditorActions.js
@@ -18,19 +18,41 @@ var NOT_REGISTERED_ERROR = 'is not a registered action',
 function EditorActions(eventBus, commandStack, modeling, selection,
   zoomScroll, copyPaste, canvas, rules, mouseTracking) {
 
+  var readOnly;
+
+  eventBus.on('readOnly.changed', function (e) {
+    readOnly = e.readOnly;
+  });
+
   this._actions = {
     undo: function() {
+      if (readOnly) {
+        return;
+      }
+
       commandStack.undo();
     },
     redo: function() {
+      if (readOnly) {
+        return;
+      }
+
       commandStack.redo();
     },
     copy: function() {
+      if (readOnly) {
+        return;
+      }
+
       var selectedElements = selection.get();
 
       copyPaste.copy(selectedElements);
     },
     paste: function() {
+      if (readOnly) {
+        return;
+      }
+
       var context = mouseTracking.getHoverContext();
 
       copyPaste.paste(context);
@@ -42,6 +64,10 @@ function EditorActions(eventBus, commandStack, modeling, selection,
       canvas.zoom(opts.value);
     },
     removeSelection: function() {
+      if (readOnly) {
+        return;
+      }
+
       var selectedElements = selection.get();
 
       if (selectedElements.length) {

--- a/lib/features/modeling/Modeling.js
+++ b/lib/features/modeling/Modeling.js
@@ -80,6 +80,7 @@ Modeling.prototype.registerHandlers = function(commandStack) {
 ///// modeling helpers /////////////////////////////////////////
 
 Modeling.prototype.moveShape = function(shape, delta, newParent, newParentIndex, hints) {
+  this._throwIfReadOnly();
 
   if (typeof newParentIndex === 'object') {
     hints = newParentIndex;
@@ -105,6 +106,8 @@ Modeling.prototype.moveShape = function(shape, delta, newParent, newParentIndex,
  * @param  {djs.model.Base} [newHost]
  */
 Modeling.prototype.updateAttachment = function(shape, newHost) {
+  this._throwIfReadOnly();
+
   var context = {
     shape: shape,
     newHost: newHost
@@ -124,6 +127,8 @@ Modeling.prototype.updateAttachment = function(shape, newHost) {
  * @param {Object} [hints]
  */
 Modeling.prototype.moveElements = function(shapes, delta, target, isAttach, hints) {
+  this._throwIfReadOnly();
+
   if (typeof isAttach === 'object') {
     hints = isAttach;
     isAttach = undefined;
@@ -153,6 +158,7 @@ Modeling.prototype.moveElements = function(shapes, delta, target, isAttach, hint
 };
 
 Modeling.prototype.moveConnection = function(connection, delta, newParent, newParentIndex, hints) {
+  this._throwIfReadOnly();
 
   if (typeof newParentIndex === 'object') {
     hints = newParentIndex;
@@ -172,6 +178,8 @@ Modeling.prototype.moveConnection = function(connection, delta, newParent, newPa
 
 
 Modeling.prototype.layoutConnection = function(connection, hints) {
+  this._throwIfReadOnly();
+
   var context = {
     connection: connection,
     hints: hints || {}
@@ -193,6 +201,7 @@ Modeling.prototype.layoutConnection = function(connection, hints) {
  * @return {djs.model.Connection} the created connection.
  */
 Modeling.prototype.createConnection = function(source, target, targetIndex, connection, parent, hints) {
+  this._throwIfReadOnly();
 
   if (typeof targetIndex === 'object') {
     hints = parent;
@@ -218,6 +227,7 @@ Modeling.prototype.createConnection = function(source, target, targetIndex, conn
 };
 
 Modeling.prototype.createShape = function(shape, position, target, targetIndex, isAttach, hints) {
+  this._throwIfReadOnly();
 
   if (typeof targetIndex !== 'number') {
     hints = isAttach;
@@ -252,6 +262,7 @@ Modeling.prototype.createShape = function(shape, position, target, targetIndex, 
 
 
 Modeling.prototype.createLabel = function(labelTarget, position, label, parent) {
+  this._throwIfReadOnly();
 
   label = this._create('label', label);
 
@@ -269,6 +280,7 @@ Modeling.prototype.createLabel = function(labelTarget, position, label, parent) 
 
 
 Modeling.prototype.appendShape = function(source, shape, position, parent, connection, connectionParent) {
+  this._throwIfReadOnly();
 
   shape = this._create('shape', shape);
 
@@ -288,6 +300,8 @@ Modeling.prototype.appendShape = function(source, shape, position, parent, conne
 
 
 Modeling.prototype.removeElements = function(elements) {
+  this._throwIfReadOnly();
+
   var context = {
     elements: elements
   };
@@ -297,6 +311,8 @@ Modeling.prototype.removeElements = function(elements) {
 
 
 Modeling.prototype.distributeElements = function(groups, axis, dimension) {
+  this._throwIfReadOnly();
+
   var context = {
     groups: groups,
     axis: axis,
@@ -308,6 +324,8 @@ Modeling.prototype.distributeElements = function(groups, axis, dimension) {
 
 
 Modeling.prototype.removeShape = function(shape, hints) {
+  this._throwIfReadOnly();
+
   var context = {
     shape: shape,
     hints: hints || {}
@@ -318,6 +336,8 @@ Modeling.prototype.removeShape = function(shape, hints) {
 
 
 Modeling.prototype.removeConnection = function(connection, hints) {
+  this._throwIfReadOnly();
+
   var context = {
     connection: connection,
     hints: hints || {}
@@ -327,6 +347,8 @@ Modeling.prototype.removeConnection = function(connection, hints) {
 };
 
 Modeling.prototype.replaceShape = function(oldShape, newShape, hints) {
+  this._throwIfReadOnly();
+
   var context = {
     oldShape: oldShape,
     newData: newShape,
@@ -339,6 +361,8 @@ Modeling.prototype.replaceShape = function(oldShape, newShape, hints) {
 };
 
 Modeling.prototype.pasteElements = function(tree, topParent, position) {
+  this._throwIfReadOnly();
+
   var context = {
     tree: tree,
     topParent: topParent,
@@ -349,6 +373,8 @@ Modeling.prototype.pasteElements = function(tree, topParent, position) {
 };
 
 Modeling.prototype.alignElements = function(elements, alignment) {
+  this._throwIfReadOnly();
+
   var context = {
     elements: elements,
     alignment: alignment
@@ -358,6 +384,8 @@ Modeling.prototype.alignElements = function(elements, alignment) {
 };
 
 Modeling.prototype.resizeShape = function(shape, newBounds) {
+  this._throwIfReadOnly();
+
   var context = {
     shape: shape,
     newBounds: newBounds
@@ -367,6 +395,8 @@ Modeling.prototype.resizeShape = function(shape, newBounds) {
 };
 
 Modeling.prototype.createSpace = function(movingShapes, resizingShapes, delta, direction) {
+  this._throwIfReadOnly();
+
   var context = {
     movingShapes: movingShapes,
     resizingShapes: resizingShapes,
@@ -378,6 +408,8 @@ Modeling.prototype.createSpace = function(movingShapes, resizingShapes, delta, d
 };
 
 Modeling.prototype.updateWaypoints = function(connection, newWaypoints, hints) {
+  this._throwIfReadOnly();
+
   var context = {
     connection: connection,
     newWaypoints: newWaypoints,
@@ -388,6 +420,8 @@ Modeling.prototype.updateWaypoints = function(connection, newWaypoints, hints) {
 };
 
 Modeling.prototype.reconnectStart = function(connection, newSource, dockingOrPoints) {
+  this._throwIfReadOnly();
+
   var context = {
     connection: connection,
     newSource: newSource,
@@ -398,6 +432,8 @@ Modeling.prototype.reconnectStart = function(connection, newSource, dockingOrPoi
 };
 
 Modeling.prototype.reconnectEnd = function(connection, newTarget, dockingOrPoints) {
+  this._throwIfReadOnly();
+
   var context = {
     connection: connection,
     newTarget: newTarget,
@@ -409,6 +445,25 @@ Modeling.prototype.reconnectEnd = function(connection, newTarget, dockingOrPoint
 
 Modeling.prototype.connect = function(source, target, attrs, hints) {
   return this.createConnection(source, target, attrs || {}, source.parent, hints);
+};
+
+Modeling.prototype.readOnly = function (readOnly) {
+  var newValue = !!readOnly,
+      oldValue = !!this._readOnly;
+
+  if (readOnly === undefined || newValue === oldValue) {
+    return oldValue;
+  }
+
+  this._readOnly = newValue;
+  this._eventBus.fire('readOnly.changed', { readOnly: newValue });
+  return newValue;
+};
+
+Modeling.prototype._throwIfReadOnly = function () {
+  if (this._readOnly) {
+    throw new Error('model is read-only');
+  }
 };
 
 Modeling.prototype._create = function(type, attrs) {

--- a/lib/features/palette/Palette.js
+++ b/lib/features/palette/Palette.js
@@ -40,6 +40,10 @@ function Palette(eventBus, canvas, dragging) {
   eventBus.on('i18n.changed', function() {
     self._update();
   });
+
+  eventBus.on('readOnly.changed', function () {
+    self._update();
+  });
 }
 
 Palette.$inject = [ 'eventBus', 'canvas', 'dragging' ];

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -227,6 +227,56 @@ describe('features/context-pad', function() {
     }));
 
 
+    describe('readOnly.changed', function () {
+
+      it('should close when model is read-only', inject(function(canvas, contextPad, overlays, eventBus) {
+
+        // given
+        var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+
+        canvas.addShape(shape);
+
+        contextPad.open(shape);
+
+        // when
+        eventBus.fire('readOnly.changed', { readOnly: true });
+
+        // then
+        expect(!!contextPad.isOpen()).to.be.false;
+      }));
+
+      it('should NOT open while model is read-only', inject(function(canvas, contextPad, overlays, eventBus) {
+
+        // given
+        var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+
+        canvas.addShape(shape);
+        eventBus.fire('readOnly.changed', { readOnly: true });
+
+        // when
+        contextPad.open(shape);
+
+        // then
+        expect(!!contextPad.isOpen()).to.be.false;
+      }));
+
+      it('should open after model has been read-only', inject(function(canvas, contextPad, overlays, eventBus) {
+
+        // given
+        var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+
+        canvas.addShape(shape);
+        eventBus.fire('readOnly.changed', { readOnly: true });
+        eventBus.fire('readOnly.changed', { readOnly: false });
+
+        // when
+        contextPad.open(shape);
+
+        // then
+        expect(contextPad.isOpen()).to.be.true;
+      }));
+    });
+
   });
 
 

--- a/test/spec/features/dragging/DraggingSpec.js
+++ b/test/spec/features/dragging/DraggingSpec.js
@@ -168,6 +168,54 @@ describe('features/dragging - Dragging', function() {
     }));
 
 
+    describe('readOnly.changed', function () {
+
+      it('should disable dragging while model is read-only', inject(function(eventBus, dragging, canvas) {
+
+        // given
+        var events = recordEvents('foo');
+        eventBus.fire('readOnly.changed', { readOnly: true });
+
+        // when
+        dragging.init(canvasEvent({ x: 10, y: 10 }), 'foo');
+
+        // then
+        expect(events.map(raw)).to.be.empty;
+      }));
+
+      it('should enable dragging when model is no longer read-only', inject(function(eventBus, dragging, canvas) {
+
+        // given
+        var events = recordEvents('foo');
+        eventBus.fire('readOnly.changed', { readOnly: true });
+        eventBus.fire('readOnly.changed', { readOnly: false });
+
+        // when
+        dragging.init(canvasEvent({ x: 10, y: 10 }), 'foo');
+
+        // then
+        expect(events.map(raw)).to.not.be.empty;
+      }));
+
+      it('should cancel ongoing running when model becomes read-only', inject(function(eventBus, dragging, canvas) {
+
+        // given
+        var events = recordEvents('foo');
+        dragging.init(canvasEvent({ x: 10, y: 10 }), 'foo');
+
+        // when
+        eventBus.fire('readOnly.changed', { readOnly: true });
+
+        // then
+        expect(events.map(raw)).to.eql([
+          { type: 'foo.init' },
+          { type: 'foo.cleanup' }
+        ]);
+      }));
+
+    });
+
+
     describe('djs-drag-active marker', function() {
 
       it('should not add to root on drag start', inject(function(dragging, canvas, elementRegistry) {

--- a/test/spec/features/editor-actions/EditorActionsSpec.js
+++ b/test/spec/features/editor-actions/EditorActionsSpec.js
@@ -188,6 +188,242 @@ describe('features/editor-actions', function() {
 
   describe('actions', function() {
 
+    describe('undo', function () {
+      var undo;
+
+      beforeEach(inject(function(commandStack) {
+        undo = sinon.spy(commandStack, 'undo');
+      }));
+
+      it('should NOT call commandStack.undo while model is read-only', inject(function(eventBus, editorActions) {
+        // given
+        eventBus.fire('readOnly.changed', { readOnly: true });
+
+        // when
+        editorActions.trigger('undo');
+
+        // then
+        expect(undo).to.not.have.been.called;
+      }));
+
+      it('should call commandStack.undo after model was read-only', inject(function(eventBus, editorActions) {
+        // given
+        eventBus.fire('readOnly.changed', { readOnly: true });
+        eventBus.fire('readOnly.changed', { readOnly: false });
+
+        // when
+        editorActions.trigger('undo');
+
+        // then
+        expect(undo).to.have.been.calledOnce;
+      }));
+
+    });
+
+    describe('redo', function () {
+      var redo;
+
+      beforeEach(inject(function(commandStack) {
+        redo = sinon.spy(commandStack, 'redo');
+      }));
+
+      it('should NOT call commandStack.redo while model is read-only', inject(function(eventBus, editorActions) {
+        // given
+        eventBus.fire('readOnly.changed', { readOnly: true });
+
+        // when
+        editorActions.trigger('redo');
+
+        // then
+        expect(redo).to.not.have.been.called;
+      }));
+
+      it('should call commandStack.redo after model was read-only', inject(function(eventBus, editorActions) {
+        // given
+        eventBus.fire('readOnly.changed', { readOnly: true });
+        eventBus.fire('readOnly.changed', { readOnly: false });
+
+        // when
+        editorActions.trigger('redo');
+
+        // then
+        expect(redo).to.have.been.calledOnce;
+      }));
+
+    });
+
+    describe('copy', function () {
+      var selectedElements,
+          copy;
+
+      beforeEach(inject(function(selection, copyPaste) {
+        selectedElements = [];
+
+        sinon.stub(selection, 'get', function() {
+          return selectedElements;
+        });
+
+        copy = sinon.stub(copyPaste, 'copy', function () {});
+      }));
+
+      it('should call copyPaste.copy with selected elements', inject(function(eventBus, editorActions) {
+        // given
+        selectedElements = ['any'];
+
+        // when
+        editorActions.trigger('copy');
+
+        // then
+        expect(copy).to.have.been.calledOnce;
+        expect(copy).to.have.been.calledWith(selectedElements);
+      }));
+
+      it('should NOT call copyPaste.copy while model is read-only', inject(function(eventBus, editorActions) {
+        // given
+        eventBus.fire('readOnly.changed', { readOnly: true });
+
+        // when
+        editorActions.trigger('copy');
+
+        // then
+        expect(copy).to.not.have.been.called;
+      }));
+
+      it('should call copyPaste.copy after model was read-only', inject(function(eventBus, editorActions) {
+        // given
+        eventBus.fire('readOnly.changed', { readOnly: true });
+        eventBus.fire('readOnly.changed', { readOnly: false });
+
+        // when
+        editorActions.trigger('copy');
+
+        // then
+        expect(copy).to.have.been.calledOnce;
+      }));
+
+    });
+
+    describe('paste', function () {
+      var hoverContext,
+          paste;
+
+      beforeEach(inject(function(mouseTracking, copyPaste) {
+        hoverContext = {};
+
+        sinon.stub(mouseTracking, 'getHoverContext', function() {
+          return hoverContext;
+        });
+
+        paste = sinon.stub(copyPaste, 'paste', function () {});
+      }));
+
+      it('should call copyPaste.paste with hoverContext', inject(function(eventBus, editorActions) {
+        // given
+        hoverContext = { foo: 'bar' };
+
+        // when
+        editorActions.trigger('paste');
+
+        // then
+        expect(paste).to.have.been.calledOnce;
+        expect(paste).to.have.been.calledWith(hoverContext);
+      }));
+
+      it('should NOT call copyPaste.paste while model is read-only', inject(function(eventBus, editorActions) {
+        // given
+        eventBus.fire('readOnly.changed', { readOnly: true });
+
+        // when
+        editorActions.trigger('paste');
+
+        // then
+        expect(paste).to.not.have.been.called;
+      }));
+
+      it('should call copyPaste.paste after model was read-only', inject(function(eventBus, editorActions) {
+        // given
+        eventBus.fire('readOnly.changed', { readOnly: true });
+        eventBus.fire('readOnly.changed', { readOnly: false });
+
+        // when
+        editorActions.trigger('paste');
+
+        // then
+        expect(paste).to.have.been.calledOnce;
+      }));
+
+    });
+
+    describe('stepZoom', function () {
+      var stepZoom,
+          opts;
+
+      beforeEach(inject(function(zoomScroll) {
+        opts = { value: 1 };
+
+        stepZoom = sinon.spy(zoomScroll, 'stepZoom');
+      }));
+
+      it('should call zoomScroll.stepZoom with value', inject(function(eventBus, editorActions) {
+        // given
+        opts = { value: 2 };
+
+        // when
+        editorActions.trigger('stepZoom', opts);
+
+        // then
+        expect(stepZoom).to.have.been.calledOnce;
+        expect(stepZoom).to.have.been.calledWith(opts.value);
+      }));
+
+      it('should call zoomScroll.stepZoom even if model is read-only', inject(function(eventBus, editorActions) {
+        // given
+        eventBus.fire('readOnly.changed', { readOnly: true });
+
+        // when
+        editorActions.trigger('stepZoom', opts);
+
+        // then
+        expect(stepZoom).to.have.been.called;
+      }));
+
+    });
+
+    describe('zoom', function () {
+      var zoom,
+          opts;
+
+      beforeEach(inject(function(canvas) {
+        opts = { value: 1 };
+
+        zoom = sinon.spy(canvas, 'zoom');
+      }));
+
+      it('should call canvas.zoom with value', inject(function(eventBus, editorActions) {
+        // given
+        opts = { value: 2 };
+
+        // when
+        editorActions.trigger('zoom', opts);
+
+        // then
+        expect(zoom).to.have.been.calledOnce;
+        expect(zoom).to.have.been.calledWith(opts.value);
+      }));
+
+      it('should call canvas.zoom even if model is read-only', inject(function(eventBus, editorActions) {
+        // given
+        eventBus.fire('readOnly.changed', { readOnly: true });
+
+        // when
+        editorActions.trigger('zoom', opts);
+
+        // then
+        expect(zoom).to.have.been.called;
+      }));
+
+    });
+
     describe('removeSelection', function() {
 
       var selectedElements,
@@ -299,6 +535,59 @@ describe('features/editor-actions', function() {
         }));
 
       });
+
+
+      describe('readOnly.changed', function () {
+
+        it('should NOT call modeling.removeElements when model is read-only', inject(function(editorActions, eventBus) {
+
+          // given
+          selectedElements = ['any'];
+          eventBus.fire('readOnly.changed', { readOnly: true });
+
+          // when
+          editorActions.trigger('removeSelection');
+
+          // then
+          expect(removeElements).to.not.have.been.called;
+        }));
+
+
+        it('should call modeling.removeElements after model was read-only', inject(function(editorActions, eventBus) {
+
+          // given
+          selectedElements = ['any'];
+          eventBus.fire('readOnly.changed', { readOnly: true });
+          eventBus.fire('readOnly.changed', { readOnly: false });
+
+          // when
+          editorActions.trigger('removeSelection');
+
+          // then
+          expect(removeElements).to.have.been.called;
+        }));
+
+      });
+
+    });
+
+    describe('moveCanvas', function () {
+      var scroll;
+
+      beforeEach(inject(function(canvas) {
+        scroll = sinon.spy(canvas, 'scroll');
+      }));
+
+      it('should scroll canvas even when model is read-only', inject(function(editorActions, eventBus) {
+        // given
+        eventBus.fire('readOnly.changed', { readOnly: true });
+
+        // when
+        editorActions.trigger('moveCanvas', { speed: 10, direction: 'left' });
+
+        // then
+        expect(scroll).to.have.been.calledOnce;
+      }));
 
     });
 

--- a/test/spec/features/modeling/AppendShapeSpec.js
+++ b/test/spec/features/modeling/AppendShapeSpec.js
@@ -156,4 +156,38 @@ describe('features/modeling - append shape', function() {
 
   });
 
+
+  describe('readOnly.changed', function() {
+
+    it('should throw Error while read-only', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+
+      // when
+      var action = function () {
+        modeling.appendShape(childShape, { id: 'appended', width: 100, height: 100 }, { x: 200, y: 200 });
+      };
+
+      // then
+      expect(action).to.throw(Error, 'model is read-only');
+    }));
+
+    it('should NOT throw Error when re-enabled', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+      modeling.readOnly(false);
+
+      // when
+      var action = function () {
+        modeling.appendShape(childShape, { id: 'appended', width: 100, height: 100 }, { x: 200, y: 200 });
+      };
+
+      // then
+      expect(action).not.to.throw();
+    }));
+
+  });
+
 });

--- a/test/spec/features/modeling/CreateLabelSpec.js
+++ b/test/spec/features/modeling/CreateLabelSpec.js
@@ -179,4 +179,38 @@ describe('features/modeling - create label', function() {
 
   });
 
+
+  describe('readOnly.changed', function() {
+
+    it('should throw Error while read-only', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+
+      // when
+      var action = function () {
+        modeling.createLabel(childShape, { x: 160, y: 250 });
+      };
+
+      // then
+      expect(action).to.throw(Error, 'model is read-only');
+    }));
+
+    it('should NOT throw Error when re-enabled', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+      modeling.readOnly(false);
+
+      // when
+      var action = function () {
+        modeling.createLabel(childShape, { x: 160, y: 250 });
+      };
+
+      // then
+      expect(action).not.to.throw();
+    }));
+
+  });
+
 });

--- a/test/spec/features/modeling/CreateShapeSpec.js
+++ b/test/spec/features/modeling/CreateShapeSpec.js
@@ -105,4 +105,38 @@ describe('features/modeling - create shape', function() {
 
   });
 
+
+  describe('readOnly.changed', function() {
+
+    it('should throw Error while read-only', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+
+      // when
+      var action = function () {
+        modeling.createShape(childShape, position, parentShape);
+      };
+
+      // then
+      expect(action).to.throw(Error, 'model is read-only');
+    }));
+
+    it('should NOT throw Error when re-enabled', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+      modeling.readOnly(false);
+
+      // when
+      var action = function () {
+        modeling.createShape(childShape, position, parentShape);
+      };
+
+      // then
+      expect(action).not.to.throw();
+    }));
+
+  });
+
 });

--- a/test/spec/features/modeling/DeleteConnectionSpec.js
+++ b/test/spec/features/modeling/DeleteConnectionSpec.js
@@ -167,4 +167,40 @@ describe('features/modeling - remove connection', function() {
       expect(childShape2.incoming).to.contain(connection);
     }));
   });
+
+
+  describe('readOnly.changed', function() {
+
+    it('should throw Error while read-only', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+
+      // when
+      var action = function () {
+        modeling.removeConnection(connection);
+      };
+
+      // then
+      expect(action).to.throw(Error, 'model is read-only');
+    }));
+
+    it('should NOT throw Error when re-enabled', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+      modeling.readOnly(false);
+
+      // when
+      var action = function () {
+        modeling.removeConnection(connection);
+      };
+
+      // then
+      expect(action).not.to.throw();
+    }));
+
+  });
+
+
 });

--- a/test/spec/features/modeling/DeleteElementsSpec.js
+++ b/test/spec/features/modeling/DeleteElementsSpec.js
@@ -102,4 +102,37 @@ describe('features/modeling - #removeElements', function() {
 
   });
 
+  describe('readOnly.changed', function() {
+
+    it('should throw Error while read-only', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+
+      // when
+      var action = function () {
+        modeling.removeElements([ connection, childShape, parentShape ]);
+      };
+
+      // then
+      expect(action).to.throw(Error, 'model is read-only');
+    }));
+
+    it('should NOT throw Error when re-enabled', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+      modeling.readOnly(false);
+
+      // when
+      var action = function () {
+        modeling.removeElements([ connection, childShape, parentShape ]);
+      };
+
+      // then
+      expect(action).not.to.throw();
+    }));
+
+  });
+
 });

--- a/test/spec/features/modeling/DeleteShapeSpec.js
+++ b/test/spec/features/modeling/DeleteShapeSpec.js
@@ -163,6 +163,40 @@ describe('features/modeling - #removeShape', function() {
       expect(childShape.label).to.be.null;
     }));
 
+
+    describe('readOnly.changed', function() {
+
+      it('should throw Error while read-only', inject(function(modeling, eventBus) {
+
+        // given
+        modeling.readOnly(true);
+
+        // when
+        var action = function () {
+          modeling.removeShape(childShape);
+        };
+
+        // then
+      expect(action).to.throw(Error, 'model is read-only');
+      }));
+
+      it('should NOT throw Error when re-enabled', inject(function(modeling, eventBus) {
+
+        // given
+        modeling.readOnly(true);
+        modeling.readOnly(false);
+
+        // when
+        var action = function () {
+          modeling.removeShape(childShape);
+        };
+
+        // then
+        expect(action).not.to.throw();
+      }));
+
+    });
+
   });
 
 

--- a/test/spec/features/modeling/DropShapeSpec.js
+++ b/test/spec/features/modeling/DropShapeSpec.js
@@ -132,4 +132,38 @@ describe('features/modeling - move shape - drop', function() {
 
   });
 
+
+  describe('readOnly.changed', function() {
+
+    it('should throw Error while read-only', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+
+      // when
+      var action = function () {
+        modeling.moveShape(shape1, { x: 5, y: 50 }, parent1);
+      };
+
+      // then
+      expect(action).to.throw(Error, 'model is read-only');
+    }));
+
+    it('should NOT throw Error when re-enabled', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+      modeling.readOnly(false);
+
+      // when
+      var action = function () {
+          modeling.moveShape(shape1, { x: 5, y: 50 }, parent1);
+      };
+
+      // then
+      expect(action).not.to.throw();
+    }));
+
+  });
+
 });

--- a/test/spec/features/modeling/LayoutConnectionSpec.js
+++ b/test/spec/features/modeling/LayoutConnectionSpec.js
@@ -117,6 +117,41 @@ describe('features/modeling - layout connection', function() {
         { x: 350, y: 150, original: { x: 325, y: 125 } }
       ]);
     }));
+
+
+    describe('readOnly.changed', function() {
+
+      it('should throw Error while read-only', inject(function(modeling, eventBus) {
+
+        // given
+        modeling.readOnly(true);
+
+        // when
+        var action = function () {
+          modeling.layoutConnection(connection);
+        };
+
+        // then
+        expect(action).to.throw(Error, 'model is read-only');
+      }));
+
+      it('should NOT throw Error when re-enabled', inject(function(modeling, eventBus) {
+
+        // given
+        modeling.readOnly(true);
+        modeling.readOnly(false);
+
+        // when
+        var action = function () {
+          modeling.layoutConnection(connection);
+        };
+
+        // then
+        expect(action).not.to.throw();
+      }));
+
+    });
+
   });
 
 

--- a/test/spec/features/modeling/MoveConnectionSpec.js
+++ b/test/spec/features/modeling/MoveConnectionSpec.js
@@ -152,4 +152,38 @@ describe('features/modeling - move connection', function() {
 
   });
 
+
+  describe('readOnly.changed', function() {
+
+    it('should throw Error while read-only', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+
+      // when
+      var action = function () {
+        modeling.moveConnection(connection, { x: 0, y: 0 }, rootShape, 0);
+      };
+
+      // then
+      expect(action).to.throw(Error, 'model is read-only');
+    }));
+
+    it('should NOT throw Error when re-enabled', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+      modeling.readOnly(false);
+
+      // when
+      var action = function () {
+        modeling.moveConnection(connection, { x: 0, y: 0 }, rootShape, 0);
+      };
+
+      // then
+      expect(action).not.to.throw();
+    }));
+
+  });
+
 });

--- a/test/spec/features/modeling/MoveElementsSpec.js
+++ b/test/spec/features/modeling/MoveElementsSpec.js
@@ -402,6 +402,40 @@ describe('features/modeling - move elements', function() {
   });
 
 
+  describe('readOnly.changed', function() {
+
+    it('should throw Error while read-only', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+
+      // when
+      var action = function () {
+        modeling.moveElements([ childShape, otherChildShape ], { x: -20, y: +20 }, otherParentShape);
+      };
+
+      // then
+      expect(action).to.throw(Error, 'model is read-only');
+    }));
+
+    it('should NOT throw Error when re-enabled', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+      modeling.readOnly(false);
+
+      // when
+      var action = function () {
+        modeling.moveElements([ childShape, otherChildShape ], { x: -20, y: +20 }, otherParentShape);
+      };
+
+      // then
+      expect(action).not.to.throw();
+    }));
+
+  });
+
+
   describe('drop', function() {
 
     // @see DropShapeSpec.js

--- a/test/spec/features/modeling/MoveShapeSpec.js
+++ b/test/spec/features/modeling/MoveShapeSpec.js
@@ -255,4 +255,38 @@ describe('features/modeling - move shape', function() {
 
   });
 
+
+  describe('readOnly.changed', function() {
+
+    it('should throw Error while read-only', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+
+      // when
+      var action = function () {
+        modeling.moveShape(childShape, { x: -20, y: +20 });
+      };
+
+      // then
+      expect(action).to.throw(Error, 'model is read-only');
+    }));
+
+    it('should NOT throw Error when re-enabled', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+      modeling.readOnly(false);
+
+      // when
+      var action = function () {
+        modeling.moveShape(childShape, { x: -20, y: +20 });
+      };
+
+      // then
+      expect(action).not.to.throw();
+    }));
+
+  });
+
 });

--- a/test/spec/features/modeling/ReadOnlySpec.js
+++ b/test/spec/features/modeling/ReadOnlySpec.js
@@ -1,0 +1,68 @@
+'use strict';
+
+/* global bootstrapDiagram, inject, sinon */
+
+var modelingModule = require('../../../../lib/features/modeling');
+
+
+describe('features/modeling - readOnly', function() {
+
+  beforeEach(bootstrapDiagram({
+    modules: [
+      modelingModule
+    ]
+  }));
+
+  it('should emit readOnly.changed when activating', inject(function (modeling, eventBus) {
+    var fire = sinon.spy(eventBus, 'fire');
+
+    // when
+    var actual = modeling.readOnly(true);
+
+    // then
+    expect(actual).to.be.true;
+    expect(fire).to.have.been.calledOnce;
+    expect(fire).to.have.been.calledWith('readOnly.changed', { readOnly: true });
+  }));
+
+  it('should emit readOnly.changed when de-activating', inject(function (modeling, eventBus) {
+    var fire = sinon.spy(eventBus, 'fire');
+
+    // given
+    modeling.readOnly(true);
+    fire.reset();
+
+    // when
+    var actual = modeling.readOnly(false);
+
+    // then
+    expect(actual).to.be.false;
+    expect(fire).to.have.been.calledOnce;
+    expect(fire).to.have.been.calledWith('readOnly.changed', { readOnly: false });
+  }));
+
+  it('should NOT emit readOnly.changed when called without arguments', inject(function (modeling, eventBus) {
+    var fire = sinon.spy(eventBus, 'fire');
+
+    // when
+    modeling.readOnly();
+
+    // then
+    expect(fire).to.not.have.been.called;
+  }));
+
+  it('should return false by default', inject(function (modeling) {
+    // when
+    // then
+    expect(modeling.readOnly()).to.be.false;
+  }));
+
+  it('should return true when activated', inject(function (modeling) {
+    // when
+    modeling.readOnly(true);
+
+    // then
+    expect(modeling.readOnly()).to.be.true;
+  }));
+
+});

--- a/test/spec/features/modeling/ReconnectConnectionSpec.js
+++ b/test/spec/features/modeling/ReconnectConnectionSpec.js
@@ -185,4 +185,38 @@ describe('features/modeling - reconnect connection', function() {
 
   });
 
+
+  describe('readOnly.changed', function() {
+
+    it('should throw Error while read-only', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+
+      // when
+      var action = function () {
+        modeling.reconnectStart(connection, childShape, { x: 120, y: 120 });
+      };
+
+      // then
+      expect(action).to.throw(Error, 'model is read-only');
+    }));
+
+    it('should NOT throw Error when re-enabled', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+      modeling.readOnly(false);
+
+      // when
+      var action = function () {
+        modeling.reconnectStart(connection, childShape, { x: 120, y: 120 });
+      };
+
+      // then
+      expect(action).not.to.throw();
+    }));
+
+  });
+
 });

--- a/test/spec/features/modeling/ReplaceShapeSpec.js
+++ b/test/spec/features/modeling/ReplaceShapeSpec.js
@@ -137,4 +137,56 @@ describe('features/modeling - replace shape', function() {
 
   });
 
+
+  describe('readOnly.changed', function() {
+
+    var root, shape;
+
+    beforeEach(inject(function(elementFactory, canvas) {
+
+      root = elementFactory.createRoot({
+        id: 'root'
+      });
+
+      canvas.setRootElement(root);
+
+      shape = elementFactory.createShape({
+        id: 'parent',
+        x: 20, y: 20, width: 200, height: 200
+      });
+
+      canvas.addShape(shape, root);
+    }));
+
+    it('should throw Error while read-only', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+
+      // when
+      var action = function () {
+        modeling.replaceShape(shape, { x: 120, y: 120, width: 200, height: 200 });
+      };
+
+      // then
+      expect(action).to.throw(Error, 'model is read-only');
+    }));
+
+    it('should NOT throw Error when re-enabled', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+      modeling.readOnly(false);
+
+      // when
+      var action = function () {
+        modeling.replaceShape(shape, { x: 120, y: 120, width: 200, height: 200 });
+      };
+
+      // then
+      expect(action).not.to.throw();
+    }));
+
+  });
+
 });

--- a/test/spec/features/modeling/ResizeShapeSpec.js
+++ b/test/spec/features/modeling/ResizeShapeSpec.js
@@ -572,6 +572,40 @@ describe('features/modeling - resize shape', function() {
       expect(resize).to.throw('newBounds must have {x, y, width, height} properties');
     }));
 
+
+    describe('readOnly.changed', function() {
+
+      it('should throw Error while read-only', inject(function(modeling, eventBus) {
+
+        // given
+        modeling.readOnly(true);
+
+        // when
+        var action = function () {
+          return modeling.resizeShape(shape2, { x: 200, y: 100, width: 124, height: 202 });
+        };
+
+        // then
+        expect(action).to.throw(Error, 'model is read-only');
+      }));
+
+      it('should NOT throw Error when re-enabled', inject(function(modeling, eventBus) {
+
+        // given
+        modeling.readOnly(true);
+        modeling.readOnly(false);
+
+        // when
+        var action = function () {
+          return modeling.resizeShape(shape2, { x: 200, y: 100, width: 124, height: 202 });
+        };
+
+        // then
+        expect(action).not.to.throw();
+      }));
+
+    });
+
   });
 
 

--- a/test/spec/features/modeling/UpdateAttachmentSpec.js
+++ b/test/spec/features/modeling/UpdateAttachmentSpec.js
@@ -305,4 +305,38 @@ describe('features/modeling - attach shape', function() {
 
   });
 
+
+  describe('readOnly.changed', function() {
+
+    it('should throw Error while read-only', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+
+      // when
+      var action = function () {
+        modeling.updateAttachment(attachedShape, null);
+      };
+
+      // then
+      expect(action).to.throw(Error, 'model is read-only');
+    }));
+
+    it('should NOT throw Error when re-enabled', inject(function(modeling, eventBus) {
+
+      // given
+      modeling.readOnly(true);
+      modeling.readOnly(false);
+
+      // when
+      var action = function () {
+        modeling.updateAttachment(attachedShape, null);
+      };
+
+      // then
+      expect(action).not.to.throw();
+    }));
+
+  });
+
 });

--- a/test/spec/features/palette/PaletteSpec.js
+++ b/test/spec/features/palette/PaletteSpec.js
@@ -222,4 +222,28 @@ describe('features/palette', function() {
   });
 
 
+  describe('readOnly.changed', function () {
+
+    var getPaletteEntries;
+
+    beforeEach(bootstrapDiagram({ modules: [paletteModule ]}));
+
+    beforeEach(inject(function(palette) {
+      var provider = new Provider();
+      palette.registerProvider(provider);
+      getPaletteEntries = sinon.spy(provider, 'getPaletteEntries');
+    }));
+
+    it('should refresh palette entries when `readOnly.changed` is fired', inject(function (eventBus) {
+      // when
+      eventBus.fire('readOnly.changed', { readOnly: true });
+      eventBus.fire('readOnly.changed', { readOnly: false });
+
+      // then
+      expect(getPaletteEntries).to.have.been.calledTwice;
+    }));
+
+  });
+
+
 });


### PR DESCRIPTION
This commit will add support for disabling modeling actions, but will leave navigation tools enabled.

To get or set the read-only state, the modeling module exposes a readOnly function.

    modeling.readOnly(true); // enable read-only
    modeling.readOnly(false); // disable read-only
    modeling.readOnly(); // will leave current state unchanged, returning true or false


The requirements I have for a read-only state are
- Modeling actions should not be permitted
- Disabled actions should not be displayed (palette and context-pad)
- Navigation (pan and zoom) should be permitted
- Selection should still be possible even in a read-only state
- Toggling read-only state should be possible programatically
- When read-only state is activated, any ongoing modeling user actions should be canceled


I am expecting comments and I will update the PR to align with any feedback given, small or big.


A live demo is available at https://adbre.github.io/bpmn-js-readonly-example/ (use the lock icon in the upper-right corner to toggle the read-only state).
Source code for the demo can be obtained at [adbre/bpmn-js-examples/disable-modeling/modeler](https://github.com/adbre/bpmn-js-examples/tree/disable-modeling/modeler).

This PR addresses the [use case I posted in the forums](https://forum.bpmn.io/t/changing-from-modeler-to-viewer-and-back-again/900/1) recently.

Please note, this PR also requires changes in bpmn-js, see bpmn-io/bpmn-js#598