### PR TITLE
Canvas groups can be ordered

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -4,7 +4,8 @@ var isNumber = require('lodash/lang/isNumber'),
     assign = require('lodash/object/assign'),
     forEach = require('lodash/collection/forEach'),
     every = require('lodash/collection/every'),
-    debounce = require('lodash/function/debounce');
+    debounce = require('lodash/function/debounce'),
+    mapValues = require('lodash/object/mapValues');
 
 var Collections = require('../util/Collections'),
     Elements = require('../util/Elements');
@@ -57,11 +58,13 @@ function createContainer(options) {
   return parent;
 }
 
-function createGroup(parent, cls) {
+function createGroup(parent, cls, childIndex) {
   var group = svgCreate('g');
   svgClasses(group).add(cls);
 
-  svgAppend(parent, group);
+  var index = childIndex !== undefined ? childIndex : parent.childNodes.length - 1;
+
+  parent.insertBefore(group, parent.childNodes[index]);
 
   return group;
 }
@@ -145,8 +148,8 @@ Canvas.prototype._init = function(config) {
      * @event canvas.init
      *
      * @type {Object}
-     * @property {Snap<SVGSVGElement>} svg the created svg element
-     * @property {Snap<SVGGroup>} viewport the direct parent of diagram elements and shapes
+     * @property {SVGElement} svg the created svg element
+     * @property {SVGElement} viewport the direct parent of diagram elements and shapes
      */
     eventBus.fire('canvas.init', {
       svg: svg,
@@ -207,32 +210,51 @@ Canvas.prototype._clear = function() {
  * Returns the default layer on which
  * all elements are drawn.
  *
- * @returns {Snap<SVGGroup>}
+ * @returns {SVGElement}
  */
 Canvas.prototype.getDefaultLayer = function() {
-  return this.getLayer(BASE_LAYER);
+  return this.getLayer(BASE_LAYER, 0);
 };
 
 /**
  * Returns a layer that is used to draw elements
- * or annotations on it.
+ * or annotations on it. 
+ * Accepts optional index parameter.
+ * Layer with same index is above previously created layer.
  *
- * @param  {String} name
+ * @param {String} name
+ * @param {Number} index
  *
- * @returns {Snap<SVGGroup>}
+ * @returns {SVGElement}
  */
-Canvas.prototype.getLayer = function(name) {
+Canvas.prototype.getLayer = function(name, index) {
 
   if (!name) {
     throw new Error('must specify a name');
   }
 
   var layer = this._layers[name];
+
   if (!layer) {
-    layer = this._layers[name] = createGroup(this._viewport, 'layer-' + name);
+    if (!index) {
+      index = 0;
+    }
+
+    var childIndex = 0;
+
+    mapValues(this._layers, function(layer) {
+      if (index >= layer.index) {
+        childIndex++;
+      }
+    });
+
+    layer = this._layers[name] = {
+      group: createGroup(this._viewport, 'layer-' + name, childIndex),
+      index: index
+    };
   }
 
-  return layer;
+  return layer.group;
 };
 
 

--- a/lib/util/Text.js
+++ b/lib/util/Text.js
@@ -204,7 +204,7 @@ function Text(config) {
  * @param {String} text
  * @param {Object} options
  *
- * @return {SVGText}
+ * @return {SVGElement}
  */
 Text.prototype.createText = function(text, options) {
   return this.layoutText(text, options).element;

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -12,6 +12,15 @@ var domQuery = require('min-dom/lib/query');
 var svgAttr = require('tiny-svg/lib/attr'),
     svgClasses = require('tiny-svg/lib/classes');
 
+function expectLayersOrder(layersParent, expected) {  
+  var layers = layersParent.childNodes;
+
+  for (var i = 0; i < layers.length; ++i) {
+    svgClasses(layers[i]).has(expected[i]);
+  }
+}
+
+
 describe('Canvas', function() {
 
   var container;
@@ -1615,6 +1624,111 @@ describe('Canvas', function() {
       }));
 
     });
+
+  });
+
+  describe('layers', function() {
+
+    beforeEach(function() {
+      container = TestContainer.get(this);
+    });
+    beforeEach(createDiagram({ canvas: { width: 300, height: 300 } }));
+
+
+    it('get default layer', inject(function(canvas) {
+
+      // when
+      canvas.getDefaultLayer();
+
+      // then
+      expectLayersOrder(canvas._viewport, [
+        'layer-base'
+      ]);
+    }));
+
+
+    it('layer with negative index is below default layer', inject(function(canvas) {
+      
+      // when
+      canvas.getDefaultLayer();
+      canvas.getLayer('foo', -10);
+
+      // then
+      expectLayersOrder(canvas._viewport, [
+        'foo',
+        'layer-base'
+      ]);
+    }));
+
+
+    it('layer with positive index is above default layer', inject(function(canvas) {
+      
+      // when
+      canvas.getDefaultLayer();
+      canvas.getLayer('foo', 10);
+
+      // then
+      expectLayersOrder(canvas._viewport, [
+        'layer-base',
+        'foo'
+      ]);
+    }));  
+
+
+    it('layer without specified index gets default index', inject(function(canvas) {
+
+      // when
+      canvas.getDefaultLayer();
+      canvas.getLayer('foo');
+
+      // then
+      expectLayersOrder(canvas._viewport, [
+        'layer-base',
+        'foo'
+      ]);
+    }));
+
+
+    it('layer with same index is above previously created layer', inject(function(canvas) {
+      
+      // when
+      canvas.getLayer('foo');
+      canvas.getLayer('bar');
+
+      // then
+      expectLayersOrder(canvas._viewport, [
+        'foo',
+        'bar'
+      ]);
+    }));
+
+
+    it('layer with higher index is above layer with lower index', inject(function(canvas) {
+      
+      // when
+      canvas.getLayer('foo', 10);
+      canvas.getLayer('bar', 20);
+
+      // then
+      expectLayersOrder(canvas._viewport, [
+        'foo',
+        'bar'
+      ]);
+    }));
+
+
+    it('layer with higher index is above layer with lower index', inject(function(canvas) {
+      
+      // when
+      canvas.getLayer('foo', 10);
+      canvas.getLayer('bar', 20);
+
+      // then
+      expectLayersOrder(canvas._viewport, [
+        'bar',
+        'foo'
+      ]);
+    }));
 
   });
 


### PR DESCRIPTION
When creating layers using `Canvas#getLayer` the order of these layers depends on the sequence of calling `getLayer`. Therefore it is not possible to make sure layer X is above layer Y. This pull request makes ordering layers possible through specifying an index when creating a layer.