### PR TITLE
chore(project): detect unresolved imports

### DIFF
--- a/lib/.eslintrc
+++ b/lib/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "import"
+  ],
+  "rules": {
+    "import/no-unresolved": "error"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "chai": "^4.2.0",
     "eslint": "^5.7.0",
     "eslint-plugin-bpmn-io": "^0.6.0",
+    "eslint-plugin-import": "^2.14.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jquery": "^3.3.1",
     "karma": "^3.1.1",


### PR DESCRIPTION
This ensures we don't accidently require files in the lib directory
via the global `lib` import. That stuff works during tests but does
not work in the final bundle.

Considerations: This plugin adds some runtime overhead to our linting
process.