### PR TITLE
Editor action refactoring

### DIFF
--- a/lib/features/editor-actions/EditorActions.js
+++ b/lib/features/editor-actions/EditorActions.js
@@ -72,6 +72,7 @@ EditorActions.prototype._registerDefaultActions = function(injector) {
   var rules = injector.get('rules', false);
   var mouseTracking = injector.get('mouseTracking', false);
   var keyboardMove = injector.get('keyboardMove', false);
+  var keyboardMoveSelection = injector.get('keyboardMoveSelection', false);
 
   // (2) check components and register actions
 
@@ -146,6 +147,13 @@ EditorActions.prototype._registerDefaultActions = function(injector) {
       keyboardMove.moveCanvas(opts);
     });
   }
+
+  if (keyboardMoveSelection) {
+    this.register('moveSelection', function(opts) {
+      keyboardMoveSelection.moveSelection(opts.direction, opts.accelerated);
+    });
+  }
+
 };
 
 

--- a/lib/features/editor-actions/EditorActions.js
+++ b/lib/features/editor-actions/EditorActions.js
@@ -11,102 +11,142 @@ var NOT_REGISTERED_ERROR = 'is not a registered action',
  * An interface that provides access to modeling actions by decoupling
  * the one who requests the action to be triggered and the trigger itself.
  *
- * It's possible to add new actions by registering them with ´registerAction´ and likewise
- * unregister existing ones with ´unregisterAction´.
+ * It's possible to add new actions by registering them with ´registerAction´
+ * and likewise unregister existing ones with ´unregisterAction´.
  *
+ *
+ * ## Life-Cycle and configuration
+ *
+ * The editor actions will wait for diagram initialization before
+ * registering default actions _and_ firing an `editorActions.init` event.
+ *
+ * Interested parties may listen to the `editorActions.init` event with
+ * low priority to check, which actions got registered. Other components
+ * may use the event to register their own actions via `registerAction`.
+ *
+ * @param {EventBus} eventBus
+ * @param {Injector} injector
  */
-export default function EditorActions(
-    eventBus, commandStack, modeling, selection,
-    zoomScroll, copyPaste, canvas, rules, mouseTracking) {
+export default function EditorActions(eventBus, injector) {
 
-  this._actions = {
-    undo: function() {
-      commandStack.undo();
-    },
-    redo: function() {
-      commandStack.redo();
-    },
-    copy: function() {
-      var selectedElements = selection.get();
+  // initialize actions
+  this._actions = {};
 
-      copyPaste.copy(selectedElements);
-    },
-    paste: function() {
-      var context = mouseTracking.getHoverContext();
+  var self = this;
 
-      copyPaste.paste(context);
-    },
-    stepZoom: function(opts) {
-      zoomScroll.stepZoom(opts.value);
-    },
-    zoom: function(opts) {
-      canvas.zoom(opts.value);
-    },
-    removeSelection: function() {
-      var selectedElements = selection.get();
+  eventBus.on('diagram.init', function() {
 
-      if (selectedElements.length) {
-        var allowed = rules.allowed('elements.delete', { elements: selectedElements }),
-            removableElements;
+    // all diagram modules got loaded; check which ones
+    // are available and register the respective default actions
+    self._registerDefaultActions(injector);
 
-        if (allowed === false) {
-          return;
-        }
-        else if (isArray(allowed)) {
-          removableElements = allowed;
-        }
-        else {
-          removableElements = selectedElements;
-        }
+    // ask interested parties to register available editor
+    // actions on diagram initialization
+    eventBus.fire('editorActions.init', {
+      editorActions: self
+    });
+  });
 
-        if (removableElements.length) {
-          modeling.removeElements(removableElements.slice());
-        }
-      }
-    },
-    moveCanvas: function(opts) {
-      var dx = 0,
-          dy = 0,
-          invertY = opts.invertY,
-          speed = opts.speed;
-
-      var actualSpeed = speed / Math.min(Math.sqrt(canvas.viewbox().scale), 1);
-
-      switch (opts.direction) {
-      case 'left': // Left
-        dx = actualSpeed;
-        break;
-      case 'up': // Up
-        dy = actualSpeed;
-        break;
-      case 'right': // Right
-        dx = -actualSpeed;
-        break;
-      case 'down': // Down
-        dy = -actualSpeed;
-        break;
-      }
-
-      if (dy && invertY) {
-        dy = -dy;
-      }
-
-      canvas.scroll({ dx: dx, dy: dy });
-    }
-  };
 }
 
 EditorActions.$inject = [
   'eventBus',
-  'commandStack',
-  'modeling',
-  'selection',
-  'zoomScroll',
-  'copyPaste',
-  'canvas',
-  'rules',
-  'mouseTracking'
+  'injector'
 ];
+
+/**
+ * Register default actions.
+ *
+ * @param {Injector} injector
+ */
+EditorActions.prototype._registerDefaultActions = function(injector) {
+
+  // (1) retrieve optional components to integrate with
+
+  var commandStack = injector.get('commandStack', false);
+  var modeling = injector.get('modeling', false);
+  var selection = injector.get('selection', false);
+  var zoomScroll = injector.get('zoomScroll', false);
+  var copyPaste = injector.get('copyPaste', false);
+  var canvas = injector.get('canvas', false);
+  var rules = injector.get('rules', false);
+  var mouseTracking = injector.get('mouseTracking', false);
+  var keyboardMove = injector.get('keyboardMove', false);
+
+  // (2) check components and register actions
+
+  if (commandStack) {
+    this.register('undo', function() {
+      commandStack.undo();
+    });
+
+    this.register('redo', function() {
+      commandStack.redo();
+    });
+  }
+
+  if (copyPaste && selection) {
+    this.register('copy', function() {
+      var selectedElements = selection.get();
+
+      copyPaste.copy(selectedElements);
+    });
+  }
+
+  if (mouseTracking && copyPaste) {
+    this.register('paste', function() {
+      var context = mouseTracking.getHoverContext();
+
+      copyPaste.paste(context);
+    });
+  }
+
+  if (zoomScroll) {
+    this.register('stepZoom', function(opts) {
+      zoomScroll.stepZoom(opts.value);
+    });
+  }
+
+  if (canvas) {
+    this.register('zoom', function(opts) {
+      canvas.zoom(opts.value);
+    });
+  }
+
+  if (modeling && selection && rules) {
+    this.register('removeSelection', function() {
+
+      var selectedElements = selection.get();
+
+      if (!selectedElements.length) {
+        return;
+      }
+
+      var allowed = rules.allowed('elements.delete', { elements: selectedElements }),
+          removableElements;
+
+      if (allowed === false) {
+        return;
+      }
+      else if (isArray(allowed)) {
+        removableElements = allowed;
+      }
+      else {
+        removableElements = selectedElements;
+      }
+
+      if (removableElements.length) {
+        modeling.removeElements(removableElements.slice());
+      }
+    });
+  }
+
+  if (keyboardMove) {
+    this.register('moveCanvas', function(opts) {
+      keyboardMove.moveCanvas(opts);
+    });
+  }
+};
 
 
 /**
@@ -192,8 +232,8 @@ EditorActions.prototype.unregister = function(action) {
  *
  * @return {Number}
  */
-EditorActions.prototype.length = function() {
-  return Object.keys(this._actions).length;
+EditorActions.prototype.getActions = function() {
+  return Object.keys(this._actions);
 };
 
 /**

--- a/lib/features/editor-actions/index.js
+++ b/lib/features/editor-actions/index.js
@@ -1,15 +1,6 @@
-import SelectionModule from '../selection';
-import CopyPasteModule from '../copy-paste';
-import ZoomScrollModule from '../../navigation/zoomscroll';
-
 import EditorActions from './EditorActions';
 
 export default {
-  __depends__: [
-    SelectionModule,
-    CopyPasteModule,
-    ZoomScrollModule
-  ],
   __init__: [ 'editorActions' ],
   editorActions: [ 'type', EditorActions ]
 };

--- a/lib/features/keyboard-move-selection/KeyboardMoveSelection.js
+++ b/lib/features/keyboard-move-selection/KeyboardMoveSelection.js
@@ -77,7 +77,7 @@ export default function KeyboardMoveSelection(
 
   keyboard.addListener(HIGHER_PRIORITY, function(event) {
 
-    var keyEvent = event.event;
+    var keyEvent = event.keyEvent;
 
     var direction = KEY_TO_DIRECTION[keyEvent.key];
 

--- a/lib/features/keyboard-move-selection/KeyboardMoveSelection.js
+++ b/lib/features/keyboard-move-selection/KeyboardMoveSelection.js
@@ -10,11 +10,47 @@ var DEFAULT_CONFIG = {
 
 var HIGHER_PRIORITY = 1500;
 
-var KEYS = {
-  LEFT: ['ArrowLeft', 'Left'],
-  UP: ['ArrowUp', 'Up'],
-  RIGHT: ['ArrowRight', 'Right'],
-  DOWN: ['ArrowDown', 'Down']
+var LEFT = 'left';
+var UP = 'up';
+var RIGHT = 'right';
+var DOWN = 'down';
+
+var KEY_TO_DIRECTION = {
+  ArrowLeft: LEFT,
+  Left: LEFT,
+  ArrowUp: UP,
+  Up: UP,
+  ArrowRight: RIGHT,
+  Right: RIGHT,
+  ArrowDown: DOWN,
+  Down: DOWN
+};
+
+var DIRECTIONS_DELTA = {
+  left: function(speed) {
+    return {
+      x: -speed,
+      y: 0
+    };
+  },
+  up: function(speed) {
+    return {
+      x: 0,
+      y: -speed
+    };
+  },
+  right: function(speed) {
+    return {
+      x: speed,
+      y: 0
+    };
+  },
+  down: function(speed) {
+    return {
+      x: 0,
+      y: speed
+    };
+  }
 };
 
 
@@ -30,97 +66,68 @@ var KEYS = {
  * @param {Modeling} modeling
  * @param {Selection} selection
  */
-export default function MoveSelection(config, keyboard, modeling, selection) {
+export default function KeyboardMoveSelection(
+    config, keyboard,
+    modeling, selection
+) {
 
   var self = this;
 
   this._config = assign({}, DEFAULT_CONFIG, config || {});
 
-  keyboard.addListener(HIGHER_PRIORITY, moveAction(KEYS.LEFT, moveLeft));
-  keyboard.addListener(HIGHER_PRIORITY, moveAction(KEYS.UP, moveUp));
-  keyboard.addListener(HIGHER_PRIORITY, moveAction(KEYS.RIGHT, moveRight));
-  keyboard.addListener(HIGHER_PRIORITY, moveAction(KEYS.DOWN, moveDown));
+  keyboard.addListener(HIGHER_PRIORITY, function(event) {
 
-  /**
-   * Returns `KeyboardEvent` listener which moves selection according to provided getDelta function.
-   *
-   * @param {string} keys - array of keys to listen for
-   * @param {Function} getDelta - function which returns coordinates delta for provided speed
-   */
-  function moveAction(keys, getDelta) {
+    var keyEvent = event.event;
 
-    return function(context) {
+    var direction = KEY_TO_DIRECTION[keyEvent.key];
 
-      var event = context.event;
-
-      if (!keyboard.isKey(keys, event)) {
-        return;
-      }
-
-      if (keyboard.isCmd(event)) {
-        return;
-      }
-
-      var selectedElements = selection.get();
-
-      if (!selectedElements.length) {
-        return;
-      }
-
-      var speed = getSpeed(event, self._config);
-
-      var coordinatesDelta = getDelta(speed);
-
-      modeling.moveElements(selectedElements, coordinatesDelta);
-
-      return true;
-    };
-  }
-
-  function getSpeed(event) {
-    if (keyboard.isShift(event)) {
-      return self._config.moveSpeedAccelerated;
+    if (!direction) {
+      return;
     }
 
-    return self._config.moveSpeed;
-  }
+    if (keyboard.isCmd(keyEvent)) {
+      return;
+    }
+
+    var accelerated = keyboard.isShift(keyEvent);
+
+    self.moveSelection(direction, accelerated);
+
+    return true;
+  });
+
+
+  /**
+   * Move selected elements in the given direction,
+   * optionally specifying accelerated movement.
+   *
+   * @param {String} direction
+   * @param {Boolean} [accelerated=false]
+   */
+  this.moveSelection = function(direction, accelerated) {
+
+    var selectedElements = selection.get();
+
+    if (!selectedElements.length) {
+      return;
+    }
+
+    var speed = this._config[
+      accelerated ?
+        'moveSpeedAccelerated' :
+        'moveSpeed'
+    ];
+
+    var delta = DIRECTIONS_DELTA[direction](speed);
+
+    modeling.moveElements(selectedElements, delta);
+  };
+
 }
 
-MoveSelection.$inject = [
+KeyboardMoveSelection.$inject = [
   'config.keyboardMoveSelection',
   'keyboard',
   'modeling',
   'selection'
 ];
-
-
-
-// helpers /////////
-
-function moveLeft(speed) {
-  return {
-    x: -speed,
-    y: 0
-  };
-}
-
-function moveUp(speed) {
-  return {
-    x: 0,
-    y: -speed
-  };
-}
-
-function moveRight(speed) {
-  return {
-    x: speed,
-    y: 0
-  };
-}
-
-function moveDown(speed) {
-  return {
-    x: 0,
-    y: +speed
-  };
-}

--- a/lib/features/keyboard/Keyboard.js
+++ b/lib/features/keyboard/Keyboard.js
@@ -88,7 +88,7 @@ Keyboard.prototype._keyHandler = function(event) {
   }
 
   var context = {
-    event: event
+    keyEvent: event
   };
 
   eventBusResult = this._eventBus.fire(KEYDOWN_EVENT, context);

--- a/lib/features/keyboard/KeyboardBindings.js
+++ b/lib/features/keyboard/KeyboardBindings.js
@@ -61,7 +61,7 @@ KeyboardBindings.prototype.registerBindings = function(keyboard, editorActions) 
   // (CTRL|CMD) + Z
   addListener('undo', function(context) {
 
-    var event = context.event;
+    var event = context.keyEvent;
 
     if (isCmd(event) && !isShift(event) && isKey(['z', 'Z'], event)) {
       editorActions.trigger('undo');
@@ -75,7 +75,7 @@ KeyboardBindings.prototype.registerBindings = function(keyboard, editorActions) 
   // CMD + SHIFT + Z
   addListener('redo', function(context) {
 
-    var event = context.event;
+    var event = context.keyEvent;
 
     if (isCmd(event) && (isKey(['y', 'Y'], event) || (isKey(['z', 'Z'], event) && isShift(event)))) {
       editorActions.trigger('redo');
@@ -88,7 +88,7 @@ KeyboardBindings.prototype.registerBindings = function(keyboard, editorActions) 
   // CTRL/CMD + C
   addListener('copy', function(context) {
 
-    var event = context.event;
+    var event = context.keyEvent;
 
     if (isCmd(event) && isKey(['c', 'C'], event)) {
       editorActions.trigger('copy');
@@ -101,7 +101,7 @@ KeyboardBindings.prototype.registerBindings = function(keyboard, editorActions) 
   // CTRL/CMD + V
   addListener('paste', function(context) {
 
-    var event = context.event;
+    var event = context.keyEvent;
 
     if (isCmd(event) && isKey(['v', 'V'], event)) {
       editorActions.trigger('paste');
@@ -114,7 +114,7 @@ KeyboardBindings.prototype.registerBindings = function(keyboard, editorActions) 
   // CTRL/CMD + +
   addListener('stepZoom', function(context) {
 
-    var event = context.event;
+    var event = context.keyEvent;
 
     if (isKey([ '+', 'Add' ], event) && isCmd(event)) {
       editorActions.trigger('stepZoom', { value: 1 });
@@ -127,7 +127,7 @@ KeyboardBindings.prototype.registerBindings = function(keyboard, editorActions) 
   // CTRL + -
   addListener('stepZoom', function(context) {
 
-    var event = context.event;
+    var event = context.keyEvent;
 
     if (isKey([ '-', 'Subtract' ], event) && isCmd(event)) {
       editorActions.trigger('stepZoom', { value: -1 });
@@ -140,7 +140,7 @@ KeyboardBindings.prototype.registerBindings = function(keyboard, editorActions) 
   // CTRL + 0
   addListener('zoom', function(context) {
 
-    var event = context.event;
+    var event = context.keyEvent;
 
     if (isKey('0', event) && isCmd(event)) {
       editorActions.trigger('zoom', { value: 1 });
@@ -153,7 +153,7 @@ KeyboardBindings.prototype.registerBindings = function(keyboard, editorActions) 
   // DEL
   addListener('removeSelection', function(context) {
 
-    var event = context.event;
+    var event = context.keyEvent;
 
     if (isKey('Delete', event)) {
       editorActions.trigger('removeSelection');

--- a/lib/features/keyboard/KeyboardBindings.js
+++ b/lib/features/keyboard/KeyboardBindings.js
@@ -4,18 +4,62 @@ import {
   isShift
 } from './KeyboardUtil';
 
+var LOW_PRIORITY = 500;
+
 
 /**
- * Adds default KeyboardEvent listeners
+ * Adds default keyboard bindings.
+ *
+ * This does not pull in any features will bind only actions that
+ * have previously been registered against the editorActions component.
+ *
+ * @param {EventBus} eventBus
+ * @param {Keyboard} keyboard
+ */
+export default function KeyboardBindings(eventBus, keyboard) {
+
+  var self = this;
+
+  eventBus.on('editorActions.init', LOW_PRIORITY, function(event) {
+
+    var editorActions = event.editorActions;
+
+    self.registerBindings(keyboard, editorActions);
+  });
+}
+
+KeyboardBindings.$inject = [
+  'eventBus',
+  'keyboard'
+];
+
+
+/**
+ * Register available keyboard bindings.
  *
  * @param {Keyboard} keyboard
  * @param {EditorActions} editorActions
  */
-export default function KeyboardBindings(keyboard, editorActions) {
+KeyboardBindings.prototype.registerBindings = function(keyboard, editorActions) {
+
+  /**
+   * Add keyboard binding if respective editor action
+   * is registered.
+   *
+   * @param {String} action name
+   * @param {Function} fn that implements the key binding
+   */
+  function addListener(action, fn) {
+
+    if (editorActions.isRegistered(action)) {
+      keyboard.addListener(fn);
+    }
+  }
+
 
   // undo
   // (CTRL|CMD) + Z
-  function undo(context) {
+  addListener('undo', function(context) {
 
     var event = context.event;
 
@@ -24,12 +68,12 @@ export default function KeyboardBindings(keyboard, editorActions) {
 
       return true;
     }
-  }
+  });
 
   // redo
   // CTRL + Y
   // CMD + SHIFT + Z
-  function redo(context) {
+  addListener('redo', function(context) {
 
     var event = context.event;
 
@@ -38,11 +82,11 @@ export default function KeyboardBindings(keyboard, editorActions) {
 
       return true;
     }
-  }
+  });
 
   // copy
   // CTRL/CMD + C
-  function copy(context) {
+  addListener('copy', function(context) {
 
     var event = context.event;
 
@@ -51,11 +95,11 @@ export default function KeyboardBindings(keyboard, editorActions) {
 
       return true;
     }
-  }
+  });
 
   // paste
   // CTRL/CMD + V
-  function paste(context) {
+  addListener('paste', function(context) {
 
     var event = context.event;
 
@@ -64,50 +108,37 @@ export default function KeyboardBindings(keyboard, editorActions) {
 
       return true;
     }
-  }
+  });
 
-  /**
-   * zoom in one step
-   * CTRL + +
-   *
-   * `=` is included because of possible combination with SHIFT
-   */
-  function zoomIn(context) {
+  // zoom in one step
+  // CTRL/CMD + +
+  addListener('stepZoom', function(context) {
 
     var event = context.event;
 
-    if (isKey([ '+', 'Add', '=' ], event) && isCmd(event)) {
+    if (isKey([ '+', 'Add' ], event) && isCmd(event)) {
       editorActions.trigger('stepZoom', { value: 1 });
 
       return true;
     }
-  }
+  });
 
-  /**
-   * zoom out one step
-   * CTRL + -
-   *
-   * `_` is included because of possible combination with SHIFT
-   */
-  function zoomOut(context) {
+  // zoom out one step
+  // CTRL + -
+  addListener('stepZoom', function(context) {
 
     var event = context.event;
 
-    if (isKey([ '-', '_', 'Subtract' ], event) && isCmd(event)) {
+    if (isKey([ '-', 'Subtract' ], event) && isCmd(event)) {
       editorActions.trigger('stepZoom', { value: -1 });
 
       return true;
     }
-  }
+  });
 
-  /**
-   * zoom to the default level
-   * CTRL + 0
-   *
-   * 96 = numpad zero
-   * 48 = regular zero
-   */
-  function zoomDefault(context) {
+  // zoom to the default level
+  // CTRL + 0
+  addListener('zoom', function(context) {
 
     var event = context.event;
 
@@ -116,11 +147,11 @@ export default function KeyboardBindings(keyboard, editorActions) {
 
       return true;
     }
-  }
+  });
 
   // delete selected element
   // DEL
-  function removeSelection(context) {
+  addListener('removeSelection', function(context) {
 
     var event = context.event;
 
@@ -129,23 +160,5 @@ export default function KeyboardBindings(keyboard, editorActions) {
 
       return true;
     }
-  }
-
-
-  keyboard.addListener(copy);
-  keyboard.addListener(paste);
-
-  keyboard.addListener(undo);
-  keyboard.addListener(redo);
-
-  keyboard.addListener(removeSelection);
-
-  keyboard.addListener(zoomDefault);
-  keyboard.addListener(zoomIn);
-  keyboard.addListener(zoomOut);
-}
-
-KeyboardBindings.$inject = [
-  'keyboard',
-  'editorActions'
-];
+  });
+};

--- a/lib/features/keyboard/index.js
+++ b/lib/features/keyboard/index.js
@@ -1,10 +1,7 @@
-import EditorActionsModule from '../editor-actions';
-
 import Keyboard from './Keyboard';
 import KeyboardBindings from './KeyboardBindings';
 
 export default {
-  __depends__: [ EditorActionsModule ],
   __init__: [ 'keyboard', 'keyboardBindings' ],
   keyboard: [ 'type', Keyboard ],
   keyboardBindings: [ 'type', KeyboardBindings ]

--- a/lib/navigation/keyboard-move/KeyboardMove.js
+++ b/lib/navigation/keyboard-move/KeyboardMove.js
@@ -31,7 +31,7 @@ export default function KeyboardMove(
 
   function arrowsListener(context) {
 
-    var event = context.event,
+    var event = context.keyEvent,
         config = self._config;
 
     if (!keyboard.isCmd(event)) {

--- a/lib/navigation/keyboard-move/KeyboardMove.js
+++ b/lib/navigation/keyboard-move/KeyboardMove.js
@@ -8,17 +8,18 @@ var DEFAULT_CONFIG = {
 
 
 /**
+ * A feature that allows users to move the canvas using the keyboard.
  *
  * @param {Object} config
  * @param {Number} [config.moveSpeed=50]
  * @param {Number} [config.moveSpeedAccelerated=200]
  * @param {Keyboard} keyboard
- * @param {EditorActions} editorActions
+ * @param {Canvas} canvas
  */
-export default function KeyboardNavigation(
+export default function KeyboardMove(
     config,
     keyboard,
-    editorActions
+    canvas
 ) {
 
   var self = this;
@@ -44,39 +45,76 @@ export default function KeyboardNavigation(
       'ArrowRight', 'Right'
     ], event)) {
 
-      var opts = {
-        speed: keyboard.isShift(event) ? config.moveSpeedAccelerated : config.moveSpeed
-      };
+      var speed = (
+        keyboard.isShift(event) ?
+          config.moveSpeedAccelerated :
+          config.moveSpeed
+      );
+
+      var direction;
 
       switch (event.key) {
       case 'ArrowLeft':
       case 'Left':
-        opts.direction = 'left';
+        direction = 'left';
         break;
       case 'ArrowUp':
       case 'Up':
-        opts.direction = 'up';
+        direction = 'up';
         break;
       case 'ArrowRight':
       case 'Right':
-        opts.direction = 'right';
+        direction = 'right';
         break;
       case 'ArrowDown':
       case 'Down':
-        opts.direction = 'down';
+        direction = 'down';
         break;
       }
 
-      editorActions.trigger('moveCanvas', opts);
+      self.moveCanvas({
+        speed: speed,
+        direction: direction
+      });
 
       return true;
     }
   }
+
+  this.moveCanvas = function(opts) {
+
+    var dx = 0,
+        dy = 0,
+        speed = opts.speed;
+
+    var actualSpeed = speed / Math.min(Math.sqrt(canvas.viewbox().scale), 1);
+
+    switch (opts.direction) {
+    case 'left': // Left
+      dx = actualSpeed;
+      break;
+    case 'up': // Up
+      dy = actualSpeed;
+      break;
+    case 'right': // Right
+      dx = -actualSpeed;
+      break;
+    case 'down': // Down
+      dy = -actualSpeed;
+      break;
+    }
+
+    canvas.scroll({
+      dx: dx,
+      dy: dy
+    });
+  };
+
 }
 
 
-KeyboardNavigation.$inject = [
+KeyboardMove.$inject = [
   'config.keyboardMove',
   'keyboard',
-  'editorActions'
+  'canvas'
 ];

--- a/lib/navigation/keyboard-move/index.js
+++ b/lib/navigation/keyboard-move/index.js
@@ -1,4 +1,3 @@
-import EditorActions from '../../features/editor-actions';
 import KeyboardModule from '../../features/keyboard';
 
 import KeyboardMove from './KeyboardMove';
@@ -6,7 +5,6 @@ import KeyboardMove from './KeyboardMove';
 
 export default {
   __depends__: [
-    EditorActions,
     KeyboardModule
   ],
   __init__: [ 'keyboardMove' ],

--- a/lib/navigation/movecanvas/MoveCanvas.js
+++ b/lib/navigation/movecanvas/MoveCanvas.js
@@ -25,10 +25,10 @@ var THRESHOLD = 15;
 
 
 /**
+ * Move the canvas via mouse.
+ *
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
- * @param {Keyboard} keyboard
- * @param {EditorActions} editorActions
  */
 export default function MoveCanvas(eventBus, canvas) {
 

--- a/test/spec/features/editor-actions/EditorActionsSpec.js
+++ b/test/spec/features/editor-actions/EditorActionsSpec.js
@@ -6,13 +6,20 @@ import {
 } from 'test/TestHelper';
 
 import editorActionsModule from 'lib/features/editor-actions';
+import keyboardMoveModule from 'lib/navigation/keyboard-move';
 import modelingModule from 'lib/features/modeling';
 import customRulesModule from './rules';
 
 
 describe('features/editor-actions', function() {
 
-  beforeEach(bootstrapDiagram({ modules: [ editorActionsModule, modelingModule, customRulesModule ] }));
+  beforeEach(bootstrapDiagram({
+    modules: [
+      editorActionsModule,
+      modelingModule,
+      customRulesModule
+    ]
+  }));
 
 
   var rootShape, parentShape, childShape, childShape2, connection;
@@ -93,21 +100,21 @@ describe('features/editor-actions', function() {
   describe('register actions', function() {
 
     it('should register a list of actions', inject(function(editorActions) {
-      // given
-      var numOfActions = editorActions.length();
 
       // when
       editorActions.register({
-        'foo': function() {
+        foo: function() {
           return 'bar';
         },
-        'bar': function() {
+        bar: function() {
           return 'foo';
         }
       });
 
       // then
-      expect(editorActions.length()).to.equal(numOfActions + 2);
+      var actions = editorActions.getActions();
+
+      expect(actions).to.include.members([ 'foo', 'bar' ]);
     }));
 
 
@@ -164,16 +171,23 @@ describe('features/editor-actions', function() {
 
   describe('utilities', function() {
 
-    it('listActions', inject(function(editorActions) {
+    it('#getActions()', inject(function(editorActions) {
+
       // when
-      var actionsLength = editorActions.length();
+      var actions = editorActions.getActions();
 
       // then
-      expect(actionsLength).to.equal(8);
+      expect(actions).to.eql([
+        'undo',
+        'redo',
+        'zoom',
+        'removeSelection'
+      ]);
     }));
 
 
-    it('isRegistered -> true', inject(function(editorActions) {
+    it('#isRegistered(action)', inject(function(editorActions) {
+
       // when
       var undo = editorActions.isRegistered('undo'),
           foo = editorActions.isRegistered('foo');
@@ -301,6 +315,39 @@ describe('features/editor-actions', function() {
       });
 
     });
+
+  });
+
+});
+
+
+describe('feature/editor-actions - actions', function() {
+
+  describe('moveCanvas', function() {
+
+    beforeEach(bootstrapDiagram({
+      modules: [
+        editorActionsModule,
+        keyboardMoveModule,
+        modelingModule
+      ]
+    }));
+
+
+    it('should trigger action', inject(function(keyboardMove, editorActions) {
+
+      // given
+      var moveSpy = sinon.spy(keyboardMove, 'moveCanvas');
+
+      // when
+      editorActions.trigger('moveCanvas', {
+        direction: 'left',
+        speed: 10
+      });
+
+      // then
+      expect(moveSpy).to.have.been.calledOnce;
+    }));
 
   });
 

--- a/test/spec/features/editor-actions/EditorActionsSpec.js
+++ b/test/spec/features/editor-actions/EditorActionsSpec.js
@@ -7,6 +7,7 @@ import {
 
 import editorActionsModule from 'lib/features/editor-actions';
 import keyboardMoveModule from 'lib/navigation/keyboard-move';
+import keyboardMoveSelectionModule from 'lib/features/keyboard-move-selection';
 import modelingModule from 'lib/features/modeling';
 import customRulesModule from './rules';
 
@@ -322,6 +323,33 @@ describe('features/editor-actions', function() {
 
 
 describe('feature/editor-actions - actions', function() {
+
+  describe('moveSelection', function() {
+
+    beforeEach(bootstrapDiagram({
+      modules: [
+        editorActionsModule,
+        keyboardMoveSelectionModule,
+        modelingModule
+      ]
+    }));
+
+    it('should trigger action', inject(function(keyboardMoveSelection, editorActions) {
+
+      // given
+      var moveSpy = sinon.spy(keyboardMoveSelection, 'moveSelection');
+
+      // when
+      editorActions.trigger('moveSelection', {
+        direction: 'left',
+        accelerated: false
+      });
+
+      // then
+      expect(moveSpy).to.have.been.calledOnce;
+    }));
+
+  });
 
   describe('moveCanvas', function() {
 

--- a/test/spec/features/keyboard-move-selection/KeyboardMoveSelectionSpec.js
+++ b/test/spec/features/keyboard-move-selection/KeyboardMoveSelectionSpec.js
@@ -1,11 +1,9 @@
 import {
   bootstrapDiagram,
-  getDiagramJS,
   inject
 } from 'test/TestHelper';
 
 import {
-  assign,
   forEach
 } from 'min-dash';
 
@@ -15,257 +13,152 @@ import keyboardMoveSelectionModule from 'lib/features/keyboard-move-selection';
 import { createKeyEvent } from 'test/util/KeyEvents';
 
 var KEYS = {
-  LEFT: [ 'ArrowLeft', 'Left' ],
-  UP: [ 'ArrowUp', 'Up' ],
-  RIGHT: [ 'ArrowRight', 'Right' ],
-  DOWN: [ 'ArrowDown', 'Down' ],
+  ArrowUp: 'up',
+  Up: 'up',
+  ArrowLeft: 'left',
+  Left: 'left',
+  ArrowRight: 'right',
+  Right: 'right',
+  ArrowDown: 'down',
+  Down: 'down'
 };
-
-var BASE_SPEED = 1;
-var HIGH_SPEED = 10;
 
 var shape1, shape2;
 
 
 describe('features/keyboard-move-selection', function() {
 
-  var defaultDiagramConfig = {
-    modules: [
-      modelingModule,
-      keyboardMoveSelectionModule
-    ],
-    canvas: {
-      deferUpdate: false
-    }
-  };
+  describe('default config', function() {
 
-  beforeEach(bootstrapDiagram(defaultDiagramConfig));
-
-  beforeEach(createShapes);
-
-  beforeEach(inject(function(selection) {
-
-    selection.select(shape1);
-    selection.select(shape2, true);
-
-  }));
+    var BASE_SPEED = 1;
+    var ACCELERATED_SPEED = 10;
 
 
-  describe('with default config', function() {
+    beforeEach(bootstrapDiagram({
+      modules: [
+        modelingModule,
+        keyboardMoveSelectionModule
+      ],
+      canvas: {
+        deferUpdate: false
+      }
+    }));
 
-    describe('without shift', function() {
-
-      /* eslint-disable no-multi-spaces */
-      var decisionTable = [
-        { desc: 'move selection left',  keys: KEYS.LEFT,  deltaX: -BASE_SPEED, deltaY: 0 },
-        { desc: 'move selection up',    keys: KEYS.UP,    deltaX: 0,           deltaY: -BASE_SPEED },
-        { desc: 'move selection right', keys: KEYS.RIGHT, deltaX: +BASE_SPEED, deltaY: 0 },
-        { desc: 'move selection down',  keys: KEYS.DOWN,  deltaX: 0,           deltaY: +BASE_SPEED },
-      ];
-      /* eslint-enable */
-
-
-      forEach(decisionTable, function(testCase) {
-
-        forEach(testCase.keys, function(key) {
-
-          it('should ' + testCase.desc, inject(function(keyboard) {
-
-            // given
-            var deltaX = testCase.deltaX,
-                deltaY = testCase.deltaY,
-                event = createKeyEvent(key, { shiftKey: false });
-
-            // when
-            keyboard._keyHandler(event);
-
-            // then
-            expect(shape1.x).to.eql(10 + deltaX);
-            expect(shape1.y).to.eql(10 + deltaY);
-            expect(shape2.x).to.eql(150 + deltaX);
-            expect(shape2.y).to.eql(10 + deltaY);
-
-          }));
-
-        });
-
-      });
-
-    });
-
-    describe('with shift', function() {
-
-      /* eslint-disable no-multi-spaces */
-      var decisionTable = [
-        { desc: 'move selection left',  keys: KEYS.LEFT,  deltaX: -HIGH_SPEED, deltaY: 0 },
-        { desc: 'move selection up',    keys: KEYS.UP,    deltaX: 0,           deltaY: -HIGH_SPEED },
-        { desc: 'move selection right', keys: KEYS.RIGHT, deltaX: +HIGH_SPEED, deltaY: 0 },
-        { desc: 'move selection down',  keys: KEYS.DOWN,  deltaX: 0,           deltaY: +HIGH_SPEED },
-      ];
-      /* eslint-enable */
+    beforeEach(inject(setupShapes));
 
 
-      forEach(decisionTable, function(testCase) {
+    describe('should default move without shift', function() {
 
-        forEach(testCase.keys, function(key) {
-
-          it('should ' + testCase.desc, inject(function(keyboard) {
-
-            // given
-            var deltaX = testCase.deltaX,
-                deltaY = testCase.deltaY,
-                event = createKeyEvent(key, { shiftKey: true });
-
-            // when
-            keyboard._keyHandler(event);
-
-            // then
-            expect(shape1.x).to.eql(10 + deltaX);
-            expect(shape1.y).to.eql(10 + deltaY);
-            expect(shape2.x).to.eql(150 + deltaX);
-            expect(shape2.y).to.eql(10 + deltaY);
-
-          }));
-
-        });
-
-      });
+      verifyMoves({ shiftKey: false }, BASE_SPEED);
 
     });
 
 
-    describe('with control or command', function() {
+    describe('should move accelerated with shift', function() {
 
-      // given
-      var TEST_KEYS = Array.prototype.concat(
-        KEYS.LEFT,
-        KEYS.UP,
-        KEYS.RIGHT,
-        KEYS.DOWN
-      );
+      verifyMoves({ shiftKey: true }, ACCELERATED_SPEED);
+
+    });
 
 
-      forEach(TEST_KEYS, function(key) {
+    describe('should not move with control', function() {
 
-        it('should not move selection when ' + key + ' and control is pressed',
-          inject(function(keyboard) {
+      verifyMove({ ctrlKey: true }, 'left', 'ArrowLeft', { x: 0, y: 0 });
 
-            // given
-            var event = createKeyEvent(key, { ctrlKey: true });
+    });
 
-            // when
-            keyboard._keyHandler(event);
 
-            // then
-            expect(shape1.x).to.eql(10);
-            expect(shape1.y).to.eql(10);
-            expect(shape2.x).to.eql(150);
-            expect(shape2.y).to.eql(10);
+    describe('should not move with meta', function() {
 
-          })
-        );
-
-      });
-
-      forEach(TEST_KEYS, function(key) {
-
-        it('should not move selection when ' + key + ' and command is pressed',
-          inject(function(keyboard) {
-
-            // given
-            var event = createKeyEvent(key, { metaKey: true });
-
-            // when
-            keyboard._keyHandler(event);
-
-            // then
-            expect(shape1.x).to.eql(10);
-            expect(shape1.y).to.eql(10);
-            expect(shape2.x).to.eql(150);
-            expect(shape2.y).to.eql(10);
-
-          })
-        );
-
-      });
+      verifyMove({ metaKey: true }, 'left', 'ArrowLeft', { x: 0, y: 0 });
 
     });
 
   });
 
 
-  describe('with custom config', function() {
+  describe('custom config', function() {
 
-    it('should use custom speed', function() {
+    var CUSTOM_SPEED = 23;
+    var CUSTOM_SPEED_ACCELERATED = 77;
 
-      // given
-      var CUSTOM_SPEED = 23;
 
-      var keyboardConfig = {
-        keyboardMoveSelection: {
-          moveSpeed: CUSTOM_SPEED
-        }
-      };
+    beforeEach(bootstrapDiagram({
+      modules: [
+        modelingModule,
+        keyboardMoveSelectionModule
+      ],
+      canvas: {
+        deferUpdate: false
+      },
+      keyboardMoveSelection: {
+        moveSpeed: CUSTOM_SPEED,
+        moveSpeedAccelerated: CUSTOM_SPEED_ACCELERATED
+      }
+    }));
 
-      bootstrapDiagram(assign(defaultDiagramConfig, keyboardConfig))();
+    beforeEach(inject(setupShapes));
 
-      var keyDownEvent = createKeyEvent(KEYS.DOWN[0]);
 
-      getDiagramJS().invoke(function(selection, keyboard) {
+    describe('should move with custom speed', function() {
 
-        // given
-        createShapes();
-        selection.select(shape1);
-        selection.select(shape2, true);
-
-        // when
-        keyboard._keyHandler(keyDownEvent);
-
-        // then
-        expect(shape1.x).to.eql(10);
-        expect(shape1.y).to.eql(10 + CUSTOM_SPEED);
-        expect(shape2.x).to.eql(150);
-        expect(shape2.y).to.eql(10 + CUSTOM_SPEED);
-
-      });
+      verifyMove({ shiftKey: false }, 'left', 'ArrowLeft', { x: -CUSTOM_SPEED, y: 0 });
 
     });
 
 
-    it('should use custom modified speed', function() {
+    describe('should move with custom accelerated speed', function() {
 
-      // given
-      var CUSTOM_HIGH_SPEED = 77;
+      verifyMove({ shiftKey: true }, 'left', 'ArrowLeft', { x: -CUSTOM_SPEED_ACCELERATED, y: 0 });
 
-      var keyboardConfig = {
-        keyboardMoveSelection: {
-          moveSpeedAccelerated: CUSTOM_HIGH_SPEED
-        }
-      };
+    });
 
-      bootstrapDiagram(assign(defaultDiagramConfig, keyboardConfig))();
+  });
 
-      var keyDownEvent = createKeyEvent(KEYS.DOWN[0], { shiftKey: true });
 
-      getDiagramJS().invoke(function(selection, keyboard) {
+  describe('api', function() {
 
-        // given
-        createShapes();
-        selection.select(shape1);
-        selection.select(shape2, true);
+    beforeEach(bootstrapDiagram({
+      modules: [
+        modelingModule,
+        keyboardMoveSelectionModule
+      ],
+      canvas: {
+        deferUpdate: false
+      }
+    }));
+
+    beforeEach(inject(setupShapes));
+
+
+    it('should provide #moveSelection(direction, false)', inject(
+      function(keyboardMoveSelection) {
 
         // when
-        keyboard._keyHandler(keyDownEvent);
+        keyboardMoveSelection.moveSelection('down', false);
 
         // then
         expect(shape1.x).to.eql(10);
-        expect(shape1.y).to.eql(10 + CUSTOM_HIGH_SPEED);
+        expect(shape1.y).to.eql(10 + 1);
         expect(shape2.x).to.eql(150);
-        expect(shape2.y).to.eql(10 + CUSTOM_HIGH_SPEED);
+        expect(shape2.y).to.eql(10 + 1);
+      }
+    ));
 
-      });
 
-    });
+    it('should provide #moveSelection(direction, true)', inject(
+      function(keyboardMoveSelection) {
+
+        // when
+        keyboardMoveSelection.moveSelection('down', true);
+
+        // then
+        expect(shape1.x).to.eql(10);
+        expect(shape1.y).to.eql(10 + 10);
+        expect(shape2.x).to.eql(150);
+        expect(shape2.y).to.eql(10 + 10);
+      }
+    ));
 
   });
 
@@ -274,26 +167,72 @@ describe('features/keyboard-move-selection', function() {
 
 // helpers ////////
 
-function createShapes() {
+function setupShapes(canvas, selection) {
 
-  getDiagramJS().invoke(function(canvas) {
+  shape1 = canvas.addShape({
+    id: 'shape1',
+    x: 10,
+    y: 10,
+    width: 100,
+    height: 100
+  });
+
+  shape2 = canvas.addShape({
+    id: 'shape2',
+    x: 150,
+    y: 10,
+    width: 100,
+    height: 100
+  });
+
+  selection.select([
+    shape1,
+    shape2
+  ]);
+}
+
+
+function delta(direction, speed) {
+
+  switch (direction) {
+  case 'left': return { x: -speed, y: 0 };
+  case 'right': return { x: speed, y: 0 };
+  case 'up': return { x: 0, y: -speed };
+  case 'down': return { x: 0, y: speed };
+  default: throw new Error('illegal direction');
+  }
+
+}
+
+
+function verifyMove(modifier, direction, key, expectedDelta) {
+
+  it('<' + key + '> --> ' + direction, inject(function(keyboard) {
 
     // given
-    shape1 = canvas.addShape({
-      id: 'shape1',
-      x: 10,
-      y: 10,
-      width: 100,
-      height: 100
-    });
+    var event = createKeyEvent(key, modifier);
 
-    shape2 = canvas.addShape({
-      id: 'shape2',
-      x: 150,
-      y: 10,
-      width: 100,
-      height: 100
-    });
+    // when
+    keyboard._keyHandler(event);
+
+    // then
+    expect(shape1.x).to.eql(10 + expectedDelta.x);
+    expect(shape1.y).to.eql(10 + expectedDelta.y);
+
+    expect(shape2.x).to.eql(150 + expectedDelta.x);
+    expect(shape2.y).to.eql(10 + expectedDelta.y);
+  }));
+
+}
+
+
+function verifyMoves(modifier, speed, expectedDelta) {
+
+  forEach(KEYS, function(direction, key) {
+
+    var d = expectedDelta || delta(direction, speed);
+
+    verifyMove(modifier, direction, key, d);
 
   });
 

--- a/test/spec/features/keyboard/CopySpec.js
+++ b/test/spec/features/keyboard/CopySpec.js
@@ -9,9 +9,10 @@ import {
   forEach
 } from 'min-dash';
 
-import modelingModule from 'lib/features/modeling';
+import copyPasteModule from 'lib/features/copy-paste';
 import editorActionsModule from 'lib/features/editor-actions';
 import keyboardModule from 'lib/features/keyboard';
+import modelingModule from 'lib/features/modeling';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
 
@@ -24,6 +25,7 @@ describe('features/keyboard - copy', function() {
 
   var defaultDiagramConfig = {
     modules: [
+      copyPasteModule,
       modelingModule,
       keyboardModule,
       editorActionsModule

--- a/test/spec/features/keyboard/CopySpec.js
+++ b/test/spec/features/keyboard/CopySpec.js
@@ -10,9 +10,9 @@ import {
 } from 'min-dash';
 
 import copyPasteModule from 'lib/features/copy-paste';
-import editorActionsModule from 'lib/features/editor-actions';
-import keyboardModule from 'lib/features/keyboard';
 import modelingModule from 'lib/features/modeling';
+import keyboardModule from 'lib/features/keyboard';
+import editorActionsModule from 'lib/features/editor-actions';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
 
@@ -28,6 +28,7 @@ describe('features/keyboard - copy', function() {
       copyPasteModule,
       modelingModule,
       keyboardModule,
+      modelingModule,
       editorActionsModule
     ],
     canvas: {
@@ -35,17 +36,19 @@ describe('features/keyboard - copy', function() {
     }
   };
 
-  var decisionTable = [{
-    desc: 'should call copy',
-    keys: KEYS,
-    ctrlKey: true,
-    called: true
-  }, {
-    desc: 'should not call copy',
-    keys: KEYS,
-    ctrlKey: false,
-    called: false
-  }];
+  var decisionTable = [
+    {
+      desc: 'should call copy',
+      keys: KEYS,
+      ctrlKey: true,
+      called: true
+    }, {
+      desc: 'should not call copy',
+      keys: KEYS,
+      ctrlKey: false,
+      called: false
+    }
+  ];
 
   beforeEach(bootstrapDiagram(defaultDiagramConfig));
 

--- a/test/spec/features/keyboard/KeyboardSpec.js
+++ b/test/spec/features/keyboard/KeyboardSpec.js
@@ -248,6 +248,7 @@ describe('features/keyboard', function() {
 
 });
 
+
 // helpers //////////
 
 function dispatchKeyboardEvent(target, type) {

--- a/test/spec/features/keyboard/PasteSpec.js
+++ b/test/spec/features/keyboard/PasteSpec.js
@@ -9,9 +9,10 @@ import {
   forEach
 } from 'min-dash';
 
-import modelingModule from 'lib/features/modeling';
+import copyPasteModule from 'lib/features/copy-paste';
 import editorActionsModule from 'lib/features/editor-actions';
 import keyboardModule from 'lib/features/keyboard';
+import modelingModule from 'lib/features/modeling';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
 
@@ -24,6 +25,7 @@ describe('features/keyboard - paste', function() {
 
   var defaultDiagramConfig = {
     modules: [
+      copyPasteModule,
       modelingModule,
       keyboardModule,
       editorActionsModule

--- a/test/spec/features/keyboard/PasteSpec.js
+++ b/test/spec/features/keyboard/PasteSpec.js
@@ -10,9 +10,9 @@ import {
 } from 'min-dash';
 
 import copyPasteModule from 'lib/features/copy-paste';
-import editorActionsModule from 'lib/features/editor-actions';
-import keyboardModule from 'lib/features/keyboard';
 import modelingModule from 'lib/features/modeling';
+import keyboardModule from 'lib/features/keyboard';
+import editorActionsModule from 'lib/features/editor-actions';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
 
@@ -27,8 +27,9 @@ describe('features/keyboard - paste', function() {
     modules: [
       copyPasteModule,
       modelingModule,
+      editorActionsModule,
       keyboardModule,
-      editorActionsModule
+      modelingModule
     ],
     canvas: {
       deferUpdate: false

--- a/test/spec/features/keyboard/ZoomSpec.js
+++ b/test/spec/features/keyboard/ZoomSpec.js
@@ -7,16 +7,15 @@ import {
   forEach
 } from 'min-dash';
 
-import modelingModule from 'lib/features/modeling';
 import editorActionsModule from 'lib/features/editor-actions';
-import keyboardModule from 'lib/features/keyboard';
 import zoomScrollModule from 'lib/navigation/zoomscroll';
+import keyboardModule from 'lib/features/keyboard';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
 
 var KEYS = {
-  ZOOM_IN: [ '+', 'Add', '=' ],
-  ZOOM_OUT: [ '-', 'Subtract', '_' ],
+  ZOOM_IN: [ '+', 'Add' ],
+  ZOOM_OUT: [ '-', 'Subtract' ],
   ZOOM_DEFAULT: [ '0' ],
 };
 
@@ -25,7 +24,6 @@ describe('features/keyboard - zoom', function() {
 
   var defaultDiagramConfig = {
     modules: [
-      modelingModule,
       keyboardModule,
       editorActionsModule,
       zoomScrollModule

--- a/test/spec/features/keyboard/ZoomSpec.js
+++ b/test/spec/features/keyboard/ZoomSpec.js
@@ -10,6 +10,7 @@ import {
 import modelingModule from 'lib/features/modeling';
 import editorActionsModule from 'lib/features/editor-actions';
 import keyboardModule from 'lib/features/keyboard';
+import zoomScrollModule from 'lib/navigation/zoomscroll';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
 
@@ -26,7 +27,8 @@ describe('features/keyboard - zoom', function() {
     modules: [
       modelingModule,
       keyboardModule,
-      editorActionsModule
+      editorActionsModule,
+      zoomScrollModule
     ],
     canvas: {
       deferUpdate: false

--- a/test/spec/navigation/keyboard-move/KeyboardMoveSpec.js
+++ b/test/spec/navigation/keyboard-move/KeyboardMoveSpec.js
@@ -47,6 +47,7 @@ describe('navigation/keyboard-move', function() {
 
   });
 
+
   describe('arrow bindings', function() {
 
     var KEYS = {


### PR DESCRIPTION
Refactors the editor actions to be independent from actual editor (or viewer) features, as discussed with @barmac.

Core features:

* only bind to actions in `EditorActions` which are implemented via features
* only register keyboard shortcuts for actions that are implemented via features
* rename `move-selection` to `keyboard-move-selection` for clarity
* adjust keyboard move selection config for clarity
* provide `EditorAction` Api for move selection feature
* expose key event via `keyEvent` property

Additional Benefit:

* EditorActions and Keyboard may now safely be used without pulling in the whole modeling code base. 