### PR TITLE
feat(zoom-scroll): switch to default zoom / scroll gestures

### DIFF
--- a/lib/navigation/zoomscroll/ZoomScroll.js
+++ b/lib/navigation/zoomscroll/ZoomScroll.js
@@ -3,17 +3,16 @@
 var domEvent = require('min-dom/lib/event'),
     domClosest = require('min-dom/lib/closest');
 
-var hasPrimaryModifier = require('../../util/Mouse').hasPrimaryModifier,
-    hasSecondaryModifier = require('../../util/Mouse').hasSecondaryModifier;
-
-var isMac = require('../../util/Platform').isMac;
-
 var getStepSize = require('./ZoomUtil').getStepSize,
     cap = require('./ZoomUtil').cap;
 
 var log10 = require('../../util/Math').log10;
 
 var bind = require('lodash/function/bind');
+
+var sign = Math.sign || function(n) {
+  return n >= 0 ? 1 : -1;
+};
 
 var RANGE = { min: 0.2, max: 4 },
     NUM_STEPS = 10;
@@ -71,7 +70,7 @@ ZoomScroll.prototype.reset = function reset() {
 
 /**
  * Zoom depending on delta.
- * 
+ *
  * @param {number} delta - Zoom delta.
  * @param {Object} position - Zoom position.
  */
@@ -102,32 +101,23 @@ ZoomScroll.prototype._handleWheel = function handleWheel(event) {
 
   event.preventDefault();
 
-  // mouse-event: SELECTION_KEY
-  // mouse-event: AND_KEY
-  var isVerticalScroll = hasPrimaryModifier(event),
-      isHorizontalScroll = hasSecondaryModifier(event);
+  // pinch to zoom is mapped to wheel + ctrlKey = true
+  // in modern browsers (!)
 
-  var factor;
+  var isZoom = event.ctrlKey;
 
-  if (isVerticalScroll || isHorizontalScroll) {
+  var isHorizontalScroll = event.shiftKey;
 
-    if (isMac) {
-      factor = event.deltaMode === 0 ? 1.25 : 50;
-    } else {
-      factor = event.deltaMode === 0 ? 1/40 : 1/2;
-    }
+  var factor,
+      delta;
 
-    var delta = {};
-
-    if (isHorizontalScroll) {
-      delta.dx = (factor * (event.deltaX || event.deltaY));
-    } else {
-      delta.dy = (factor * event.deltaY);
-    }
-    this.scroll(delta);
+  if (!isZoom) {
+    factor = event.deltaMode === 0 ? 1.25 : 18;
   } else {
-    factor = (event.deltaMode === 0 ? 1/40 : 1/2);
+    factor = event.deltaMode === 0 ? 1/40 : 1/4;
+  }
 
+  if (isZoom) {
     var elementRect = element.getBoundingClientRect();
 
     var offset =  {
@@ -135,8 +125,30 @@ ZoomScroll.prototype._handleWheel = function handleWheel(event) {
       y: event.clientY - elementRect.top
     };
 
+    delta = -(
+      Math.sqrt(
+        Math.pow(event.deltaY, 2) +
+        Math.pow(event.deltaX, 2)
+      ) * sign(event.deltaY) * factor
+    );
+
     // zoom in relative to diagram {x,y} coordinates
-    this.zoom(event.deltaY * factor / (-5), offset);
+    this.zoom(delta, offset);
+  } else {
+
+    if (isHorizontalScroll) {
+      delta = {
+        dx: factor * event.deltaY,
+        dy: 0
+      };
+    } else {
+      delta = {
+        dx: -(factor * event.deltaX),
+        dy: -(factor * event.deltaY)
+      };
+    }
+
+    this.scroll(delta);
   }
 };
 
@@ -156,7 +168,7 @@ ZoomScroll.prototype.stepZoom = function stepZoom(delta, position) {
 
 /**
  * Zoom in/out given a step size.
- * 
+ *
  * @param {number} delta - Zoom delta. Can be positive or negative.
  * @param {Object} position - Zoom position.
  * @param {number} stepSize - Step size.


### PR DESCRIPTION
Switch away from our proprietary, Google maps style zoom/scroll
behavior to the defacto standard for interacting with canvas(s):

Mouse Interaction:

* MouseWheel : scroll vertically
* MouseWheel + SHIFT : scroll horizontally
* MouseWheel + CTRL : zoom in / out

Touch Pad Interaction:

* Two finger move : scroll (as indicated)
* Two finger pinch : zoom in/out via pinch-to-zoom

Support for the pinch gesture varies by browser / touch pad:

* On Mac OS Firefox / Chrome generally support the pinch
  gesture while Safari does not (applies some different fancy
  behavior)
* On Linux/Windows pinch is supported in Chrome and Firefox
  on high precision touch pads only.

Closes #240