### PR TITLE
Add ability to create non-scaling overlays

### DIFF
--- a/lib/features/overlays/Overlays.js
+++ b/lib/features/overlays/Overlays.js
@@ -96,7 +96,8 @@ function Overlays(eventBus, canvas, elementRegistry) {
     show: {
       minZoom: 0.7,
       maxZoom: 5.0
-    }
+    },
+    scale: true
   };
 
   /**
@@ -191,6 +192,7 @@ Overlays.prototype.get = function(search) {
  * @param {Number}                  [overlay.position.top]       relative to element bbox top attachment
  * @param {Number}                  [overlay.position.bottom]    relative to element bbox bottom attachment
  * @param {Number}                  [overlay.position.right]     relative to element bbox right attachment
+ * @param {Boolean}                 [overlay.scale]              false to preserve the same size regardless of diagram zoom  
  *
  * @return {String}                 id that may be used to reference the overlay for update or removal
  */
@@ -456,6 +458,20 @@ Overlays.prototype._updateOverlayVisibilty = function(overlay, viewbox) {
     }
 
     setVisible(htmlContainer, visible);
+  }
+  this._updateOverlayScale(overlay, this._canvas.viewbox());
+};
+
+Overlays.prototype._updateOverlayScale = function(overlay, viewbox) {
+  var revertScale = !overlay.scale,
+      htmlContainer = overlay.htmlContainer;
+  if (revertScale) {
+    var scale = 1 / viewbox.scale || 1;
+    var transform = 'scale(' + scale + ',' + scale + ')';
+    htmlContainer.style['transform-origin'] = 'top left';
+    htmlContainer.style.transform = transform;
+    htmlContainer.style['-ms-transform'] = transform;
+    htmlContainer.style['-webkit-transform'] = transform;
   }
 };
 


### PR DESCRIPTION
I propose to add ability to create non-scaling overlays, which retain the same size regardless of current diagram zoom. So I added boolean `scale` attribute to overlay configuration properties.

For now, all overlays scales and moves with the diagram, because overlay container is transformed on zoom and scroll events. How can we allow some overlays to be scale-independent in this situation? The idea is simple: we should revert scale for individual overlays using `transform: scale(1/zoom, 1/zoom)` and `transform-origin: top left` CSS properties.

The same feature can also be easily added to **tooltips** module.