### PR TITLE
fix(auto-resize): resize collapsed element when it is expanded

### DIFF
--- a/lib/features/auto-resize/AutoResize.js
+++ b/lib/features/auto-resize/AutoResize.js
@@ -94,6 +94,22 @@ export default function AutoResize(eventBus, elementRegistry, modeling, rules) {
 
     self._expand(shape.children || [], shape);
   });
+
+  this.postExecuted([ 'shape.resize' ], function(event) {
+    var context = event.context,
+        hints = context.hints,
+        shape = context.shape,
+        parent = shape.parent;
+
+    if (hints && (hints.root === false || hints.autoResize === false)) {
+      return;
+    }
+
+    if (parent) {
+      self._expand([ shape ], parent);
+    }
+  });
+
 }
 
 AutoResize.$inject = [

--- a/lib/features/auto-resize/AutoResize.js
+++ b/lib/features/auto-resize/AutoResize.js
@@ -78,6 +78,22 @@ export default function AutoResize(eventBus, elementRegistry, modeling, rules) {
       self._expand(elements, parentId);
     });
   });
+
+  this.postExecuted([ 'shape.toggleCollapse' ], function(event) {
+    var context = event.context,
+        hints = context.hints,
+        shape = context.shape;
+
+    if (hints && (hints.root === false || hints.autoResize === false)) {
+      return;
+    }
+
+    if (shape.collapsed) {
+      return;
+    }
+
+    self._expand(shape.children || [], shape);
+  });
 }
 
 AutoResize.$inject = [

--- a/lib/features/modeling/cmd/ReplaceShapeHandler.js
+++ b/lib/features/modeling/cmd/ReplaceShapeHandler.js
@@ -59,7 +59,9 @@ ReplaceShapeHandler.prototype.preExecute = function(context) {
     y: newData.y
   };
 
-  newShape = context.newShape = context.newShape || self.createShape(newData, position, oldShape.parent);
+  newShape = context.newShape = (
+    context.newShape || self.createShape(newData, position, oldShape.parent, hints)
+  );
 
 
   // (2) update the host
@@ -133,9 +135,9 @@ ReplaceShapeHandler.prototype.execute = function(context) {};
 ReplaceShapeHandler.prototype.revert = function(context) {};
 
 
-ReplaceShapeHandler.prototype.createShape = function(shape, position, target) {
+ReplaceShapeHandler.prototype.createShape = function(shape, position, target, hints) {
   var modeling = this._modeling;
-  return modeling.createShape(shape, position, target);
+  return modeling.createShape(shape, position, target, hints);
 };
 
 

--- a/lib/features/modeling/cmd/ReplaceShapeHandler.js
+++ b/lib/features/modeling/cmd/ReplaceShapeHandler.js
@@ -59,9 +59,9 @@ ReplaceShapeHandler.prototype.preExecute = function(context) {
     y: newData.y
   };
 
-  newShape = context.newShape = (
-    context.newShape || self.createShape(newData, position, oldShape.parent, hints)
-  );
+  newShape = context.newShape =
+    context.newShape ||
+    self.createShape(newData, position, oldShape.parent, hints);
 
 
   // (2) update the host

--- a/test/spec/features/auto-resize/AutoResizeSpec.js
+++ b/test/spec/features/auto-resize/AutoResizeSpec.js
@@ -613,6 +613,104 @@ describe('features/auto-resize', function() {
   });
 
 
+  describe('resize child shape', function() {
+
+    var rootShape,
+        parentShape,
+        resizedShape;
+
+    beforeEach(bootstrapDiagram({
+      modules: [
+        modelingModule,
+        autoResizeModule,
+        customAutoResizeModule,
+        replaceModule
+      ]
+    }));
+
+
+    beforeEach(inject(function(elementFactory, canvas) {
+      rootShape = elementFactory.createRoot({
+        id: 'root'
+      });
+
+      canvas.setRootElement(rootShape);
+
+      parentShape = elementFactory.createShape({
+        id: 'parent',
+        x: 100, y: 100, width: 300, height: 300
+      });
+
+      canvas.addShape(parentShape, rootShape);
+
+      resizedShape = elementFactory.createShape({
+        id: 'resizedShape',
+        x: 110, y: 110, width: 200, height: 200
+      });
+
+      canvas.addShape(resizedShape, parentShape);
+    }));
+
+
+    describe('resize child', function() {
+
+      it('should resize parent', inject(
+        function(modeling, autoResize) {
+
+          // given
+          var autoResizeSpy = sinon.spy(autoResize, '_expand');
+
+          var newBounds = {
+            x: 110,
+            y: 110,
+            width: 300,
+            height: 300
+          };
+
+          // when
+          modeling.resizeShape(resizedShape, newBounds);
+
+          // then
+          expect(autoResizeSpy).to.be.called;
+          expect(parentShape).to.have.bounds({ x: 100, y: 100, width: 320, height: 320 });
+        })
+      );
+
+    });
+
+
+    describe('hints', function() {
+
+      it('should not resize parent on autoResize=false hint',
+        inject(function(eventBus, modeling, autoResize) {
+          // given
+          var autoResizeSpy = sinon.spy(autoResize, '_expand');
+
+          eventBus.on('commandStack.shape.resize.preExecute', function(event) {
+            event.context.hints = { autoResize: false };
+          });
+
+          var newBounds = {
+            x: 110,
+            y: 110,
+            width: 300,
+            height: 300
+          };
+
+          // when
+          modeling.resizeShape(resizedShape, newBounds);
+
+          // then
+          expect(autoResizeSpy).to.not.be.called;
+          expect(parentShape).to.have.bounds({ x: 100, y: 100, width: 300, height: 300 });
+        })
+      );
+
+    });
+
+  });
+
+
   it('should provide extension points', inject(function(autoResize, modeling) {
 
     // given

--- a/test/spec/features/auto-resize/AutoResizeSpec.js
+++ b/test/spec/features/auto-resize/AutoResizeSpec.js
@@ -347,7 +347,6 @@ describe('features/auto-resize', function() {
       ]
     }));
 
-
     beforeEach(inject(function(elementFactory, canvas) {
       rootShape = elementFactory.createRoot({
         id: 'root'
@@ -363,16 +362,20 @@ describe('features/auto-resize', function() {
 
         collapsedShape = elementFactory.createShape({
           id: 'collapsedShape',
-          x: 110, y: 110, width: 200, height: 200,
+          x: 110,
+          y: 110,
+          width: 200,
+          height: 200,
           collapsed: true
         });
 
         canvas.addShape(collapsedShape, rootShape);
-
       }));
+
 
       it('should resize element which is expanded',
         inject(function(elementFactory, canvas, modeling, autoResize) {
+
           // given
           var autoResizeSpy = sinon.spy(autoResize, '_expand');
 
@@ -388,14 +391,28 @@ describe('features/auto-resize', function() {
           modeling.toggleCollapse(collapsedShape);
 
           // then
-          expect(collapsedShape).to.have.bounds({ x: 110, y: 110, width: 420, height: 420 });
-          expect(hiddenContainedChild).to.have.bounds({ x: 120, y: 120, width: 400, height: 400 });
+          expect(collapsedShape).to.have.bounds({
+            x: 110,
+            y: 110,
+            width: 420,
+            height: 420
+          });
+
+          expect(hiddenContainedChild).to.have.bounds({
+            x: 120,
+            y: 120,
+            width: 400,
+            height: 400
+          });
+
           expect(autoResizeSpy).to.be.called;
         })
       );
 
+
       it('should resize element which is expanded even if it has no children',
         inject(function(modeling, autoResize) {
+
           // given
           var autoResizeSpy = sinon.spy(autoResize, '_expand');
 
@@ -403,13 +420,21 @@ describe('features/auto-resize', function() {
           modeling.toggleCollapse(collapsedShape);
 
           // then
-          expect(collapsedShape).to.have.bounds({ x: 110, y: 110, width: 200, height: 200 });
+          expect(collapsedShape).to.have.bounds({
+            x: 110,
+            y: 110,
+            width: 200,
+            height: 200
+          });
+
           expect(autoResizeSpy).to.be.called;
         })
       );
 
+
       it('should not resize an expanded element which is collapsed',
         inject(function(elementFactory, canvas, modeling, autoResize) {
+
           // given
           var autoResizeSpy = sinon.spy(autoResize, '_expand');
 
@@ -425,12 +450,19 @@ describe('features/auto-resize', function() {
           modeling.toggleCollapse(expandedShape);
 
           // then
-          expect(collapsedShape).to.have.bounds({ x: 110, y: 110, width: 200, height: 200 });
+          expect(collapsedShape).to.have.bounds({
+            x: 110,
+            y: 110,
+            width: 200,
+            height: 200
+          });
+
           expect(autoResizeSpy).to.not.be.called;
         })
       );
 
     });
+
 
     describe('as a child of another element', function() {
 
@@ -438,7 +470,10 @@ describe('features/auto-resize', function() {
 
         parentShape = elementFactory.createShape({
           id: 'parentShape',
-          x: 110, y: 110, width: 200, height: 200
+          x: 110,
+          y: 110,
+          width: 200,
+          height: 200
         });
 
         canvas.addShape(parentShape, rootShape);
@@ -458,11 +493,12 @@ describe('features/auto-resize', function() {
         });
 
         canvas.addShape(hiddenContainedChild, collapsedShape);
-
       }));
+
 
       it('should resize also the parent element',
         inject(function(modeling, autoResize) {
+
           // given
           var autoResizeSpy = sinon.spy(autoResize, '_expand');
 
@@ -470,8 +506,20 @@ describe('features/auto-resize', function() {
           modeling.toggleCollapse(collapsedShape);
 
           // then
-          expect(collapsedShape).to.have.bounds({ x: 120, y: 120, width: 420, height: 420 });
-          expect(parentShape).to.have.bounds({ x: 110, y: 110, width: 440, height: 440 });
+          expect(collapsedShape).to.have.bounds({
+            x: 120,
+            y: 120,
+            width: 420,
+            height: 420
+          });
+
+          expect(parentShape).to.have.bounds({
+            x: 110,
+            y: 110,
+            width: 440,
+            height: 440
+          });
+
           expect(autoResizeSpy).to.be.calledWith([ hiddenContainedChild ], collapsedShape);
           expect(autoResizeSpy).to.be.calledWith([ collapsedShape ], parentShape);
         })
@@ -486,16 +534,20 @@ describe('features/auto-resize', function() {
 
         collapsedShape = elementFactory.createShape({
           id: 'collapsedShape',
-          x: 110, y: 110, width: 200, height: 200,
+          x: 110,
+          y: 110,
+          width: 200,
+          height: 200,
           collapsed: true
         });
 
         canvas.addShape(collapsedShape, rootShape);
-
       }));
+
 
       it('should not resize on autoResize=false hint',
         inject(function(eventBus, modeling, autoResize) {
+
           // given
           var autoResizeSpy = sinon.spy(autoResize, '_expand');
 
@@ -507,7 +559,13 @@ describe('features/auto-resize', function() {
           modeling.toggleCollapse(collapsedShape);
 
           // then
-          expect(collapsedShape).to.have.bounds({ x: 110, y: 110, width: 200, height: 200 });
+          expect(collapsedShape).to.have.bounds({
+            x: 110,
+            y: 110,
+            width: 200,
+            height: 200
+          });
+
           expect(autoResizeSpy).to.not.be.called;
         })
       );


### PR DESCRIPTION
This PR fixes a problem which occurs when a collapsed element has children of bigger size than it is. Previously, the children would cover up the parent, making it unusable.

* AutoResize will now be activated whenever a collapsed element
  is expanded unless the auto resizing is explicitly deactivated
* (ReplaceShape) Hints will be now passed to create a replacing shape to determine
if auto resizing should be fired.
* AutoResize will be fired when a child element is resized
unless hints disallow it.

Closes #287 
Closes [#786](https://github.com/bpmn-io/bpmn-js/issues/786)