### PR TITLE
Take top & bottom padding into account when calculating total height of layout text

### DIFF
--- a/lib/util/Text.js
+++ b/lib/util/Text.js
@@ -282,7 +282,7 @@ Text.prototype.layoutText = function(text, options) {
 
   var totalHeight = reduce(layouted, function(sum, line, idx) {
     return sum + (lineHeight || line.height);
-  }, 0) + padding.bottom;
+  }, 0) + padding.top + padding.bottom;
 
   var maxLineWidth = reduce(layouted, function(sum, line, idx) {
     return line.width > sum ? line.width : sum;

--- a/lib/util/Text.js
+++ b/lib/util/Text.js
@@ -282,7 +282,7 @@ Text.prototype.layoutText = function(text, options) {
 
   var totalHeight = reduce(layouted, function(sum, line, idx) {
     return sum + (lineHeight || line.height);
-  }, 0);
+  }, 0) + padding.bottom;
 
   var maxLineWidth = reduce(layouted, function(sum, line, idx) {
     return line.width > sum ? line.width : sum;

--- a/test/spec/util/TextSpec.js
+++ b/test/spec/util/TextSpec.js
@@ -444,7 +444,7 @@ describe('util - Text', function() {
         });
 
         expect(text).to.exist;
-        expect(toFitBBox(text, { x: 0, y: -3, width: 100, height: 106 })).to.be.true;
+        expect(toFitBBox(text, { x: 0, y: -8, width: 100, height: 106 })).to.be.true;
       });
 
 


### PR DESCRIPTION
Padding has been ignored until now.