### PR TITLE
Hide toggle if palette open

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -327,8 +327,7 @@ svg.new-parent {
 }
 
 .djs-palette.open .djs-palette-toggle {
-  width: 100%;
-  height: 10px;
+  display: none;
 }
 
 /**


### PR DESCRIPTION
Since the toggle is not intuitive and people rarely find it let alone the fact that hiding the palette doesn't seem to be a use-case at all we should hide the toggle by default. The API for showing/hiding the palette remains unchanged.

Closes #257 