### PR TITLE
Overlay rework

### DIFF
--- a/lib/features/overlays/Overlays.js
+++ b/lib/features/overlays/Overlays.js
@@ -96,7 +96,8 @@ function Overlays(eventBus, canvas, elementRegistry) {
     show: {
       minZoom: 0.7,
       maxZoom: 5.0
-    }
+    },
+    scale: true
   };
 
   /**
@@ -191,6 +192,7 @@ Overlays.prototype.get = function(search) {
  * @param {Number}                  [overlay.position.top]       relative to element bbox top attachment
  * @param {Number}                  [overlay.position.bottom]    relative to element bbox bottom attachment
  * @param {Number}                  [overlay.position.right]     relative to element bbox right attachment
+ * @param {Boolean}                 [overlay.scale]              false to preserve the same size regardless of diagram zoom  
  *
  * @return {String}                 id that may be used to reference the overlay for update or removal
  */
@@ -456,6 +458,20 @@ Overlays.prototype._updateOverlayVisibilty = function(overlay, viewbox) {
     }
 
     setVisible(htmlContainer, visible);
+  }
+  this._updateOverlayScale(overlay, this._canvas.viewbox());
+};
+
+Overlays.prototype._updateOverlayScale = function(overlay, viewbox) {
+  var revertScale = !overlay.scale,
+      htmlContainer = overlay.htmlContainer;
+  if (revertScale) {
+    var scale = 1 / viewbox.scale || 1;
+    var transform = 'scale(' + scale + ',' + scale + ')';
+    htmlContainer.style['transform-origin'] = 'top left';
+    htmlContainer.style.transform = transform;
+    htmlContainer.style['-ms-transform'] = transform;
+    htmlContainer.style['-webkit-transform'] = transform;
   }
 };
 

--- a/lib/features/overlays/Overlays.js
+++ b/lib/features/overlays/Overlays.js
@@ -93,11 +93,29 @@ function isDef(o) {
  * var id = overlays.add(...);
  * overlays.remove(id);
  *
+ *
+ * You may configure overlay defaults during tool by providing a `config` module
+ * with `overlays.defaults` as an entry:
+ *
+ * {
+ *   overlays: {
+ *     defaults: {
+ *       show: {
+ *         minZoom: 0.7,
+ *         maxZoom: 5.0
+ *       },
+ *       scale: {
+ *         min: 1
+ *       }
+ *     }
+ * }
+ *
+ * @param {Object} config
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
  * @param {ElementRegistry} elementRegistry
  */
-function Overlays(eventBus, canvas, elementRegistry) {
+function Overlays(config, eventBus, canvas, elementRegistry) {
 
   this._eventBus = eventBus;
   this._canvas = canvas;
@@ -105,13 +123,13 @@ function Overlays(eventBus, canvas, elementRegistry) {
 
   this._ids = ids;
 
-  this._overlayDefaults = {
-    show: {
-      minZoom: 0.7,
-      maxZoom: 5.0
-    },
+  this._overlayDefaults = assign({
+    // no show constraints
+    show: null,
+
+    // always scale
     scale: true
-  };
+  }, config && config.defaults);
 
   /**
    * Mapping overlayId -> overlay
@@ -130,7 +148,12 @@ function Overlays(eventBus, canvas, elementRegistry) {
 }
 
 
-Overlays.$inject = [ 'eventBus', 'canvas', 'elementRegistry' ];
+Overlays.$inject = [
+  'config.overlays',
+  'eventBus',
+  'canvas',
+  'elementRegistry'
+];
 
 module.exports = Overlays;
 
@@ -469,12 +492,16 @@ Overlays.prototype._addOverlay = function(overlay) {
 
 Overlays.prototype._updateOverlayVisibilty = function(overlay, viewbox) {
   var show = overlay.show,
+      minZoom = show && show.minZoom,
+      maxZoom = show && show.maxZoom,
       htmlContainer = overlay.htmlContainer,
       visible = true;
 
   if (show) {
-    if (show.minZoom > viewbox.scale ||
-        show.maxZoom < viewbox.scale) {
+    if (
+      (isDef(minZoom) && minZoom > viewbox.scale) ||
+      (isDef(minZoom) && maxZoom < viewbox.scale)
+    ) {
       visible = false;
     }
 

--- a/lib/features/overlays/Overlays.js
+++ b/lib/features/overlays/Overlays.js
@@ -38,6 +38,19 @@ function setVisible(el, visible) {
   el.style.display = visible === false ? 'none' : '';
 }
 
+function setTransform(el, transform) {
+
+  el.style['transform-origin'] = 'top left';
+
+  [ '', '-ms-', '-webkit-' ].forEach(function(prefix) {
+    el.style[prefix + 'transform'] = transform;
+  });
+}
+
+function isDef(o) {
+  return typeof o !== 'undefined';
+}
+
 /**
  * A service that allows users to attach overlays to diagram elements.
  *
@@ -192,7 +205,10 @@ Overlays.prototype.get = function(search) {
  * @param {Number}                  [overlay.position.top]       relative to element bbox top attachment
  * @param {Number}                  [overlay.position.bottom]    relative to element bbox bottom attachment
  * @param {Number}                  [overlay.position.right]     relative to element bbox right attachment
- * @param {Boolean}                 [overlay.scale]              false to preserve the same size regardless of diagram zoom  
+ * @param {Boolean|Object}          [overlay.scale=true]         false to preserve the same size regardless of
+ *                                                               diagram zoom
+ * @param {Number}                  [overlay.scale.min]
+ * @param {Number}                  [overlay.scale.max]
  *
  * @return {String}                 id that may be used to reference the overlay for update or removal
  */
@@ -358,6 +374,7 @@ Overlays.prototype._updateOverlay = function(overlay) {
   setPosition(htmlContainer, left || 0, top || 0);
 };
 
+
 Overlays.prototype._createOverlayContainer = function(element) {
   var html = domify('<div class="djs-overlays" style="position: absolute" />');
 
@@ -378,14 +395,20 @@ Overlays.prototype._createOverlayContainer = function(element) {
 
 
 Overlays.prototype._updateRoot = function(viewbox) {
-  var a = viewbox.scale || 1;
-  var d = viewbox.scale || 1;
+  var scale = viewbox.scale || 1;
 
-  var matrix = 'matrix(' + a + ',0,0,' + d + ',' + (-1 * viewbox.x * a) + ',' + (-1 * viewbox.y * d) + ')';
+  var matrix = 'matrix(' +
+  [
+    scale,
+    0,
+    0,
+    scale,
+    -1 * viewbox.x * scale,
+    -1 * viewbox.y * scale
+  ].join(',') +
+  ')';
 
-  this._overlayRoot.style.transform = matrix;
-  this._overlayRoot.style['-ms-transform'] = matrix;
-  this._overlayRoot.style['-webkit-transform'] = matrix;
+  setTransform(this._overlayRoot, matrix);
 };
 
 
@@ -401,9 +424,6 @@ Overlays.prototype._getOverlayContainer = function(element, raw) {
 
   return container;
 };
-
-
-
 
 
 Overlays.prototype._addOverlay = function(overlay) {
@@ -446,6 +466,7 @@ Overlays.prototype._addOverlay = function(overlay) {
   this._updateOverlayVisibilty(overlay, this._canvas.viewbox());
 };
 
+
 Overlays.prototype._updateOverlayVisibilty = function(overlay, viewbox) {
   var show = overlay.show,
       htmlContainer = overlay.htmlContainer,
@@ -459,21 +480,45 @@ Overlays.prototype._updateOverlayVisibilty = function(overlay, viewbox) {
 
     setVisible(htmlContainer, visible);
   }
-  this._updateOverlayScale(overlay, this._canvas.viewbox());
+
+  this._updateOverlayScale(overlay, viewbox);
 };
 
+
 Overlays.prototype._updateOverlayScale = function(overlay, viewbox) {
-  var revertScale = !overlay.scale,
+  var shouldScale = overlay.scale,
+      minScale,
+      maxScale,
       htmlContainer = overlay.htmlContainer;
-  if (revertScale) {
-    var scale = 1 / viewbox.scale || 1;
-    var transform = 'scale(' + scale + ',' + scale + ')';
-    htmlContainer.style['transform-origin'] = 'top left';
-    htmlContainer.style.transform = transform;
-    htmlContainer.style['-ms-transform'] = transform;
-    htmlContainer.style['-webkit-transform'] = transform;
+
+  var scale, transform = '';
+
+  if (shouldScale !== true) {
+
+    if (shouldScale === false) {
+      minScale = 1;
+      maxScale = 1;
+    } else {
+      minScale = shouldScale.min;
+      maxScale = shouldScale.max;
+    }
+
+    if (isDef(minScale) && viewbox.scale < minScale) {
+      scale = (1 / viewbox.scale || 1) * minScale;
+    }
+
+    if (isDef(maxScale) && viewbox.scale > maxScale) {
+      scale = (1 / viewbox.scale || 1) * maxScale;
+    }
   }
+
+  if (isDef(scale)) {
+    transform = 'scale(' + scale + ',' + scale + ')';
+  }
+
+  setTransform(htmlContainer, transform);
 };
+
 
 Overlays.prototype._updateOverlaysVisibilty = function(viewbox) {
 

--- a/test/spec/features/overlays/OverlaysSpec.js
+++ b/test/spec/features/overlays/OverlaysSpec.js
@@ -586,7 +586,83 @@ describe('features/overlays', function() {
       }
 
 
-      it('should conditionally hide overlay', inject(function(overlays, canvas) {
+      it('should always show overlays', inject(function(overlays, canvas) {
+
+        // given
+        var html = createOverlay();
+
+        overlays.add(shape, {
+          html: html,
+          position: { left: 20, bottom: 0 }
+        });
+
+        // when zoom in visibility range
+        canvas.zoom(0.7);
+
+        // then
+        expect(isVisible(html)).to.be.true;
+
+
+        // when zoom below visibility range
+        canvas.zoom(0.6);
+
+        // then
+        expect(isVisible(html)).to.be.true;
+
+
+        // when zoom in visibility range
+        canvas.zoom(3.0);
+
+        // then
+        expect(isVisible(html)).to.be.true;
+
+
+        // when zoom above visibility range
+        canvas.zoom(6.0);
+
+        // then
+        expect(isVisible(html)).to.be.true;
+      }));
+
+    });
+
+
+    describe('overriding defaults', function() {
+
+      beforeEach(bootstrapDiagram({
+        modules: [ overlayModule ],
+        canvas: { deferUpdate: false },
+        overlays: {
+          defaults: {
+            show: {
+              minZoom: 0.7,
+              maxZoom: 5.0
+            }
+          }
+        }
+      }));
+
+
+      var shape;
+
+      beforeEach(inject(function(canvas) {
+
+        shape = canvas.addShape({
+          id: 'shape',
+          x: 100,
+          y: 100,
+          width: 100,
+          height: 100
+        });
+      }));
+
+
+      function isVisible(element) {
+        return element.parentNode.style.display !== 'none';
+      }
+
+
+      it('should conditionally hide overlays', inject(function(overlays, canvas) {
 
         // given
         var html = createOverlay();
@@ -633,7 +709,15 @@ describe('features/overlays', function() {
 
     beforeEach(bootstrapDiagram({
       modules: [ overlayModule ],
-      canvas: { deferUpdate: false }
+      canvas: { deferUpdate: false },
+      overlays: {
+        defaults: {
+          show: {
+            minZoom: 0.7,
+            maxZoom: 5.0
+          }
+        }
+      }
     }));
 
 


### PR DESCRIPTION
Incorporate #228 with the addition of being able to configure scaling in a more fine grained manner.

Make auto-hiding of overlays optional, effectively closing #229.


Closing #229 is a breaking change and deserves a mention in blog posts or other places (where appropriate). 