### PR TITLE
fix(core/EventBus): do not iterate over mutating array of listeners

### DIFF
--- a/lib/core/EventBus.js
+++ b/lib/core/EventBus.js
@@ -332,9 +332,14 @@ EventBus.prototype._invokeListeners = function(event, args, listeners) {
 
   var idx,
       listener,
-      returnValue;
+      returnValue,
+      listenersCopy;
 
-  for (idx = 0; (listener = listeners[idx]); idx++) {
+  // make a shallow copy of the listeners
+  // due to possible mutation of the listeners array
+  listenersCopy = listeners.slice(0);
+
+  for (idx = 0; (listener = listenersCopy[idx]); idx++) {
 
     // handle stopped propagation
     if (event.cancelBubble) {

--- a/test/spec/core/EventBusSpec.js
+++ b/test/spec/core/EventBusSpec.js
@@ -523,6 +523,31 @@ describe('core/EventBus', function() {
       expect(listener1).not.to.have.been.called;
     });
 
+    it('should call all listeners atleast once', function() {
+      // given
+      var listener = sinon.spy();
+      var listener2 = sinon.spy();
+
+      eventBus.once('foo', listener);
+      eventBus.on('foo', listener2);
+
+      // when
+      eventBus.fire('foo');
+
+      // then
+      expect(listener).to.have.been.calledOnce;
+      expect(listener2).to.have.been.calledOnce;
+
+      // but when...
+      eventBus.fire('foo');
+
+      // then
+      // still only called once
+      expect(listener).to.have.been.calledOnce;
+      // should be called again
+      expect(listener2).to.have.been.calledTwice;
+
+    });
   });
 
 


### PR DESCRIPTION
This pr fixes the problem of a run once listener removing itself from the list of listeners that can cause some listeners not to be called at all.

Closes #293 