### PR TITLE
feat(popup-menu): make scaling configurable with default min and max

### DIFF
--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -16,16 +16,40 @@ import {
 var DATA_REF = 'data-id';
 
 
+function setTransform(element, transform) {
+  element.style['transform-origin'] = 'top left';
+
+  [ '', '-ms-', '-webkit-' ].forEach(function(prefix) {
+    element.style[prefix + 'transform'] = transform;
+  });
+}
+
+function isDefined(value) {
+  return typeof value !== 'undefined';
+}
+
+
 /**
  * A popup menu that can be used to display a list of actions anywhere in the canvas.
  *
+ * @param {Object} config
+ * @param {Boolean|Object} [config.scale={ min: 1.0, max: 1.5 }]
+ * @param {Number} [config.scale.min]
+ * @param {Number} [config.scale.max]
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
  *
  * @class
  * @constructor
  */
-export default function PopupMenu(eventBus, canvas) {
+export default function PopupMenu(config, eventBus, canvas) {
+
+  this._config = assign({
+    scale: {
+      min: 1,
+      max: 1.5
+    }
+  }, config && { scale: config.scale });
 
   this._eventBus = eventBus;
   this._canvas = canvas;
@@ -33,7 +57,11 @@ export default function PopupMenu(eventBus, canvas) {
   this._current = {};
 }
 
-PopupMenu.$inject = [ 'eventBus', 'canvas' ];
+PopupMenu.$inject = [
+  'config.popupMenu',
+  'eventBus',
+  'canvas'
+];
 
 /**
  * Registers a popup menu provider
@@ -264,11 +292,7 @@ PopupMenu.prototype._attachContainer = function(container, parent, cursor) {
     self.trigger(event);
   });
 
-  // apply canvas zoom level
-  var zoom = this._canvas.zoom();
-
-  container.style.transformOrigin = 'top left';
-  container.style.transform = 'scale(' + zoom + ')';
+  this._updateScale(container);
 
   // Attach to DOM
   parent.appendChild(container);
@@ -279,6 +303,45 @@ PopupMenu.prototype._attachContainer = function(container, parent, cursor) {
 
   // Add Handler
   this._bindHandlers();
+};
+
+
+/**
+ * Updates popup style.transform with respect to the config and zoom level.
+ *
+ * @method _updateScale
+ *
+ * @param {Object} container
+ */
+PopupMenu.prototype._updateScale = function(container) {
+  var zoom = this._canvas.zoom();
+
+  var scaleConfig = this._config.scale,
+      minScale,
+      maxScale,
+      scale = zoom;
+
+  if (scaleConfig !== true) {
+
+    if (scaleConfig === false) {
+      minScale = 1;
+      maxScale = 1;
+    } else {
+      minScale = scaleConfig.min;
+      maxScale = scaleConfig.max;
+    }
+
+    if (isDefined(minScale) && zoom < minScale) {
+      scale = minScale;
+    }
+
+    if (isDefined(maxScale) && zoom > maxScale) {
+      scale = maxScale;
+    }
+
+  }
+
+  setTransform(container, 'scale(' + scale + ')');
 };
 
 


### PR DESCRIPTION
Popup menu scaling is now globally configurable.

By default it does not scale below 1.0 and above 1.5.

Closes [#861](https://github.com/bpmn-io/bpmn-js/issues/861)