### PR TITLE
test(util/KeyEvents): simplify utility

### DIFF
--- a/test/spec/features/keyboard/KeyboardSpec.js
+++ b/test/spec/features/keyboard/KeyboardSpec.js
@@ -149,10 +149,8 @@ describe('features/keyboard', function() {
         var inputField = document.createElement('input');
         testDiv.appendChild(inputField);
 
-        var event = createKeyEvent(TEST_KEY, {}, inputField);
-
         // when
-        keyboard._keyHandler(event);
+        keyboard._keyHandler({ key: TEST_KEY, target: inputField });
 
         // then
         expect(eventBusSpy).to.not.be.called;
@@ -240,6 +238,7 @@ describe('features/keyboard', function() {
 
         // then
         expect(keyboardEventStub).to.be.called;
+
         expect(event.defaultPrevented).to.be.true;
       }
     ));

--- a/test/util/KeyEvents.js
+++ b/test/util/KeyEvents.js
@@ -3,26 +3,21 @@ import {
   isString
 } from 'min-dash';
 
-export function createKeyEvent(key, modifiers, target) {
-
+/**
+ * Create a fake key event for testing purposes.
+ *
+ * @param {String|Number} key the key or keyCode/charCode
+ * @param {Object} [attrs]
+ *
+ * @return {Event}
+ */
+export function createKeyEvent(key, attrs) {
   var event = document.createEvent('Events') || new document.defaultView.CustomEvent('keyEvent');
 
-  var options = modifiers || {};
+  // init and mark as bubbles / cancelable
+  event.initEvent('keydown', false, true);
 
-  if (isString(key)) {
-    options.key = key;
-  }
+  var keyAttrs = isString(key) ? { key: key } : { keyCode: key, which: key };
 
-  options.keyCode = key;
-  options.which = key;
-  options.target = target || document;
-  options.preventDefault = preventDefault;
-
-  return assign({}, event, options);
-}
-
-// helpers //////
-
-function preventDefault() {
-  this.defaultPrevented = true;
+  return assign(event, keyAttrs, attrs || {});
 }


### PR DESCRIPTION
Drop target, as we cannot easily instantiate it.

Allow arbitrary attributes to initialize the event with.