### PR TITLE
fix(keyboard-bindings): add ie-specific key binding to remove selection

### DIFF
--- a/lib/features/keyboard/KeyboardBindings.js
+++ b/lib/features/keyboard/KeyboardBindings.js
@@ -155,7 +155,7 @@ KeyboardBindings.prototype.registerBindings = function(keyboard, editorActions) 
 
     var event = context.keyEvent;
 
-    if (isKey('Delete', event)) {
+    if (isKey([ 'Delete', 'Del' ], event)) {
       editorActions.trigger('removeSelection');
 
       return true;

--- a/test/spec/features/keyboard/RemoveSelectionSpec.js
+++ b/test/spec/features/keyboard/RemoveSelectionSpec.js
@@ -17,7 +17,10 @@ import { createKeyEvent } from 'test/util/KeyEvents';
 
 var spy = sinon.spy;
 
-var KEYS = [ 'Delete' ];
+var KEYS = [
+  'Delete',
+  'Del'
+];
 
 
 describe('features/keyboard - remove selection', function() {
@@ -38,19 +41,21 @@ describe('features/keyboard - remove selection', function() {
 
   forEach(KEYS, function(key) {
 
-    it('should call remove selection', inject(function(keyboard, editorActions) {
+    it('should call remove selection when ' + key + ' is pressed',
+      inject(function(keyboard, editorActions) {
 
-      // given
-      var removeSelectionSpy = spy(editorActions, 'trigger');
+        // given
+        var removeSelectionSpy = spy(editorActions, 'trigger');
 
-      var event = createKeyEvent(key);
+        var event = createKeyEvent(key);
 
-      // when
-      keyboard._keyHandler(event);
+        // when
+        keyboard._keyHandler(event);
 
-      // then
-      expect(removeSelectionSpy.calledWith('removeSelection')).to.be.true;
-    }));
+        // then
+        expect(removeSelectionSpy.calledWith('removeSelection')).to.be.true;
+      })
+    );
 
   });
 


### PR DESCRIPTION
This PR adds [IE-specific](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values#Editing_keys) key value for `Delete` button.

Closes [#904](https://github.com/bpmn-io/bpmn-js/issues/904)