### PR TITLE
feat(interactionEvents): add contextmenu event

### DIFF
--- a/lib/features/interaction-events/InteractionEvents.js
+++ b/lib/features/interaction-events/InteractionEvents.js
@@ -3,6 +3,8 @@
 var forEach = require('lodash/collection/forEach'),
     domDelegate = require('min-dom/lib/delegate');
 
+var isPrimaryButton = require('../../util/Mouse').isPrimaryButton;
+
 var svgAppend = require('tiny-svg/lib/append'),
     svgAttr = require('tiny-svg/lib/attr'),
     svgCreate = require('tiny-svg/lib/create');
@@ -50,6 +52,13 @@ function InteractionEvents(eventBus, elementRegistry, styles) {
    *                                   defaults to the event target
    */
   function fire(type, event, element) {
+
+    // only react on left mouse button interactions
+    // except for interaction events that are enabled 
+    // for secundary mouse button
+    if (!isPrimaryButton(event) && !isSecundaryEnabled(type)) {
+      return;
+    }
 
     var target, gfx, returnValue;
 
@@ -101,6 +110,24 @@ function InteractionEvents(eventBus, elementRegistry, styles) {
     mouseup: 'element.mouseup',
     contextmenu: 'element.contextmenu'
   };
+
+  // add bindings that are enabled for secundary mouse button events
+  var secundaryButtonEnabledBindings = [
+    bindings.contextmenu
+  ];
+
+  /**
+   * checks if an event type is enabled for secundary mouse button
+   * 
+   * @param {any} type 
+   * @returns {boolean}
+   */
+  function isSecundaryEnabled(type) {
+    if (secundaryButtonEnabledBindings.indexOf(type) < 0) {
+      return false;
+    }
+    return true;
+  }
 
 
   ///// manual event trigger

--- a/lib/features/interaction-events/InteractionEvents.js
+++ b/lib/features/interaction-events/InteractionEvents.js
@@ -3,8 +3,6 @@
 var forEach = require('lodash/collection/forEach'),
     domDelegate = require('min-dom/lib/delegate');
 
-var isPrimaryButton = require('../../util/Mouse').isPrimaryButton;
-
 var svgAppend = require('tiny-svg/lib/append'),
     svgAttr = require('tiny-svg/lib/attr'),
     svgCreate = require('tiny-svg/lib/create');
@@ -28,6 +26,7 @@ var LOW_PRIORITY = 500;
  *   * element.click
  *   * element.dblclick
  *   * element.mousedown
+ *   * element.contextmenu
  *
  * Each event is a tuple { element, gfx, originalEvent }.
  *
@@ -51,12 +50,6 @@ function InteractionEvents(eventBus, elementRegistry, styles) {
    *                                   defaults to the event target
    */
   function fire(type, event, element) {
-
-    // only react on left mouse button interactions
-    // for interaction events
-    if (!isPrimaryButton(event)) {
-      return;
-    }
 
     var target, gfx, returnValue;
 
@@ -105,7 +98,8 @@ function InteractionEvents(eventBus, elementRegistry, styles) {
     click: 'element.click',
     dblclick: 'element.dblclick',
     mousedown: 'element.mousedown',
-    mouseup: 'element.mouseup'
+    mouseup: 'element.mouseup',
+    contextmenu: 'element.contextmenu'
   };
 
 
@@ -290,6 +284,17 @@ module.exports = InteractionEvents;
  * An event indicating that the mouse has gone up on an element.
  *
  * @event element.mouseup
+ *
+ * @type {Object}
+ * @property {djs.model.Base} element
+ * @property {SVGElement} gfx
+ * @property {Event} originalEvent
+ */
+
+/**
+ * An event indicating that the right mouse button has clicked an element.
+ *
+ * @event element.contextmenu
  *
  * @type {Object}
  * @property {djs.model.Base} element

--- a/lib/features/interaction-events/InteractionEvents.js
+++ b/lib/features/interaction-events/InteractionEvents.js
@@ -54,7 +54,7 @@ function InteractionEvents(eventBus, elementRegistry, styles) {
   function fire(type, event, element) {
 
     // only react on left mouse button interactions
-    // except for interaction events that are enabled 
+    // except for interaction events that are enabled
     // for secundary mouse button
     if (!isPrimaryButton(event) && !isSecundaryEnabled(type)) {
       return;
@@ -118,8 +118,8 @@ function InteractionEvents(eventBus, elementRegistry, styles) {
 
   /**
    * checks if an event type is enabled for secundary mouse button
-   * 
-   * @param {any} type 
+   *
+   * @param {any} type
    * @returns {boolean}
    */
   function isSecundaryEnabled(type) {

--- a/test/spec/features/interaction-events/InteractionEventsSpec.js
+++ b/test/spec/features/interaction-events/InteractionEventsSpec.js
@@ -64,12 +64,12 @@ describe('features/interaction-events', function() {
 
   describe('event emitting', function() {
 
-    it('should emit element.(click|hover|out|dblclick) events', inject(function(eventBus) {
+    it('should emit element.(click|hover|out|dblclick|contextmenu) events', inject(function(eventBus) {
 
       // TODO(nre): automate this test
       // we could mock raw dom events via custom events and ensure our correct synthetic events fire
 
-      [ 'hover', 'out', 'click', 'dblclick' ].forEach(function(type) {
+      [ 'hover', 'out', 'click', 'dblclick', 'contextmenu' ].forEach(function(type) {
         eventBus.on('element.' + type, function(event) {
           console.log(type, event);
         });


### PR DESCRIPTION
* add new event "contextmenu" to InteractionEvents
* add new the new event to the current spec of InteractionEvents

BREAKING CHANGE:
remove "isPrimaryButton" import and remove the if block in the fire method. This is needed to not ignore right clicks anymore.

before:
```
// only react on left mouse button interactions
// for interaction events
if (!isPrimaryButton(event)) {
  return;
}
```

after:
block is removed

Closes bpmn-io/bpmn-js#750