### PR TITLE
fix: Stronger check for Jquery

### DIFF
--- a/lib/features/overlays/Overlays.js
+++ b/lib/features/overlays/Overlays.js
@@ -413,7 +413,7 @@ Overlays.prototype._addOverlay = function(overlay) {
       overlayContainer;
 
   // unwrap jquery (for those who need it)
-  if (html.get) {
+  if (html.get && window.jQuery) {
     html = html.get(0);
   }
 

--- a/lib/features/overlays/Overlays.js
+++ b/lib/features/overlays/Overlays.js
@@ -413,7 +413,7 @@ Overlays.prototype._addOverlay = function(overlay) {
       overlayContainer;
 
   // unwrap jquery (for those who need it)
-  if (html.get && window.jQuery) {
+  if (html.get && html.constructor.prototype.jquery) {
     html = html.get(0);
   }
 

--- a/lib/features/tooltips/Tooltips.js
+++ b/lib/features/tooltips/Tooltips.js
@@ -279,7 +279,7 @@ Tooltips.prototype._addTooltip = function(tooltip) {
       tooltipRoot = this._tooltipRoot;
 
   // unwrap jquery (for those who need it)
-  if (html.get && window.jQuery) {
+  if (html.get && html.constructor.prototype.jquery) {
     html = html.get(0);
   }
 

--- a/lib/features/tooltips/Tooltips.js
+++ b/lib/features/tooltips/Tooltips.js
@@ -279,7 +279,7 @@ Tooltips.prototype._addTooltip = function(tooltip) {
       tooltipRoot = this._tooltipRoot;
 
   // unwrap jquery (for those who need it)
-  if (html.get) {
+  if (html.get && window.jQuery) {
     html = html.get(0);
   }
 

--- a/test/spec/features/overlays/OverlaysIntegrationSpec.js
+++ b/test/spec/features/overlays/OverlaysIntegrationSpec.js
@@ -293,6 +293,7 @@ describe('features/overlay - integration', function() {
     it('should allow to pass jquery element as overlay', inject(function(canvas, overlays) {
 
       // given
+      window.jQuery = $;
       var shape = canvas.addShape({
         id: 'test',
         x: 50,


### PR DESCRIPTION
Other libraries exits that adds the `.get()` functionality to element nodes, in my case Mootools which behaves in a different fashion resulting in multiple errors.
 
Since the comment indicates that the condition is only for JQuery users, it should only fire if the lib is present. 

