### PR TITLE
1019 Add Basic Snap-to-Grid

### DIFF
--- a/lib/features/grid-snapping/Grid.js
+++ b/lib/features/grid-snapping/Grid.js
@@ -1,0 +1,110 @@
+import {
+  append as svgAppend,
+  attr as svgAttr,
+  clear as svgClear,
+  create as svgCreate
+} from 'tiny-svg';
+
+import { query as domQuery } from 'min-dom';
+
+var SPACING = 10,
+    GRID_COLOR = '#ccc',
+    LAYER_NAME = 'djs-grid';
+
+var GRID_DIMENSIONS = {
+  width : 100000,
+  height: 100000
+};
+
+
+export default function Grid(canvas, config, eventBus) {
+  this._canvas = canvas;
+
+  this.hasGrid = false;
+
+  if (config) {
+    this.visible = config.visible === false ? false : true;
+  } else {
+    this.visible = true;
+  }
+
+  var self = this;
+
+  eventBus.on('diagram.init', function() {
+    self._init();
+
+    self.setVisible(self.visible);
+  });
+}
+
+Grid.prototype._init = function() {
+  var defs = domQuery('defs', this._canvas._svg);
+
+  if (!defs) {
+    defs = svgCreate('defs');
+
+    svgAppend(this._canvas._svg, defs);
+  }
+
+  var pattern = this.pattern = svgCreate('pattern');
+
+  svgAttr(pattern, {
+    id: 'djs-grid-pattern',
+    width: SPACING,
+    height: SPACING,
+    patternUnits: 'userSpaceOnUse'
+  });
+
+  var circle = this.circle = svgCreate('circle');
+
+  svgAttr(circle, {
+    cx: 0.5,
+    cy: 0.5,
+    r: 0.5,
+    fill: GRID_COLOR
+  });
+
+  svgAppend(pattern, circle);
+
+  svgAppend(defs, pattern);
+
+  var grid = this.grid = svgCreate('rect');
+
+  svgAttr(grid, {
+    x: -(GRID_DIMENSIONS.width / 2),
+    y: -(GRID_DIMENSIONS.height / 2),
+    width: GRID_DIMENSIONS.width,
+    height: GRID_DIMENSIONS.height,
+    fill: 'url(#djs-grid-pattern)'
+  });
+};
+
+Grid.prototype.isVisible = function() {
+  return this.visible;
+};
+
+Grid.prototype.setVisible = function(visible) {
+  this.visible = visible;
+
+  var parent = this._getParent();
+
+  if (visible) {
+    svgAppend(parent, this.grid);
+  } else {
+    svgClear(parent);
+  }
+};
+
+Grid.prototype.toggleVisible = function() {
+  this.setVisible(!this.visible);
+};
+
+Grid.prototype._getParent = function() {
+  return this._canvas.getLayer(LAYER_NAME, -2);
+};
+
+Grid.$inject = [
+  'canvas',
+  'config.grid',
+  'eventBus'
+];

--- a/lib/features/grid-snapping/GridSnapping.js
+++ b/lib/features/grid-snapping/GridSnapping.js
@@ -1,0 +1,205 @@
+import {
+  setSnapped,
+  isSnapped
+} from '../snapping/SnapUtil';
+
+import { isCmd } from '../keyboard/KeyboardUtil';
+
+import { isNumber } from 'min-dash';
+
+var SPACING = 10,
+    LOWER_PRIORITY = 1200;
+
+
+export default function GridSnapping(
+    eventBus,
+    config,
+    grid
+) {
+  this._grid = grid;
+
+  if (config) {
+    this.active = config.active === false ? false : true;
+  } else {
+    this.active = true;
+  }
+
+  var self = this;
+
+  eventBus.on('diagram.init', LOWER_PRIORITY, function() {
+    self.setActive(self.active);
+
+    if (!self.active) {
+      grid.setVisible(false);
+    }
+  });
+
+  eventBus.on([
+    'shape.move.move',
+    'shape.move.end',
+    'create.move',
+    'create.end',
+    'connect.move',
+    'connect.end',
+    'resize.move',
+    'resize.end',
+    'bendpoint.move.move',
+    'bendpoint.move.end',
+    'connectionSegment.move.move',
+    'connectionSegment.move.end'
+  ], LOWER_PRIORITY, function(event) {
+    var originalEvent = event.originalEvent;
+
+    if (!self.active || (originalEvent && isCmd(originalEvent))) {
+      return;
+    }
+
+    [ 'x', 'y' ].forEach(function(axis) {
+      if (!isSnapped(event, axis)) {
+        self.snap(event, axis);
+      }
+    });
+  });
+}
+
+GridSnapping.prototype.snap = function(event, axis) {
+  var snapConstraints = getSnapConstraints(event, axis);
+
+  var snappedValue = this._getSnappedValue(event[ axis ], snapConstraints);
+
+  setSnapped(event, axis, snappedValue);
+};
+
+GridSnapping.prototype._getSnappedValue = function(value, snapConstraints) {
+  value = quantize(value, SPACING);
+
+  var min, max;
+
+  if (snapConstraints) {
+    min = snapConstraints.min;
+    max = snapConstraints.max;
+
+    if (isNumber(min)) {
+      min = quantize(min, SPACING, 'ceil');
+
+      value = Math.max(value, min);
+    }
+
+    if (isNumber(max)) {
+      max = quantize(max, SPACING, 'floor');
+
+      value = Math.min(value, max);
+    }
+  }
+
+  return value;
+};
+
+GridSnapping.prototype.isActive = function() {
+  return this.active;
+};
+
+GridSnapping.prototype.setActive = function(active) {
+  this.active = active;
+};
+
+GridSnapping.prototype.toggleActive = function() {
+  this.setActive(!this.active);
+};
+
+GridSnapping.$inject = [
+  'eventBus',
+  'config.gridSnapping',
+  'grid'
+];
+
+// helpers //////////
+
+/**
+ * Get minimum and maximum snap constraints.
+ *
+ * @param {Object} event - Event.
+ * @param {String} axis - Axis.
+ *
+ * @returns {Object}
+ */
+function getSnapConstraints(event, axis) {
+  var context = event.context,
+      resizeConstraints = context.resizeConstraints;
+
+  if (!resizeConstraints) {
+    return null;
+  }
+
+  var direction = context.direction;
+
+  var minResizeConstraints = resizeConstraints.min,
+      maxResizeConstraints = resizeConstraints.max;
+
+  var snapConstraints = {};
+
+  // resize
+  if (minResizeConstraints) {
+
+    if (isHorizontal(axis)) {
+
+      if (isWest(direction)) {
+        snapConstraints.max = minResizeConstraints.left;
+      } else {
+        snapConstraints.min = minResizeConstraints.right;
+      }
+
+    } else {
+
+      if (isNorth(direction)) {
+        snapConstraints.max = minResizeConstraints.top;
+      } else {
+        snapConstraints.min = minResizeConstraints.bottom;
+      }
+
+    }
+  }
+
+  if (maxResizeConstraints) {
+
+    if (isHorizontal(axis)) {
+
+      if (isWest(direction)) {
+        snapConstraints.min = maxResizeConstraints.left;
+      } else {
+        snapConstraints.max = maxResizeConstraints.right;
+      }
+
+    } else {
+
+      if (isNorth(direction)) {
+        snapConstraints.min = maxResizeConstraints.top;
+      } else {
+        snapConstraints.max = maxResizeConstraints.bottom;
+      }
+
+    }
+  }
+
+  return snapConstraints;
+}
+
+function isHorizontal(axis) {
+  return axis === 'x';
+}
+
+function isNorth(direction) {
+  return direction.charAt(0) === 'n';
+}
+
+function isWest(direction) {
+  return direction.charAt(1) === 'w';
+}
+
+function quantize(value, quantum, fn) {
+  if (!fn) {
+    fn = 'round';
+  }
+
+  return Math[ fn ](value / quantum) * quantum;
+}

--- a/lib/features/grid-snapping/index.js
+++ b/lib/features/grid-snapping/index.js
@@ -1,0 +1,8 @@
+import Grid from './Grid';
+import GridSnapping from './GridSnapping';
+
+export default {
+  __init__: [ 'grid', 'gridSnapping' ],
+  grid: [ 'type', Grid ],
+  gridSnapping: [ 'type', GridSnapping ]
+};

--- a/lib/features/resize/Resize.js
+++ b/lib/features/resize/Resize.js
@@ -67,7 +67,7 @@ export default function Resize(eventBus, rules, modeling, dragging) {
    * Handle resize move by specified delta.
    *
    * @param {Object} context
-   * @param {Point delta
+   * @param {Point} delta
    */
   function handleMove(context, delta) {
 

--- a/lib/features/resize/Resize.js
+++ b/lib/features/resize/Resize.js
@@ -189,7 +189,12 @@ Resize.prototype.activate = function(event, shape, contextOrDirection) {
     throw new Error('must provide a direction (nw|se|ne|sw)');
   }
 
-  dragging.init(event, 'resize', {
+  var referencePoint = {
+    x: /w/.test(direction) ? shape.x : shape.x + shape.width,
+    y: /n/.test(direction) ? shape.y : shape.y + shape.height
+  };
+
+  dragging.init(event, referencePoint, 'resize', {
     autoActivate: true,
     cursor: 'resize-' + (/nw|se/.test(direction) ? 'nwse' : 'nesw'),
     data: {

--- a/lib/features/snapping/Snapping.js
+++ b/lib/features/snapping/Snapping.js
@@ -22,6 +22,8 @@ import {
   create as svgCreate
 } from 'tiny-svg';
 
+var SNAP_TOLERANCE = 7;
+
 
 /**
  * A general purpose snapping component for diagram elements.
@@ -125,7 +127,7 @@ Snapping.prototype.snap = function(event) {
       var locationSnapping;
 
       if (!snapping[axis]) {
-        locationSnapping = snapPoints.snap(snapCurrent, location, axis, 7);
+        locationSnapping = snapPoints.snap(snapCurrent, location, axis, SNAP_TOLERANCE);
 
         if (locationSnapping !== undefined) {
           snapping[axis] = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3218,9 +3218,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -3237,7 +3237,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3246,7 +3247,7 @@
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3258,19 +3259,21 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3278,17 +3281,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3306,7 +3312,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3355,7 +3361,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3375,12 +3381,12 @@
           "optional": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
@@ -3405,7 +3411,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3417,6 +3424,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3431,6 +3439,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3438,19 +3447,21 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3462,6 +3473,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3473,7 +3485,7 @@
           "optional": true
         },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.2.4",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3484,18 +3496,18 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.10.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
             "tar": "^4"
@@ -3512,13 +3524,13 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.5",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.2.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3542,7 +3554,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3554,6 +3567,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3593,12 +3607,12 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -3628,18 +3642,19 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3654,7 +3669,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.6.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3675,6 +3690,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3694,6 +3710,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3705,17 +3722,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
           }
         },
@@ -3726,23 +3743,25 @@
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3844,26 +3863,17 @@
       "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
     },
     "handlebars": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
+      "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
       "dev": true,
       "requires": {
-        "async": "^2.5.0",
+        "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.10"
-          }
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4558,9 +4568,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -5383,9 +5393,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
       "dev": true,
       "optional": true
     },
@@ -7514,16 +7524,23 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.4.tgz",
+      "integrity": "sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.17.1",
+        "commander": "~2.20.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true,
+          "optional": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/test/spec/features/grid-snapping/GridSnappingSpec.js
+++ b/test/spec/features/grid-snapping/GridSnappingSpec.js
@@ -1,0 +1,706 @@
+import {
+  bootstrapDiagram,
+  getDiagramJS,
+  inject
+} from 'test/TestHelper';
+
+import modelingModule from 'lib/features/modeling';
+import gridSnappingModule from 'lib/features/grid-snapping';
+import bendpointsModule from 'lib/features/bendpoints';
+import connectModule from 'lib/features/connect';
+import createModule from 'lib/features/create';
+import moveModule from 'lib/features/move';
+import resizeModule from 'lib/features/resize';
+
+import CroppingConnectionDocking from 'lib/layout/CroppingConnectionDocking';
+
+import { asTRBL } from 'lib/layout/LayoutUtil';
+
+var layoutModule = {
+  connectionDocking: [ 'type', CroppingConnectionDocking ]
+};
+
+import {
+  createCanvasEvent as canvasEvent
+} from '../../../util/MockEvents';
+
+var LOW_PRIORITY = 500;
+
+
+describe('features/grid-snapping', function() {
+
+  describe('init', function() {
+
+    it('should init as active by default', function() {
+
+      // when
+      bootstrapDiagram({
+        modules: [
+          modelingModule,
+          gridSnappingModule,
+          moveModule
+        ]
+      })();
+
+      // then
+      var gridSnapping = getDiagramJS().get('gridSnapping');
+
+      expect(gridSnapping.isActive()).to.be.true;
+    });
+
+
+    it('should init as NOT active', function() {
+
+      // when
+      bootstrapDiagram({
+        modules: [
+          modelingModule,
+          gridSnappingModule,
+          moveModule
+        ],
+        gridSnapping: {
+          active: false
+        }
+      })();
+
+      // then
+      var gridSnapping = getDiagramJS().get('gridSnapping');
+
+      expect(gridSnapping.isActive()).to.be.false;
+    });
+
+
+    describe('api', function() {
+
+      beforeEach(bootstrapDiagram({
+        modules: [
+          modelingModule,
+          gridSnappingModule,
+          moveModule
+        ]
+      }));
+
+
+      it('#isActive', inject(function(gridSnapping) {
+
+        // then
+        expect(gridSnapping.isActive()).to.be.true;
+
+        // when
+        gridSnapping.setActive(false);
+
+        // then
+        expect(gridSnapping.isActive()).to.be.false;
+      }));
+
+
+      it('#setActive', inject(function(gridSnapping) {
+
+        // when
+        gridSnapping.setActive(false);
+
+        // then
+        expect(gridSnapping.isActive()).to.be.false;
+      }));
+
+
+      it('#toggleActive', inject(function(gridSnapping) {
+
+        // when
+        gridSnapping.toggleActive();
+
+        // then
+        expect(gridSnapping.isActive()).to.be.false;
+
+        // when
+        gridSnapping.toggleActive();
+
+        // then
+        expect(gridSnapping.isActive()).to.be.true;
+      }));
+
+    });
+
+  });
+
+
+  describe('snapping', function() {
+    var rootShape,
+        rootShapeGfx,
+        shape1,
+        shape2,
+        newShape,
+        connection,
+        connectionGfx;
+
+    beforeEach(bootstrapDiagram({
+      modules: [
+        modelingModule,
+        gridSnappingModule,
+        bendpointsModule,
+        connectModule,
+        createModule,
+        moveModule,
+        resizeModule,
+        layoutModule
+      ]
+    }));
+
+    beforeEach(inject(function(elementFactory, elementRegistry, canvas) {
+
+      rootShape = elementFactory.createRoot({
+        id: 'root'
+      });
+
+      canvas.setRootElement(rootShape);
+
+      rootShapeGfx = elementRegistry.getGraphics(rootShape);
+
+      shape1 = elementFactory.createShape({
+        id: 'shape1',
+        x: 100, y: 100, width: 100, height: 100
+      });
+
+      canvas.addShape(shape1, rootShape);
+
+      shape2 = elementFactory.createShape({
+        id: 'shape2',
+        x: 250, y: 250, width: 100, height: 100
+      });
+
+      canvas.addShape(shape2, rootShape);
+
+      var shape3 = elementFactory.createShape({
+        id: 'shape3',
+        x: 300, y: 100, width: 100, height: 100
+      });
+
+      canvas.addShape(shape3, rootShape);
+
+      connection = elementFactory.createConnection({
+        id: 'connection',
+        source: shape1,
+        target: shape3,
+        waypoints: [
+          { x: 150, y: 150 },
+          { x: 350, y: 150 }
+        ]
+      });
+
+      canvas.addConnection(connection, rootShape);
+
+      connectionGfx = elementRegistry.getGraphics(connection);
+
+      newShape = elementFactory.createShape({
+        id: 'newShape',
+        x: 0, y: 0, width: 100, height: 100
+      });
+    }));
+
+    describe('<move>', function() {
+
+      it('should snap', inject(function(dragging, eventBus, move) {
+
+        // given
+        var events = recordEvents(eventBus, [
+          'shape.move.move',
+          'shape.move.end'
+        ]);
+
+        move.start(canvasEvent({ x: 150, y: 150 }), shape1);
+
+        // when
+        dragging.hover({ element: rootShape, gfx: rootShapeGfx });
+
+        dragging.move(canvasEvent({ x: 156, y: 153 }));
+        dragging.move(canvasEvent({ x: 162, y: 156 }));
+        dragging.move(canvasEvent({ x: 168, y: 159 }));
+        dragging.move(canvasEvent({ x: 174, y: 162 }));
+        dragging.move(canvasEvent({ x: 180, y: 165 }));
+
+        dragging.end();
+
+        // then
+        expect(events.map(position)).to.eql([
+          { x: 160, y: 150 }, // move
+          { x: 160, y: 160 }, // move
+          { x: 170, y: 160 }, // move
+          { x: 170, y: 160 }, // move
+          { x: 180, y: 170 }, // move
+          { x: 180, y: 170 } // end
+        ]);
+
+        expect(shape1.x + shape1.width / 2).to.equal(180);
+        expect(shape1.y + shape1.height / 2).to.equal(170);
+      }));
+
+
+      it('should NOT snap (cmd)', inject(function(dragging, eventBus, move) {
+
+        // given
+        var events = recordEvents(eventBus, [
+          'shape.move.move',
+          'shape.move.end'
+        ]);
+
+        var data = { ctrlKey: true };
+
+        move.start(canvasEvent({ x: 150, y: 150 }, data), shape1);
+
+        // when
+        dragging.hover({ element: rootShape, gfx: rootShapeGfx });
+
+        dragging.move(canvasEvent({ x: 156, y: 153 }, data));
+        dragging.move(canvasEvent({ x: 162, y: 156 }, data));
+        dragging.move(canvasEvent({ x: 168, y: 159 }, data));
+        dragging.move(canvasEvent({ x: 174, y: 162 }, data));
+        dragging.move(canvasEvent({ x: 180, y: 165 }, data));
+
+        dragging.end();
+
+        // then
+        expect(events.map(position)).to.eql([
+          { x: 156, y: 153 }, // move
+          { x: 162, y: 156 }, // move
+          { x: 168, y: 159 }, // move
+          { x: 174, y: 162 }, // move
+          { x: 180, y: 165 }, // move
+          { x: 180, y: 165 } // end
+        ]);
+
+        expect(shape1.x + shape1.width / 2).to.equal(180);
+        expect(shape1.y + shape1.height / 2).to.equal(165);
+      }));
+
+    });
+
+
+    it('<create>', inject(function(create, dragging, eventBus) {
+
+      // given
+      var events = recordEvents(eventBus, [
+        'create.move',
+        'create.end'
+      ]);
+
+      create.start(canvasEvent({ x: 150, y: 250 }), newShape);
+
+      // when
+      dragging.hover({ element: rootShape, gfx: rootShapeGfx });
+
+      dragging.move(canvasEvent({ x: 156, y: 253 }));
+      dragging.move(canvasEvent({ x: 162, y: 256 }));
+      dragging.move(canvasEvent({ x: 168, y: 259 }));
+      dragging.move(canvasEvent({ x: 174, y: 262 }));
+      dragging.move(canvasEvent({ x: 180, y: 265 }));
+
+      dragging.end();
+
+      // then
+      expect(events.map(position)).to.eql([
+        { x: 150, y: 250 }, // move (triggered on create.start thanks to autoActivate)
+        { x: 160, y: 250 }, // move
+        { x: 160, y: 260 }, // move
+        { x: 170, y: 260 }, // move
+        { x: 170, y: 260 }, // move
+        { x: 180, y: 270 }, // move
+        { x: 180, y: 270 } // end
+      ]);
+
+      expect(newShape.x + newShape.width / 2).to.equal(180);
+      expect(newShape.y + newShape.height / 2).to.equal(270);
+    }));
+
+
+    it('<connect>', inject(function(connect, dragging, eventBus) {
+
+      // given
+      var events = recordEvents(eventBus, [
+        'connect.move',
+        'connect.end'
+      ]);
+
+      connect.start(canvasEvent({ x: 250, y: 250 }), shape1);
+
+      // when
+      dragging.move(canvasEvent({ x: 256, y: 253 }));
+      dragging.move(canvasEvent({ x: 262, y: 256 }));
+      dragging.move(canvasEvent({ x: 268, y: 259 }));
+      dragging.move(canvasEvent({ x: 274, y: 262 }));
+      dragging.move(canvasEvent({ x: 280, y: 265 }));
+
+      dragging.hover({ element: shape2 });
+
+      dragging.end();
+
+      // then
+      expect(events.map(position)).to.eql([
+        { x: 260, y: 250 },
+        { x: 260, y: 260 },
+        { x: 270, y: 260 },
+        { x: 270, y: 260 },
+        { x: 280, y: 270 },
+        { x: 280, y: 270 }
+      ]);
+
+      expect(shape1.outgoing[1].waypoints.map(position)).to.eql([
+        { x: 150, y: 150 },
+        { x: 280, y: 270 }
+      ]);
+    }));
+
+
+    describe('<resize>', function() {
+
+      var events;
+
+      beforeEach(inject(function(eventBus) {
+        events = recordEvents(eventBus, [
+          'resize.move',
+          'resize.end'
+        ]);
+      }));
+
+
+      it('without constraints', inject(function(dragging, resize) {
+
+        // given
+        resize.activate(canvasEvent({ x: 100, y: 200 }), shape1, 'sw');
+
+        // when
+        dragging.move(canvasEvent({ x: 106, y: 203 }));
+        dragging.move(canvasEvent({ x: 112, y: 206 }));
+        dragging.move(canvasEvent({ x: 118, y: 209 }));
+        dragging.move(canvasEvent({ x: 124, y: 212 }));
+        dragging.move(canvasEvent({ x: 130, y: 215 }));
+
+        dragging.end();
+
+        // then
+        expect(events.map(position)).to.eql([
+          { x: 100, y: 200 }, // move (triggered on resize.activate thanks to autoActivate)
+          { x: 110, y: 200 }, // move
+          { x: 110, y: 210 }, // move
+          { x: 120, y: 210 }, // move
+          { x: 120, y: 210 }, // move
+          { x: 130, y: 220 }, // move
+          { x: 130, y: 220 } // end
+        ]);
+
+        expect(shape1.width).to.equal(70);
+        expect(shape1.height).to.equal(120);
+      }));
+
+
+      it('with constraints (min)', inject(function(dragging, resize) {
+
+        // given
+        resize.activate(canvasEvent({ x: 100, y: 200 }), shape1, {
+          direction: 'sw',
+          resizeConstraints: {
+            min: asTRBL({
+              x: 125,
+              y: 125,
+              width: 70,
+              height: 70
+            })
+          }
+        });
+
+        // when
+        dragging.move(canvasEvent({ x: 112, y: 203 }));
+        dragging.move(canvasEvent({ x: 124, y: 206 }));
+        dragging.move(canvasEvent({ x: 136, y: 209 }));
+        dragging.move(canvasEvent({ x: 148, y: 212 }));
+        dragging.move(canvasEvent({ x: 160, y: 215 }));
+
+        dragging.end();
+
+        // then
+        expect(events.map(position)).to.eql([
+          { x: 100, y: 200 }, // move (triggered on resize.activate thanks to autoActivate)
+          { x: 110, y: 200 }, // move
+          { x: 120, y: 210 }, // move
+          { x: 120, y: 210 }, // move
+          { x: 120, y: 210 }, // move
+          { x: 120, y: 220 }, // move
+          { x: 120, y: 220 } // end
+        ]);
+
+        expect(shape1.width).to.equal(80);
+        expect(shape1.height).to.equal(120);
+      }));
+
+
+      it('with constraints (max)', inject(function(dragging, resize) {
+
+        // given
+        resize.activate(canvasEvent({ x: 100, y: 200 }), shape1, {
+          direction: 'sw',
+          resizeConstraints: {
+            max: asTRBL({
+              x: 75,
+              y: 75,
+              width: 150,
+              height: 150
+            })
+          }
+        });
+
+        // when
+        dragging.move(canvasEvent({ x: 88, y: 203 }));
+        dragging.move(canvasEvent({ x: 76, y: 206 }));
+        dragging.move(canvasEvent({ x: 64, y: 209 }));
+        dragging.move(canvasEvent({ x: 52, y: 212 }));
+        dragging.move(canvasEvent({ x: 40, y: 215 }));
+
+        dragging.end();
+
+        // then
+        expect(events.map(position)).to.eql([
+          { x: 100, y: 200 }, // move (triggered on resize.activate thanks to autoActivate)
+          { x: 90, y: 200 }, // move
+          { x: 80, y: 210 }, // move
+          { x: 80, y: 210 }, // move
+          { x: 80, y: 210 }, // move
+          { x: 80, y: 220 }, // move
+          { x: 80, y: 220 } // end
+        ]);
+
+        expect(shape1.width).to.equal(120);
+        expect(shape1.height).to.equal(120);
+      }));
+
+    });
+
+
+
+    it('<bendpoint.move>', inject(function(bendpointMove, dragging, eventBus) {
+
+      // given
+      var events = recordEvents(eventBus, [
+        'bendpoint.move.move',
+        'bendpoint.move.end'
+      ]);
+
+      bendpointMove.start(canvasEvent({ x: 250, y: 150 }), connection, 1, true);
+
+      dragging.hover({ element: connection, gfx: connectionGfx });
+
+      // when
+      dragging.move(canvasEvent({ x: 250, y: 162 }));
+      dragging.move(canvasEvent({ x: 250, y: 174 }));
+      dragging.move(canvasEvent({ x: 250, y: 186 }));
+      dragging.move(canvasEvent({ x: 250, y: 198 }));
+      dragging.move(canvasEvent({ x: 250, y: 210 }));
+
+      dragging.end();
+
+      // then
+      expect(events.map(position)).to.eql([
+        { x: 250, y: 160 }, // move
+        { x: 250, y: 170 }, // move
+        { x: 250, y: 190 }, // move
+        { x: 250, y: 200 }, // move
+        { x: 250, y: 210 }, // move
+        { x: 250, y: 210 } // end
+      ]);
+
+      expect(shape1.outgoing[0].waypoints.map(position)).to.eql([
+        { x: 200, y: 180 },
+        { x: 250, y: 210 },
+        { x: 300, y: 180 }
+      ]);
+    }));
+
+
+    it('<connectionSegment.move>', inject(function(connectionSegmentMove, dragging, eventBus) {
+
+      // given
+      var events = recordEvents(eventBus, [
+        'connectionSegment.move.move',
+        'connectionSegment.move.end'
+      ]);
+
+      connectionSegmentMove.start(canvasEvent({ x: 250, y: 150 }), connection, 1);
+
+      // when
+      dragging.move(canvasEvent({ x: 250, y: 162 }));
+      dragging.move(canvasEvent({ x: 250, y: 174 }));
+      dragging.move(canvasEvent({ x: 250, y: 186 }));
+      dragging.move(canvasEvent({ x: 250, y: 198 }));
+      dragging.move(canvasEvent({ x: 250, y: 210 }));
+
+      dragging.end();
+
+      // then
+      expect(events.map(position)).to.eql([
+        { x: 250, y: 160 }, // move
+        { x: 250, y: 170 }, // move
+        { x: 250, y: 190 }, // move
+        { x: 250, y: 200 }, // move
+        { x: 250, y: 210 }, // move
+        { x: 250, y: 210 } // end
+      ]);
+
+      expect(shape1.outgoing[0].waypoints.map(position)).to.eql([
+        { x: 150, y: 200 },
+        { x: 150, y: 210 },
+        { x: 350, y: 210 },
+        { x: 350, y: 200 }
+      ]);
+    }));
+
+  });
+
+
+  describe('grid', function() {
+
+    it('should be visible by default', function() {
+
+      // when
+      bootstrapDiagram({
+        modules: [
+          modelingModule,
+          gridSnappingModule,
+          moveModule
+        ]
+      })();
+
+      // then
+      var grid = getDiagramJS().get('grid'),
+          gfx = grid._getParent();
+
+      expect(grid.isVisible()).to.be.true;
+      expect(gfx.childNodes).to.have.length(1);
+    });
+
+
+    it('should NOT be visible (grid.visible = false)', function() {
+
+      // when
+      bootstrapDiagram({
+        modules: [
+          modelingModule,
+          gridSnappingModule,
+          moveModule
+        ],
+        grid: {
+          visible: false
+        }
+      })();
+
+      // then
+      var grid = getDiagramJS().get('grid'),
+          gfx = grid._getParent();
+
+      expect(grid.isVisible()).to.be.false;
+      expect(gfx.childNodes).to.have.length(0);
+    });
+
+
+    it('should NOT be visible (gridSnapping.active = false)', function() {
+
+      // when
+      bootstrapDiagram({
+        modules: [
+          modelingModule,
+          gridSnappingModule,
+          moveModule
+        ],
+        gridSnapping: {
+          active: false
+        }
+      })();
+
+      // then
+      var grid = getDiagramJS().get('grid'),
+          gfx = grid._getParent();
+
+      expect(grid.isVisible()).to.be.false;
+      expect(gfx.childNodes).to.have.length(0);
+    });
+
+
+    describe('api', function() {
+
+      beforeEach(bootstrapDiagram({
+        modules: [
+          modelingModule,
+          gridSnappingModule,
+          moveModule
+        ]
+      }));
+
+
+      it('#isVisible', inject(function(grid) {
+
+        // then
+        expect(grid.isVisible()).to.be.true;
+
+        // when
+        grid.setVisible(false);
+
+        // then
+        expect(grid.isVisible()).to.be.false;
+      }));
+
+
+      it('#setVisible', inject(function(grid) {
+
+        // when
+        grid.setVisible(false);
+
+        // then
+        var gfx = grid._getParent();
+
+        expect(grid.isVisible()).to.be.false;
+        expect(gfx.childNodes).to.have.length(0);
+      }));
+
+
+      it('#toggleVisible', inject(function(grid) {
+
+        // when
+        grid.toggleVisible();
+
+        // then
+        var gfx = grid._getParent();
+
+        expect(grid.isVisible()).to.be.false;
+        expect(gfx.childNodes).to.have.length(0);
+
+        // when
+        grid.toggleVisible();
+
+        // then
+        expect(grid.isVisible()).to.be.true;
+        expect(gfx.childNodes).to.have.length(1);
+      }));
+
+    });
+
+  });
+
+});
+
+// helpers //////////
+
+function recordEvents(eventBus, eventTypes) {
+  var events = [];
+
+  eventTypes.forEach(function(eventType) {
+    eventBus.on(eventType, LOW_PRIORITY, function(event) {
+      events.push(event);
+    });
+  });
+
+  return events;
+}
+
+function position(event) {
+  return {
+    x: event.x,
+    y: event.y
+  };
+}

--- a/test/spec/features/snapping/SnappingSpec.js
+++ b/test/spec/features/snapping/SnappingSpec.js
@@ -72,7 +72,9 @@ describe('features/snapping', function() {
 
   describe('bootstrap', function() {
 
-    it('should bootstrap diagram with component', inject(function() {}));
+    it('should bootstrap diagram with component', inject(function(snapping) {
+      expect(snapping).to.exist;
+    }));
 
   });
 


### PR DESCRIPTION
Snaps the following actions to a grid:
 * creating/moving/resizing/connecting shapes
 * moving bendpoints/connection segments

Furthermore, it:
* snaps with lower priority than snapping
* considers constraints when resizing shapes

Related to https://github.com/bpmn-io/bpmn-js/issues/973