### PR TITLE
719 add minimum scale for context pad

### DIFF
--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -246,6 +246,10 @@ ContextPad.prototype.getPad = function(element) {
       right: -9,
       top: -6
     },
+    scale: {
+      min: 1,
+      max: 1.5
+    },
     html: html
   });
 

--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -1,4 +1,5 @@
 import {
+  assign,
   isFunction,
   isArray,
   forEach
@@ -20,22 +21,40 @@ var entrySelector = '.entry';
  * A context pad that displays element specific, contextual actions next
  * to a diagram element.
  *
+ * @param {Object} config
+ * @param {Boolean|Object} [config.scale={ min: 1.0, max: 1.5 }]
+ * @param {Number} [config.scale.min]
+ * @param {Number} [config.scale.max]
  * @param {EventBus} eventBus
  * @param {Overlays} overlays
  */
-export default function ContextPad(eventBus, overlays) {
+export default function ContextPad(config, eventBus, overlays) {
 
   this._providers = [];
 
   this._eventBus = eventBus;
   this._overlays = overlays;
+  this._overlaysConfig = assign({
+    position: {
+      right: -9,
+      top: -6
+    },
+    scale: {
+      min: 1,
+      max: 1.5
+    }
+  }, config && { scale: config.scale });
 
   this._current = null;
 
   this._init();
 }
 
-ContextPad.$inject = [ 'eventBus', 'overlays' ];
+ContextPad.$inject = [
+  'config.contextPad',
+  'eventBus',
+  'overlays'
+];
 
 
 /**
@@ -228,6 +247,10 @@ ContextPad.prototype.getPad = function(element) {
 
   var html = domify('<div class="djs-context-pad"></div>');
 
+  var overlaysConfig = assign({
+    html: html
+  }, this._overlaysConfig);
+
   domDelegate.bind(html, entrySelector, 'click', function(event) {
     self.trigger('click', event);
   });
@@ -241,17 +264,7 @@ ContextPad.prototype.getPad = function(element) {
     event.stopPropagation();
   });
 
-  this._overlayId = overlays.add(element, 'context-pad', {
-    position: {
-      right: -9,
-      top: -6
-    },
-    scale: {
-      min: 1,
-      max: 1.5
-    },
-    html: html
-  });
+  this._overlayId = overlays.add(element, 'context-pad', overlaysConfig);
 
   var pad = overlays.get(this._overlayId);
 

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -349,7 +349,12 @@ describe('features/context-pad', function() {
     it('should handle drag event', inject(function(canvas, contextPad) {
 
       // given
-      var shape = canvas.addShape({ id: 's1', width: 100, height: 100, x: 10, y: 10, type: 'drag' });
+      var shape = canvas.addShape({
+        id: 's1',
+        width: 100, height: 100,
+        x: 10, y: 10,
+        type: 'drag'
+      });
 
       contextPad.open(shape);
 
@@ -368,7 +373,9 @@ describe('features/context-pad', function() {
 
   });
 
+
   describe('scaling', function() {
+
     beforeEach(bootstrapDiagram({ modules: [ contextPadModule, providerModule ] }));
 
     var NUM_REGEX = /[+-]?\d*[.]?\d+(?=,|\))/g;
@@ -392,7 +399,12 @@ describe('features/context-pad', function() {
     function verifyScale(expectedScales) {
       return inject(function(canvas, contextPad) {
         // given
-        var shape = canvas.addShape({ id: 's1', width: 100, height: 100, x: 10, y: 10, type: 'drag' });
+        var shape = canvas.addShape({
+          id: 's1',
+          width: 100, height: 100,
+          x: 10, y: 10,
+          type: 'drag'
+        });
 
         contextPad.open(shape);
 
@@ -419,6 +431,7 @@ describe('features/context-pad', function() {
       });
     }
 
+
     it('should scale within the limits of [ 1.0, 1.5 ] by default', function() {
       var expectedScales = [ 1.0, 1.2, 1.5, 1.5, 1.0 ];
 
@@ -428,6 +441,7 @@ describe('features/context-pad', function() {
 
       return verifyScale(expectedScales);
     });
+
 
     it('should scale within the limits set in config', function() {
       var config = {
@@ -446,6 +460,7 @@ describe('features/context-pad', function() {
       return verifyScale(expectedScales);
     });
 
+
     it('should scale with scale = true', function() {
       var config = {
         scale: false
@@ -460,6 +475,7 @@ describe('features/context-pad', function() {
       return verifyScale(expectedScales);
     });
 
+
     it('should not scale with scale = false', function() {
       var config = {
         scale: false
@@ -473,5 +489,7 @@ describe('features/context-pad', function() {
 
       return verifyScale(expectedScales);
     });
+
   });
+
 });


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->
This PR adds default minimum and maximum scale of ContextPad and allows to set scaling for ContextPad in config.

Closes [#719](https://github.com/bpmn-io/bpmn-js/issues/719)