### PR TITLE
feat(popup-menu): support multiple classnames on popup-menu entries

### DIFF
--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -375,7 +375,7 @@ PopupMenu.prototype._createEntry = function(entry) {
   entryClasses.add('entry');
 
   if (entry.className) {
-    entryClasses.add(entry.className);
+    entry.className.split(' ').forEach(className => entryClasses.add(className));
   }
 
   domAttr(entryContainer, DATA_REF, entry.id);

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -537,7 +537,7 @@ describe('features/popup', function() {
         getEntries: function() {
           return [
             { id: '1', label: 'Entry 1' },
-            { id: '2', label: 'Entry 2 - special', className: 'special-entry' }
+            { id: '2', label: 'Entry 2 - special', className: 'special-entry another-special-entry' }
           ];
         }
       };
@@ -549,6 +549,10 @@ describe('features/popup', function() {
 
       // then
       var element = queryPopup(popupMenu, '.special-entry');
+
+      expect(element.textContent).to.eql('Entry 2 - special');
+
+      element = queryPopup(popupMenu, '.another-special-entry');
 
       expect(element.textContent).to.eql('Entry 2 - special');
     }));


### PR DESCRIPTION
### Proposed Changes

* A popup-menu entry can now accept multiple classes as `className` each of them delimited by a space, e. g. `className: 'class1 class2'`