### PR TITLE
feat(global-connect): use rules for canStartConnection

### DIFF
--- a/lib/features/global-connect/GlobalConnect.js
+++ b/lib/features/global-connect/GlobalConnect.js
@@ -1,14 +1,25 @@
 var MARKER_OK = 'connect-ok',
     MARKER_NOT_OK = 'connect-not-ok';
 
-
+/**
+ * @class
+ * @constructor
+ *
+ * @param {EventBus} eventBus
+ * @param {Dragging} dragging
+ * @param {Connect} connect
+ * @param {Canvas} canvas
+ * @param {ToolManager} toolManager
+ * @param {Rules} rules
+ */
 export default function GlobalConnect(
     eventBus, dragging, connect,
-    canvas, toolManager) {
+    canvas, toolManager, rules) {
 
   var self = this;
 
   this._dragging = dragging;
+  this._rules = rules;
 
   toolManager.registerTool('global-connect', {
     tool: 'global-connect',
@@ -73,9 +84,9 @@ GlobalConnect.$inject = [
   'dragging',
   'connect',
   'canvas',
-  'toolManager'
+  'toolManager',
+  'rules'
 ];
-
 
 /**
  * Initiates tool activity.
@@ -88,7 +99,6 @@ GlobalConnect.prototype.start = function(event) {
     }
   });
 };
-
 
 GlobalConnect.prototype.toggle = function() {
   if (this.isActive()) {
@@ -104,12 +114,6 @@ GlobalConnect.prototype.isActive = function() {
   return context && /^global-connect/.test(context.prefix);
 };
 
-
-GlobalConnect.prototype.registerProvider = function(provider) {
-  this._provider = provider;
-};
-
-
 /**
  * Check if source shape can initiate connection.
  *
@@ -117,5 +121,5 @@ GlobalConnect.prototype.registerProvider = function(provider) {
  * @return {Boolean}
  */
 GlobalConnect.prototype.canStartConnect = function(startTarget) {
-  return this._provider.canStartConnect(startTarget);
+  return this._rules.allowed('connection.start', { source: startTarget });
 };

--- a/test/spec/features/global-connect/GlobalConnectSpec.js
+++ b/test/spec/features/global-connect/GlobalConnectSpec.js
@@ -9,22 +9,22 @@ import { createCanvasEvent as canvasEvent } from '../../../util/MockEvents';
 
 import modelingModule from 'lib/features/modeling';
 import globalConnectModule from 'lib/features/global-connect';
-
-
-function Provider(allow) {
-  this.canStartConnect = function functionName() {
-    return allow;
-  };
-}
+import rulesModule from './rules';
 
 
 describe('features/global-connect-tool', function() {
 
-  beforeEach(bootstrapDiagram({ modules: [ modelingModule, globalConnectModule ] }));
+  beforeEach(bootstrapDiagram({
+    modules: [
+      modelingModule,
+      globalConnectModule,
+      rulesModule
+    ]
+  }));
 
-  var rootShape, shape1, shape2;
+  var rootShape, shapeAbleToStartConnection, shapeUnableToStartConnection;
 
-  beforeEach(inject(function(elementFactory, canvas, globalConnect) {
+  beforeEach(inject(function(elementFactory, canvas) {
 
     rootShape = elementFactory.createRoot({
       id: 'root'
@@ -32,45 +32,44 @@ describe('features/global-connect-tool', function() {
 
     canvas.setRootElement(rootShape);
 
-    shape1 = elementFactory.createShape({
+    shapeAbleToStartConnection = elementFactory.createShape({
       id: 's1',
-      x: 100, y: 100, width: 300, height: 300
+      x: 100, y: 100, width: 300, height: 300,
+      canStartConnection: true
     });
 
-    canvas.addShape(shape1, rootShape);
+    canvas.addShape(shapeAbleToStartConnection, rootShape);
 
-    shape2 = elementFactory.createShape({
+    shapeUnableToStartConnection = elementFactory.createShape({
       id: 's2',
       x: 500, y: 100, width: 100, height: 100
     });
 
-    canvas.addShape(shape2, rootShape);
+    canvas.addShape(shapeUnableToStartConnection, rootShape);
   }));
 
 
   it('should start connect if allowed', inject(function(eventBus, globalConnect, dragging) {
 
     // given
+    var shape = shapeAbleToStartConnection;
     var connectSpy = sinon.spy(function(event) {
       expect(event.context).to.eql({
-        source: shape1,
+        source: shape,
         sourcePosition: { x: 150, y: 130 }
       });
     });
 
-    globalConnect.registerProvider(new Provider(true));
-
-    // then
     eventBus.once('connect.init', connectSpy);
 
     // when
     globalConnect.start(canvasEvent({ x: 0, y: 0 }));
 
     dragging.move(canvasEvent({ x: 150, y: 130 }));
-    dragging.hover(canvasEvent({ x: 150, y: 130 }, { element: shape1 }));
+    dragging.hover(canvasEvent({ x: 150, y: 130 }, { element: shape }));
     dragging.end(canvasEvent({ x: 0, y: 0 }));
 
-    eventBus.fire('element.out', canvasEvent({ x: 99, y: 99 }, { element: shape1 }));
+    eventBus.fire('element.out', canvasEvent({ x: 99, y: 99 }, { element: shape }));
 
     // then
     expect(connectSpy).to.have.been.called;
@@ -79,19 +78,20 @@ describe('features/global-connect-tool', function() {
 
   it('should NOT start connect if rejected', inject(function(eventBus, globalConnect, dragging) {
     // given
-    globalConnect.registerProvider(new Provider(false));
+    var shape = shapeUnableToStartConnection;
+    var connectSpy = sinon.spy();
 
-    // then
-    eventBus.once('connect.init', function(event) {
-      throw new Error('"connect.init" should not be called');
-    });
+    eventBus.once('connect.init', connectSpy);
 
     // when
     globalConnect.start(canvasEvent({ x: 0, y: 0 }));
-    dragging.hover(canvasEvent({ x: 150, y: 150 }, { element: shape1 }));
+    dragging.hover(canvasEvent({ x: 150, y: 150 }, { element: shape }));
     dragging.end(canvasEvent({ x: 0, y: 0 }));
 
-    eventBus.fire('element.out', canvasEvent({ x: 99, y: 99 }, { element: shape1 }));
+    eventBus.fire('element.out', canvasEvent({ x: 99, y: 99 }, { element: shape }));
+
+    // then
+    expect(connectSpy).to.not.have.been.called;
   }));
 
 });

--- a/test/spec/features/global-connect/rules/GlobalConnectRules.js
+++ b/test/spec/features/global-connect/rules/GlobalConnectRules.js
@@ -1,0 +1,24 @@
+import inherits from 'inherits';
+
+import RuleProvider from 'lib/features/rules/RuleProvider';
+
+export default function GlobalConnectRules(eventBus) {
+  RuleProvider.call(this, eventBus);
+}
+
+GlobalConnectRules.$inject = ['eventBus'];
+
+inherits(GlobalConnectRules, RuleProvider);
+
+GlobalConnectRules.prototype.init = function() {
+
+  this.addRule('connection.start', function(context) {
+    var source = context.source;
+
+    if (source.canStartConnection) {
+      return true;
+    }
+
+    return false;
+  });
+};

--- a/test/spec/features/global-connect/rules/index.js
+++ b/test/spec/features/global-connect/rules/index.js
@@ -1,0 +1,6 @@
+import GlobalConnectRules from './GlobalConnectRules';
+
+export default {
+  __init__: [ 'globalConnectRules' ],
+  globalConnectRules: [ 'type', GlobalConnectRules ]
+};


### PR DESCRIPTION
This PR refactors GlobalConnect tool in order to make use of rules instead of hardcoded provider behaviour to determine whether the tool can be used with selected element.

* remove `GlobalConnect#registerProvider`
* use `connection.start` rule to determine whether
  an element can start a connection

Closes [#565](https://github.com/bpmn-io/bpmn-js/issues/565)

BREAKING CHANGE:

* `GlobalConnect#registerProvider` got removed. Create
  a rule for `connection.start` instead.