### PR TITLE
Allow pasting of labels

### DIFF
--- a/lib/features/modeling/cmd/PasteHandler.js
+++ b/lib/features/modeling/cmd/PasteHandler.js
@@ -179,13 +179,12 @@ PasteHandler.prototype.postExecute = function(context) {
 
   forEach(labels, function(labelDescriptor) {
     var labelTarget = self._getCreatedElement(labelDescriptor.labelTarget, tree),
-        labels, labelTargetPos, newPosition;
+        labels = [ labelDescriptor ],
+        labelTargetPos, newPosition;
 
     if (!labelTarget) {
       return;
     }
-
-    labels = labelTarget.labels;
 
     if (!labels || !labels.length) {
       return;

--- a/test/spec/features/copy-paste/CopyPasteSpec.js
+++ b/test/spec/features/copy-paste/CopyPasteSpec.js
@@ -277,6 +277,24 @@ describe('features/copy-paste', function() {
         expect(parentShape.children).to.have.length(2);
       }));
 
+      it('should paste with labels', inject(function(copyPaste, modeling) {
+        // given
+        modeling.createLabel(childShape, { x: 160, y: 145 });
+
+        // when
+        copyPaste.copy([ childShape ]);
+        copyPaste.paste({
+          element: parentShape,
+          point: {
+            x: 900,
+            y: 350
+          }
+        });
+
+        // then
+        // child shape + label
+        expect(parentShape.children).to.have.length(2);
+      }));
 
       describe('rule integration', function() {
 


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?_

Closes #206

Includes passing reproduction test case from 4d5c744.

I'm still familiarizing myself with the library so perhaps I've inadvertently made a mistake. The solution is borrowed from https://github.com/bpmn-io/diagram-js/issues/206#issuecomment-281365896 but considers multi-label support (i.e. `label` -> `labels` as an array).

Happy to make any necessary changes.