### PR TITLE
refactor(modeling): move labels + attachers with closure

### DIFF
--- a/lib/features/attach-support/AttachSupport.js
+++ b/lib/features/attach-support/AttachSupport.js
@@ -74,26 +74,15 @@ export default function AttachSupport(injector, eventBus, rules, modeling) {
   });
 
 
-  // move all attachments after the other shapes are done moving
-  this.postExecuted('elements.move', function(event) {
-
-    var context = event.context,
-        delta = context.delta,
-        newParent = context.newParent,
+  // add all attachers to move closure
+  this.preExecuted('elements.move', HIGH_PRIORITY, function(e) {
+    var context = e.context,
         closure = context.closure,
-        enclosedElements = closure.enclosedElements,
-        attachers = getAttachers(enclosedElements);
+        shapes = context.shapes,
+        attachers = getAttachers(shapes);
 
-    // ensure we move all attachers with their hosts
-    // if they have not been moved already
     forEach(attachers, function(attacher) {
-      if (!enclosedElements[attacher.id]) {
-        modeling.moveShape(attacher, delta, newParent);
-
-        forEach(attacher.labels, function(label) {
-          modeling.moveShape(label, delta, newParent);
-        });
-      }
+      closure.add(attacher, closure.topLevel[attacher.host.id]);
     });
   });
 

--- a/lib/features/label-support/LabelSupport.js
+++ b/lib/features/label-support/LabelSupport.js
@@ -1,15 +1,12 @@
 import {
   forEach,
-  filter,
-  reduce
+  filter
 } from 'min-dash';
 
 import inherits from 'inherits';
 
 var LOW_PRIORITY = 250,
     HIGH_PRIORITY = 1400;
-
-import { getMid } from '../../layout/LayoutUtil';
 
 import {
   add as collectionAdd,
@@ -75,45 +72,28 @@ export default function LabelSupport(injector, eventBus, modeling) {
 
   });
 
-  // fetch all labels to be moved together with their
-  // pre-move mid; we'll use this to determine, if a label
-  // needs move afterwards
-  this.postExecute('elements.move', HIGH_PRIORITY, function(e) {
+  // add all labels to move closure
+  this.preExecuted('elements.move', HIGH_PRIORITY, function(e) {
     var context = e.context,
         closure = context.closure,
         enclosedElements = closure.enclosedElements;
 
-    context.enclosedLabels = reduce(enclosedElements, function(enclosedLabels, element) {
+    var enclosedLabels = [];
+
+    // find labels that are not part of
+    // move closure yet and add them
+    forEach(enclosedElements, function(element) {
       forEach(element.labels, function(label) {
 
         if (!enclosedElements[label.id]) {
-          enclosedLabels.push([ label, getMid(label) ]);
+          enclosedLabels.push(label);
         }
       });
-
-      return enclosedLabels;
-    }, []);
-  });
-
-  // move previously fetched labels, if the have not been moved already
-  this.postExecuted('elements.move', function(e) {
-
-    var context = e.context,
-        labels = context.enclosedLabels,
-        delta = context.delta;
-
-    forEach(labels, function(entry) {
-      var label = entry[0];
-      var mid = entry[1];
-
-      var currentMid = getMid(label);
-
-      // has label not been moved yet?
-      if (currentMid.x === mid.x && currentMid.y === mid.y) {
-        modeling.moveShape(label, delta, label.labelTarget.parent);
-      }
     });
+
+    closure.addAll(enclosedLabels);
   });
+
 
   this.preExecute([
     'connection.delete',

--- a/lib/features/modeling/cmd/helper/MoveClosure.js
+++ b/lib/features/modeling/cmd/helper/MoveClosure.js
@@ -1,0 +1,34 @@
+import {
+  assign
+} from 'min-dash';
+
+import {
+  getClosure
+} from '../../../../util/Elements';
+
+
+export default function MoveClosure() {
+
+  this.allShapes = {};
+  this.allConnections = {};
+
+  this.enclosedElements = {};
+  this.enclosedConnections = {};
+
+  this.topLevel = {};
+}
+
+
+MoveClosure.prototype.add = function(element, isTopLevel) {
+  return this.addAll([ element ], isTopLevel);
+};
+
+
+MoveClosure.prototype.addAll = function(elements, isTopLevel) {
+
+  var newClosure = getClosure(elements, !!isTopLevel, this);
+
+  assign(this, newClosure);
+
+  return this;
+};

--- a/lib/features/modeling/cmd/helper/MoveHelper.js
+++ b/lib/features/modeling/cmd/helper/MoveHelper.js
@@ -3,13 +3,12 @@ import {
 } from 'min-dash';
 
 import {
-  getClosure
-} from '../../../../util/Elements';
-
-import {
   getMovedSourceAnchor,
   getMovedTargetAnchor
 } from './AnchorsHelper';
+
+import MoveClosure from './MoveClosure';
+
 
 /**
  * A helper that is able to carry out serialized move
@@ -93,6 +92,8 @@ MoveHelper.prototype.moveClosure = function(closure, delta, newParent, newHost, 
  * Returns the closure for the selected elements
  *
  * @param  {Array<djs.model.Base>} elements
- * @return {Object} closure
+ * @return {MoveClosure} closure
  */
-MoveHelper.prototype.getClosure = getClosure;
+MoveHelper.prototype.getClosure = function(elements) {
+  return new MoveClosure().addAll(elements, true);
+};

--- a/lib/util/Elements.js
+++ b/lib/util/Elements.js
@@ -1,6 +1,9 @@
 import {
+  assign,
   isArray,
   isNumber,
+  isObject,
+  isUndefined,
   groupBy,
   forEach
 } from 'min-dash';
@@ -112,20 +115,38 @@ export function selfAndAllChildren(elements, allowDuplicates) {
 
 /**
  * Gets the the closure for all selected elements,
- * their connections and their attachment's connections
+ * their enclosed children and connections.
  *
  * @param {Array<djs.model.Base>} elements
- * @return {Object} enclosure
+ * @param {Boolean} [isTopLevel=true]
+ * @param {Object} [existingClosure]
+ *
+ * @return {Object} newClosure
  */
-export function getClosure(elements) {
+export function getClosure(elements, isTopLevel, closure) {
 
-  // original elements passed to this function
-  var topLevel = groupBy(elements, function(e) { return e.id; });
+  if (isUndefined(isTopLevel)) {
+    isTopLevel = true;
+  }
 
-  var allShapes = {},
-      allConnections = {},
-      enclosedElements = {},
-      enclosedConnections = {};
+  if (isObject(isTopLevel)) {
+    closure = isTopLevel;
+    isTopLevel = true;
+  }
+
+
+  closure = closure || {};
+
+  var allShapes = copyObject(closure.allShapes),
+      allConnections = copyObject(closure.allConnections),
+      enclosedElements = copyObject(closure.enclosedElements),
+      enclosedConnections = copyObject(closure.enclosedConnections);
+
+  var topLevel = copyObject(
+    closure.topLevel,
+    isTopLevel && groupBy(elements, function(e) { return e.id; })
+  );
+
 
   function handleConnection(c) {
     if (topLevel[c.source.id] && topLevel[c.target.id]) {
@@ -287,4 +308,11 @@ export function getType(element) {
   }
 
   return 'root';
+}
+
+
+// helpers ///////////////////////////////
+
+function copyObject(src1, src2) {
+  return assign({}, src1 || {}, src2 || {});
 }

--- a/test/spec/features/attach-support/AttachSupportSpec.js
+++ b/test/spec/features/attach-support/AttachSupportSpec.js
@@ -29,6 +29,9 @@ import { classes as svgClasses } from 'tiny-svg';
 var ATTACH = { attach: true };
 var NO_ATTACH = { attach: false };
 
+/* global sinon */
+var { spy } = sinon;
+
 
 describe('features/attach-support', function() {
 
@@ -81,7 +84,7 @@ describe('features/attach-support', function() {
     beforeEach(inject(function(canvas, elementFactory, modeling) {
 
       host = elementFactory.createShape({
-        id:'host',
+        id: 'host',
         x: 700, y: 100,
         width: 100, height: 100
       });
@@ -191,6 +194,33 @@ describe('features/attach-support', function() {
       // then
       expect(attacher.host).not.to.exist;
       expect(parentShape.attachers).not.to.include(attacher);
+    }));
+
+
+    it('should move with closure', inject(function(modeling, eventBus) {
+
+      // given
+      var listener = spy(function(event) {
+
+        var closure = event.context.closure;
+
+        // attacher is part of closure
+        expect(closure.allShapes).to.contain.key(attacher.id);
+
+        // attacher did move with closure
+        expect(attacher).to.have.position({
+          x: 400 - 25 - 50,
+          y: 110 - 25
+        });
+      });
+
+      eventBus.once('commandStack.elements.move.postExecuted', 5000, listener);
+
+      // when
+      modeling.moveElements([ parentShape ], { x: -50, y: 0 });
+
+      // then
+      expect(listener).to.have.been.called;
     }));
 
   });
@@ -1654,7 +1684,6 @@ describe('features/attach-support', function() {
     }));
 
   });
-
 
 
   describe('append', function() {

--- a/test/spec/features/label-support/LabelSupportSpec.js
+++ b/test/spec/features/label-support/LabelSupportSpec.js
@@ -17,6 +17,9 @@ import {
   classes as svgClasses
 } from 'tiny-svg';
 
+/* global sinon */
+var { spy } = sinon;
+
 
 describe('features/label-support', function() {
 
@@ -280,6 +283,34 @@ describe('features/label-support', function() {
 
     });
 
+
+    it('should move with closure', inject(function(modeling, eventBus) {
+
+      // given
+      var listener = spy(function(event) {
+
+        var closure = event.context.closure;
+
+        // labels are part of closure
+        expect(closure.allShapes).to.contain.keys(
+          label.id,
+          otherLabel.id
+        );
+
+        // labels did move with closure
+        expect(label).to.have.position({ x: 235, y: 240 });
+        expect(otherLabel).to.have.position({ x: 235, y: 290 });
+      });
+
+      eventBus.once('commandStack.elements.move.postExecuted', 5000, listener);
+
+      // when
+      modeling.moveElements([ childShape ], { x: 75, y: 10 });
+
+      // then
+      expect(listener).to.have.been.called;
+    }));
+
   });
 
 
@@ -302,33 +333,6 @@ describe('features/label-support', function() {
       // then
       expect(label.x).to.eql(235);
       expect(label.y).to.eql(230);
-    }));
-
-
-    it('should not move, if already moved', inject(function(eventBus, modeling) {
-
-      // given
-      var labelPosition = {
-        x: label.x,
-        y: label.y
-      };
-
-      eventBus.once('commandStack.shape.move.postExecute', function(e) {
-
-        var shape = e.context.shape;
-
-        var label = shape.label;
-
-        modeling.moveShape(label, { x: 30, y: 0 });
-      });
-
-      // when
-      modeling.moveElements([ childShape ], { x: 75, y: 0 }, parentShape);
-
-      // then
-      // label was not moved by LabelSupport
-      expect(label.x).to.eql(labelPosition.x + 30);
-      expect(label.y).to.eql(labelPosition.y);
     }));
 
 

--- a/test/spec/util/ElementsSpec.js
+++ b/test/spec/util/ElementsSpec.js
@@ -136,7 +136,7 @@ describe('util/Elements', function() {
 
   describe('getClosure', function() {
 
-    it('should test getClosure', function() {
+    it('should work', function() {
       var closure = getClosure([ shapeB, shapeE ]);
 
       expect(closure.allShapes).to.have.keys('b', 'e', 'c', 'c.0', 'c.1');
@@ -145,6 +145,20 @@ describe('util/Elements', function() {
       expect(closure.topLevel).to.have.keys('e', 'b', 'connection1');
 
       expect(closure.topLevel['connection1']).to.eql([ connection1 ]);
+    });
+
+
+    it('should be extensible', function() {
+      var closure = getClosure([ shapeB, shapeE ], false, {
+        topLevel: {
+          'foo': []
+        }
+      });
+
+      expect(closure.allShapes).to.have.keys('b', 'e', 'c', 'c.0', 'c.1');
+      expect(closure.allConnections).to.have.keys('connection1');
+      expect(closure.enclosedElements).to.have.keys('b', 'e', 'connection1', 'c', 'c.0', 'c.1');
+      expect(closure.topLevel).to.have.keys('foo');
     });
 
   });


### PR DESCRIPTION
Prior to this change we adopted a complicated mechanism to move attachers and labels after the actual move closure.

This change simplifies the matter: We now add attachers and labels to the move closure and let our existing move mechanisms handle their movements, too.

As a result, users can rely on the fact that all elements moved once

* connection layouting is triggered
* the elements.move postExecute phase is triggered

:tada: