### PR TITLE
fix(reconnect): reconnect should clear markers on IE/Edge

### DIFF
--- a/lib/features/bendpoints/BendpointMove.js
+++ b/lib/features/bendpoints/BendpointMove.js
@@ -126,9 +126,31 @@ function BendpointMove(injector, eventBus, canvas, dragging, graphicsFactory, ru
   });
 
   eventBus.on('bendpoint.move.hover', function(e) {
+    var context = e.context;
+    context.hover = e.hover;
+    if (e.hover) {
+      canvas.addMarker(e.hover, MARKER_CONNECT_HOVER);
+      // asks whether reconnect / bendpoint move / bendpoint add
+      // is allowed at the given position
+      var allowed = context.allowed = rules.allowed(context.type, context);
 
-    e.context.hover = e.hover;
-    canvas.addMarker(e.hover, MARKER_CONNECT_HOVER);
+      if (allowed) {
+
+        if (context.hover) {
+          canvas.removeMarker(context.hover, MARKER_NOT_OK);
+          canvas.addMarker(context.hover, MARKER_OK);
+
+          context.target = context.hover;
+        }
+      } else if (allowed === false) {
+        if (context.hover) {
+          canvas.removeMarker(context.hover, MARKER_OK);
+          canvas.addMarker(context.hover, MARKER_NOT_OK);
+
+          context.target = null;
+        }
+      }
+    }
   });
 
   eventBus.on([
@@ -168,28 +190,6 @@ function BendpointMove(injector, eventBus, canvas, dragging, graphicsFactory, ru
       }
 
       connection.waypoints = connectionDocking.getCroppedWaypoints(connection, source, target);
-    }
-
-    // asks whether reconnect / bendpoint move / bendpoint add
-    // is allowed at the given position
-    var allowed = context.allowed = rules.allowed(context.type, context);
-
-    if (allowed) {
-
-      if (context.hover) {
-        canvas.removeMarker(context.hover, MARKER_NOT_OK);
-        canvas.addMarker(context.hover, MARKER_OK);
-
-        context.target = context.hover;
-      }
-    } else
-    if (allowed === false) {
-      if (context.hover) {
-        canvas.removeMarker(context.hover, MARKER_OK);
-        canvas.addMarker(context.hover, MARKER_NOT_OK);
-
-        context.target = null;
-      }
     }
 
     // add dragger gfx


### PR DESCRIPTION
- On IE/Edge bendpoint move related events don't clear markers
- Code to add OK / NOT_OK markers was moved from 'bendpoint.move.move'
event to 'bendpoint.move.hover'.

<!--

Thanks for filing a pull request!

Make sure you've read through [our contributing guide](https://github.com/bpmn-io/diagram-js/blob/master/CONTRIBUTING.md#creating-a-pull-request) before you continue.

-->


Fixes #236 


### Proposed Changes

* Resolve the issue by move the code that adds markers  from 'bendpoint.move.move' to 'bendpoint.move.hover'.
