### PR TITLE
Use delta function instead of subtract

### DIFF
--- a/lib/features/dragging/Dragging.js
+++ b/lib/features/dragging/Dragging.js
@@ -23,6 +23,10 @@ import {
   install as installClickTrap
 } from '../../util/ClickTrap';
 
+import {
+  delta as deltaPos
+} from '../../util/PositionUtil';
+
 var DRAG_ACTIVE_CLS = 'djs-drag-active';
 
 
@@ -38,13 +42,6 @@ function isTouchEvent(event) {
 
 function getLength(point) {
   return Math.sqrt(Math.pow(point.x, 2) + Math.pow(point.y, 2));
-}
-
-function substract(p1, p2) {
-  return {
-    x: p1.x - p2.x,
-    y: p1.y - p2.y
-  };
 }
 
 /**
@@ -181,11 +178,11 @@ export default function Dragging(eventBus, canvas, selection) {
 
     var globalStart = context.globalStart,
         globalCurrent = toPoint(event),
-        globalDelta = substract(globalCurrent, globalStart);
+        globalDelta = deltaPos(globalCurrent, globalStart);
 
     var localStart = context.localStart,
         localCurrent = toLocalPoint(globalCurrent),
-        localDelta = substract(localCurrent, localStart);
+        localDelta = deltaPos(localCurrent, localStart);
 
     // activate context explicitly or once threshold is reached
     if (!context.active && (activate || getLength(globalDelta) > context.threshold)) {
@@ -478,7 +475,7 @@ export default function Dragging(eventBus, canvas, selection) {
       data: data,
       payload: {},
       globalStart: globalStart,
-      displacement: substract(relativeTo, localStart),
+      displacement: deltaPos(relativeTo, localStart),
       localStart: localStart,
       isTouch: isTouch
     }, options);

--- a/lib/navigation/movecanvas/MoveCanvas.js
+++ b/lib/navigation/movecanvas/MoveCanvas.js
@@ -8,8 +8,8 @@ import {
 } from '../../util/ClickTrap';
 
 import {
-  substract
-} from '../../util/Math';
+  delta as deltaPos
+} from '../../util/PositionUtil';
 
 import {
   event as domEvent,
@@ -36,7 +36,7 @@ export default function MoveCanvas(eventBus, canvas) {
 
     var start = context.start,
         position = toPoint(event),
-        delta = substract(position, start);
+        delta = deltaPos(position, start);
 
     if (!context.dragging && length(delta) > THRESHOLD) {
       context.dragging = true;
@@ -50,7 +50,7 @@ export default function MoveCanvas(eventBus, canvas) {
 
       var lastPosition = context.last || context.start;
 
-      delta = substract(position, lastPosition);
+      delta = deltaPos(position, lastPosition);
 
       canvas.scroll({
         dx: delta.x,

--- a/lib/util/Math.js
+++ b/lib/util/Math.js
@@ -6,10 +6,4 @@ export function log10(x) {
   return Math.log(x) / Math.log(10);
 }
 
-
-export function substract(p1, p2) {
-  return {
-    x: p1.x - p2.x,
-    y: p1.y - p2.y
-  };
-}
+export { delta as substract } from './PositionUtil';


### PR DESCRIPTION
This PR removes the duplicate function `Math#substract` and uses the more often used function `PositionUtil#delta`.