### PR TITLE
Reuse is defined

### DIFF
--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -2,7 +2,8 @@ import {
   assign,
   isFunction,
   isArray,
-  forEach
+  forEach,
+  isDefined
 } from 'min-dash';
 
 import {
@@ -34,16 +35,19 @@ export default function ContextPad(config, eventBus, overlays) {
 
   this._eventBus = eventBus;
   this._overlays = overlays;
-  this._overlaysConfig = assign({
+
+  var scale = isDefined(config && config.scale) ? config.scale : {
+    min: 1,
+    max: 1.5
+  };
+
+  this._overlaysConfig = {
     position: {
       right: -9,
       top: -6
     },
-    scale: {
-      min: 1,
-      max: 1.5
-    }
-  }, config && { scale: config.scale });
+    scale: scale
+  };
 
   this._current = null;
 

--- a/lib/features/overlays/Overlays.js
+++ b/lib/features/overlays/Overlays.js
@@ -7,6 +7,7 @@ import {
   find,
   filter,
   matchPattern,
+  isDefined
 } from 'min-dash';
 
 import {
@@ -28,35 +29,6 @@ var ids = new Ids('ov');
 
 var LOW_PRIORITY = 500;
 
-
-function createRoot(parent) {
-  var root = domify('<div class="djs-overlay-container" style="position: absolute; width: 0; height: 0;" />');
-  parent.insertBefore(root, parent.firstChild);
-
-  return root;
-}
-
-
-function setPosition(el, x, y) {
-  assign(el.style, { left: x + 'px', top: y + 'px' });
-}
-
-function setVisible(el, visible) {
-  el.style.display = visible === false ? 'none' : '';
-}
-
-function setTransform(el, transform) {
-
-  el.style['transform-origin'] = 'top left';
-
-  [ '', '-ms-', '-webkit-' ].forEach(function(prefix) {
-    el.style[prefix + 'transform'] = transform;
-  });
-}
-
-function isDef(o) {
-  return typeof o !== 'undefined';
-}
 
 /**
  * A service that allows users to attach overlays to diagram elements.
@@ -504,8 +476,8 @@ Overlays.prototype._updateOverlayVisibilty = function(overlay, viewbox) {
 
   if (show) {
     if (
-      (isDef(minZoom) && minZoom > viewbox.scale) ||
-      (isDef(maxZoom) && maxZoom < viewbox.scale)
+      (isDefined(minZoom) && minZoom > viewbox.scale) ||
+      (isDefined(maxZoom) && maxZoom < viewbox.scale)
     ) {
       visible = false;
     }
@@ -535,16 +507,16 @@ Overlays.prototype._updateOverlayScale = function(overlay, viewbox) {
       maxScale = shouldScale.max;
     }
 
-    if (isDef(minScale) && viewbox.scale < minScale) {
+    if (isDefined(minScale) && viewbox.scale < minScale) {
       scale = (1 / viewbox.scale || 1) * minScale;
     }
 
-    if (isDef(maxScale) && viewbox.scale > maxScale) {
+    if (isDefined(maxScale) && viewbox.scale > maxScale) {
       scale = (1 / viewbox.scale || 1) * maxScale;
     }
   }
 
-  if (isDef(scale)) {
+  if (isDefined(scale)) {
     transform = 'scale(' + scale + ',' + scale + ')';
   }
 
@@ -640,3 +612,31 @@ Overlays.prototype._init = function() {
 
   eventBus.on('diagram.clear', this.clear, this);
 };
+
+
+
+// helpers /////////////////////////////
+
+function createRoot(parent) {
+  var root = domify('<div class="djs-overlay-container" style="position: absolute; width: 0; height: 0;" />');
+  parent.insertBefore(root, parent.firstChild);
+
+  return root;
+}
+
+function setPosition(el, x, y) {
+  assign(el.style, { left: x + 'px', top: y + 'px' });
+}
+
+function setVisible(el, visible) {
+  el.style.display = visible === false ? 'none' : '';
+}
+
+function setTransform(el, transform) {
+
+  el.style['transform-origin'] = 'top left';
+
+  [ '', '-ms-', '-webkit-' ].forEach(function(prefix) {
+    el.style[prefix + 'transform'] = transform;
+  });
+}

--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -3,6 +3,7 @@ import {
   assign,
   find,
   matchPattern,
+  isDefined
 } from 'min-dash';
 
 import {
@@ -31,12 +32,14 @@ var DATA_REF = 'data-id';
  */
 export default function PopupMenu(config, eventBus, canvas) {
 
-  this._config = assign({
-    scale: {
-      min: 1,
-      max: 1.5
-    }
-  }, config && { scale: config.scale });
+  var scale = isDefined(config && config.scale) ? config.scale : {
+    min: 1,
+    max: 1.5
+  };
+
+  this._config = {
+    scale: scale
+  };
 
   this._eventBus = eventBus;
   this._canvas = canvas;
@@ -503,8 +506,4 @@ function setTransform(element, transform) {
   [ '', '-ms-', '-webkit-' ].forEach(function(prefix) {
     element.style[prefix + 'transform'] = transform;
   });
-}
-
-function isDefined(value) {
-  return typeof value !== 'undefined';
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "didi": "^4.0.0",
     "hammerjs": "^2.0.1",
     "inherits": "^2.0.1",
-    "min-dash": "^3.0.0",
+    "min-dash": "^3.2.0",
     "min-dom": "^3.0.0",
     "object-refs": "^0.3.0",
     "path-intersection": "^1.0.2",

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -433,13 +433,28 @@ describe('features/context-pad', function() {
     }
 
 
-    it('should scale within the limits of [ 1.0, 1.5 ] by default', function() {
+    it('should scale [ 1.0, 1.5 ] by default', function() {
 
       // given
       var expectedScales = [ 1.0, 1.2, 1.5, 1.5, 1.0 ];
 
       bootstrapDiagram({
         modules: [ contextPadModule, providerModule ]
+      })();
+
+      // when
+      verifyScales(expectedScales);
+    });
+
+
+    it('should scale [ 1.0, 1.5 ] without scale config', function() {
+
+      // given
+      var expectedScales = [ 1.0, 1.2, 1.5, 1.5, 1.0 ];
+
+      bootstrapDiagram({
+        modules: [ contextPadModule, providerModule ],
+        contextPad: {}
       })();
 
       // when

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -1019,7 +1019,7 @@ describe('features/popup', function() {
     }
 
 
-    it('should scale within the limits of [ 1.0, 1.5 ] by default', function() {
+    it('should scale within [ 1.0, 1.5 ] by default', function() {
       // given
       var expectedScales = [ 1.0, 1.2, 1.5, 1.5, 1.0 ];
 
@@ -1028,6 +1028,23 @@ describe('features/popup', function() {
           popupMenuModule,
           modelingModule
         ]
+      })();
+
+      // when
+      verifyScales(expectedScales);
+    });
+
+
+    it('should scale within [ 1.0, 1.5 ] without scale config', function() {
+      // given
+      var expectedScales = [ 1.0, 1.2, 1.5, 1.5, 1.0 ];
+
+      bootstrapDiagram({
+        modules: [
+          popupMenuModule,
+          modelingModule
+        ],
+        popupMenu: {}
       })();
 
       // when


### PR DESCRIPTION
This PR:

* fixes an error if users omit _scale_ from the `popupMenu` and `contextPad` config
* reuses `isDefined` from `min-dash`
* bumps `min-dash` version, as the old version shipped with broken `{ isUndefined, isDefined }` helpers