### PR TITLE
chore(project): Add CSS files to sideEffects declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   ],
   "author": "bpmn.io",
   "license": "MIT",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-preset-env": "^1.6.1",


### PR DESCRIPTION
### Proposed Changes

The new `sideEffects: false` declaration in the `package.json` is not quite correct. The CSS files, by their own nature, do have side effects. Currently, importing the CSS file into your project doesn't work in the production build -- since Webpack strips it out. 

The [Webpack docs](https://webpack.js.org/guides/tree-shaking/) state

> Note that any imported file is subject to tree shaking. This means if you use something like css-loader in your project and import a CSS file, it needs to be added to the side effect list so it will not be unintentionally dropped in production mode.

This PR simply adds the CSS files to the declaration so that. if imported, they make it to the final production bundle.