### PR TITLE
fix(core/Canvas): reset cached viewbox on element changes

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -158,6 +158,18 @@ Canvas.prototype._init = function(config) {
 
   }, this);
 
+  // reset viewbox on shape changes to
+  // recompute the viewbox
+  eventBus.on([
+    'shape.added',
+    'connection.added',
+    'shape.removed',
+    'connection.removed',
+    'elements.changed'
+  ], function() {
+    delete this._cachedViewbox;
+  }, this);
+
   eventBus.on('diagram.destroy', 500, this._destroy, this);
   eventBus.on('diagram.clear', 500, this._clear, this);
 };

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -25,7 +25,12 @@ describe('Canvas', function() {
    */
   function createDiagram(options) {
     return bootstrapDiagram(function() {
-      return merge({ canvas: { container: container, deferUpdate: false } }, options);
+      return merge({
+        canvas: {
+          container: container,
+          deferUpdate: false
+        }
+      }, options);
     }, {});
   }
 
@@ -1233,6 +1238,66 @@ describe('Canvas', function() {
           outer: { width: 300, height: 300 }
         });
       }));
+
+
+      it('should remove cached viewbox on shape add', inject(function(canvas) {
+
+        // given
+        // enforce initial zoom
+        canvas.zoom('fit-viewport');
+
+        canvas.addShape({
+          id: 's0',
+          x: 50, y: 100,
+          width: 600, height: 200
+        });
+
+        // when
+        canvas.zoom('fit-viewport');
+
+        // then
+        expect(canvas.viewbox()).to.eql({
+          x: 50, y: 100,
+          width: 600, height: 600,
+          scale: 0.5,
+          inner: { width: 600, height: 200, x: 50, y: 100 },
+          outer: { width: 300, height: 300 }
+        });
+
+      }));
+
+
+      it('should remove cached viewbox on shape add', inject(
+        function(canvas, eventBus, graphicsFactory) {
+          var shape = canvas.addShape({
+            id: 's0',
+            x: 0, y: 100,
+            width: 600, height: 200
+          });
+
+          // given
+          // enforce initial zoom
+          canvas.zoom('fit-viewport');
+
+          // simultate element changed (move x+50)
+          shape.x = 50;
+          graphicsFactory.update('shape', shape, canvas.getGraphics(shape));
+          eventBus.fire('elements.changed', { elements: [ shape ] });
+
+          // when
+          canvas.zoom('fit-viewport');
+
+          // then
+          expect(canvas.viewbox()).to.eql({
+            x: 50, y: 100,
+            width: 600, height: 600,
+            scale: 0.5,
+            inner: { width: 600, height: 200, x: 50, y: 100 },
+            outer: { width: 300, height: 300 }
+          });
+
+        }
+      ));
 
 
       describe('reposition', function() {


### PR DESCRIPTION
Ensure we reset the cached viewbox on element changes
so that the next `viewbox()` call pick up the possibly
updated SVG bounding box.

Related to bpmn-io/bpmn-js#771
