### PR TITLE
Support array of classNames when adding entries

### DIFF
--- a/lib/features/palette/Palette.js
+++ b/lib/features/palette/Palette.js
@@ -168,8 +168,8 @@ Palette.prototype._update = function() {
       }
 
       if (entry.className) {
-        const classNames = Array.isArray(entry.className ) ? entry.className : [ entry.className ];
-        classNames.forEach(e => domClasses(control).add(e));
+        var classNames = Array.isArray(entry.className ) ? entry.className : [ entry.className ];
+        classNames.forEach( function(e) { domClasses(control).add(e); });
       }
 
       if (entry.imageUrl) {

--- a/lib/features/palette/Palette.js
+++ b/lib/features/palette/Palette.js
@@ -168,7 +168,8 @@ Palette.prototype._update = function() {
       }
 
       if (entry.className) {
-        domClasses(control).add(entry.className);
+        const classNames = Array.isArray(entry.className ) ? entry.className : [ entry.className ];
+        classNames.forEach(e => domClasses(control).add(e));
       }
 
       if (entry.imageUrl) {

--- a/test/spec/features/palette/PaletteSpec.js
+++ b/test/spec/features/palette/PaletteSpec.js
@@ -132,6 +132,35 @@ describe('features/palette', function() {
       expect(domQuery('img', entryB)).to.exist;
     }));
 
+
+    it('should handle array-of-string as css classes', inject(function(canvas, palette) {
+
+      // given
+      var entries  = {
+        'entryA': {
+          alt: 'A',
+          className: [ 'FOO', 'BAAAR' ]
+        },
+      };
+
+      var provider = new Provider(entries);
+
+      // when
+      palette.registerProvider(provider);
+      palette.open();
+
+      // then data structure should set
+      var pEntries = palette.getEntries();
+      expect(pEntries.entryA).to.exist;
+
+      // then DOM should contain entries
+      var entryA = domQuery('[data-action="entryA"]', palette._container);
+      expect(entryA).to.exist;
+      expect(domClasses(entryA).has('FOO')).to.be.true;
+      expect(domClasses(entryA).has('BAAAR')).to.be.true;
+
+    }));
+
   });
 
 

--- a/test/spec/features/palette/PaletteSpec.js
+++ b/test/spec/features/palette/PaletteSpec.js
@@ -140,7 +140,7 @@ describe('features/palette', function() {
         'entryA': {
           alt: 'A',
           className: [ 'FOO', 'BAAAR' ]
-        },
+        }
       };
 
       var provider = new Provider(entries);


### PR DESCRIPTION
feat(palette): When adding entries, allow className to be an array of strings.
