### PR TITLE
feat(core/EventBus): allow #off to remove multiple event listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: add ability to remove multiple events via `EventBus#off`
+
 ## 2.3.0
 
 * `FEAT`: hide palette toggle in expanded state (a none-feature, technically) ([#257](https://github.com/bpmn-io/diagram-js/issues/257))

--- a/lib/core/EventBus.js
+++ b/lib/core/EventBus.js
@@ -194,30 +194,19 @@ EventBus.prototype.once = function(event, priority, callback, that) {
  *
  * If no callback is given, all listeners for a given event name are being removed.
  *
- * @param {String} event
+ * @param {String|Array<String>} events
  * @param {Function} [callback]
  */
-EventBus.prototype.off = function(event, callback) {
-  var listeners = this._getListeners(event),
-      listener,
-      listenerCallback,
-      idx;
+EventBus.prototype.off = function(events, callback) {
 
-  if (callback) {
+  events = isArray(events) ? events : [ events ];
 
-    // move through listeners from back to front
-    // and remove matching listeners
-    for (idx = listeners.length - 1; (listener = listeners[idx]); idx--) {
-      listenerCallback = listener.callback;
+  var self = this;
 
-      if (listenerCallback === callback || listenerCallback[FN_REF] === callback) {
-        listeners.splice(idx, 1);
-      }
-    }
-  } else {
-    // clear listeners
-    listeners.length = 0;
-  }
+  events.forEach(function(event) {
+    self._removeListener(event, callback);
+  });
+
 };
 
 
@@ -433,6 +422,31 @@ EventBus.prototype._getListeners = function(name) {
   }
 
   return listeners;
+};
+
+
+EventBus.prototype._removeListener = function(event, callback) {
+
+  var listeners = this._getListeners(event),
+      listener,
+      listenerCallback,
+      idx;
+
+  if (callback) {
+
+    // move through listeners from back to front
+    // and remove matching listeners
+    for (idx = listeners.length - 1; (listener = listeners[idx]); idx--) {
+      listenerCallback = listener.callback;
+
+      if (listenerCallback === callback || listenerCallback[FN_REF] === callback) {
+        listeners.splice(idx, 1);
+      }
+    }
+  } else {
+    // clear listeners
+    listeners.length = 0;
+  }
 };
 
 

--- a/test/spec/core/EventBusSpec.js
+++ b/test/spec/core/EventBusSpec.js
@@ -500,6 +500,23 @@ describe('core/EventBus', function() {
       expect(listener1).to.have.been.called;
     });
 
+
+    it('should remove multiple listeners', function() {
+
+      // given
+      var listener1 = sinon.spy();
+
+      eventBus.on([ 'foo', 'bar' ], listener1);
+      eventBus.off([ 'foo', 'bar' ], listener1);
+
+      // when
+      eventBus.fire({ type: 'foo' });
+      eventBus.fire({ type: 'bar' });
+
+      // then
+      expect(listener1).not.to.have.been.called;
+    });
+
   });
 
 


### PR DESCRIPTION
The method `EventBus#on` allows us to register multiple event listeners at the same time:

```
eventBus.on([
  'commandStack.changed',
  'selection.changed'
], doStuff);
```

However, you're not able to un-register these events right now:

```
eventBus.off([
  'commandStack.changed',
  'selection.changed'
], doStuff);

// won't work :-(
```

This PR adresses this issue.