### PR TITLE
chore(popup-menu): allow multiple popupMenuProvider

### DIFF
--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -30,6 +30,7 @@ export default function PopupMenu(eventBus, canvas) {
   this._eventBus = eventBus;
   this._canvas = canvas;
   this._providers = {};
+  this._current = {};
 }
 
 PopupMenu.$inject = [ 'eventBus', 'canvas' ];
@@ -60,30 +61,67 @@ PopupMenu.prototype.registerProvider = function(id, provider) {
 
 
 /**
- * Create a popup menu according to a given element. The id refers to the ID
- * of the provider that must be registered before.
+ * Determine if the popup menu has entries.
  *
- * @param  {String} id provider id
- * @param  {Object} element
- *
- * @return {PopupMenu} popup menu instance
+ * @return {Boolean} true if empty
  */
-PopupMenu.prototype.create = function(id, element) {
+PopupMenu.prototype.isEmpty = function(element, providerId) {
+  if (!element) {
+    throw new Error('element parameter is missing');
+  }
+
+  if (!providerId) {
+    throw new Error('providerId parameter is missing');
+  }
+
+  var provider = this._providers[providerId];
+
+  var entries = provider.getEntries(element),
+      headerEntries = provider.getHeaderEntries && provider.getHeaderEntries(element);
+
+  var hasEntries = entries.length > 0,
+      hasHeaderEntries = headerEntries && headerEntries.length > 0;
+
+  return !hasEntries && !hasHeaderEntries;
+};
+
+
+/**
+ * Create entries and open popup menu at given position
+ *
+ * @param  {Object} element
+ * @param  {String} id provider id
+ * @param  {Object} position
+ *
+ * @return {Object} popup menu instance
+ */
+PopupMenu.prototype.open = function(element, id, position) {
 
   var provider = this._providers[id];
-
-  if (!provider) {
-    throw new Error('Provider is not registered: ' + id);
-  }
 
   if (!element) {
     throw new Error('Element is missing');
   }
 
+  if (!provider) {
+    throw new Error('Provider is not registered: ' + id);
+  }
+
+  if (!position) {
+    throw new Error('the position argument is missing');
+  }
+
+  if (this.isOpen()) {
+    this.close();
+  }
+
+  this._emit('open');
+
   var current = this._current = {
     provider: provider,
     className: id,
-    element: element
+    element: element,
+    position: position
   };
 
   if (provider.getHeaderEntries) {
@@ -91,49 +129,6 @@ PopupMenu.prototype.create = function(id, element) {
   }
 
   current.entries = provider.getEntries(element);
-
-  return this;
-};
-
-
-/**
- * Determine if the popup menu has entries.
- *
- * @return {Boolean} true if empty
- */
-PopupMenu.prototype.isEmpty = function() {
-
-  var current = this._current;
-
-  return current.entries.length === 0 && current.headerEntries && current.headerEntries.length === 0;
-};
-
-
-/**
- * Open popup menu at given position
- *
- * @param {Object} position
- *
- * @return {Object} popup menu instance
- */
-PopupMenu.prototype.open = function(position) {
-
-  if (!position) {
-    throw new Error('the position argument is missing');
-  }
-
-  // make sure, only one popup menu is open at a time
-  if (this.isOpen()) {
-    this.close();
-  }
-
-  this._emit('open');
-
-  var current = this._current,
-      canvas = this._canvas,
-      parent = canvas.getContainer();
-
-  current.position = position;
 
   current.container = this._createContainer();
 
@@ -152,9 +147,10 @@ PopupMenu.prototype.open = function(position) {
     );
   }
 
-  this._attachContainer(current.container, parent, position.cursor);
+  var canvas = this._canvas,
+      parent = canvas.getContainer();
 
-  return this;
+  this._attachContainer(current.container, parent, position.cursor);
 };
 
 


### PR DESCRIPTION
Prevoiusly the popupMenu#create needed to be called when
context pad was opening. This is no longer needed. Now
only popupMenu#open needs to be called on context pad entry
click.

BREAKING CHANGES:

* popupMenu#create was removed
* popupMenu#open now expects element, id, position as params
* popupMenu#isEmpty now expects element, providerId as params

<!--

Thanks for filing a pull request!

Make sure you've read through [our contributing guide](https://github.com/bpmn-io/diagram-js/blob/master/CONTRIBUTING.md#creating-a-pull-request) before you continue.

-->


Fixes #253 