### PR TITLE
fix(example): add source and target for example connection

### DIFF
--- a/example/app/app.js
+++ b/example/app/app.js
@@ -91,7 +91,9 @@ var connection1 = elementFactory.createConnection({
   waypoints: [
     { x: 250, y: 180 },
     { x: 290, y: 220 }
-  ]
+  ],
+  source: shape1,
+  target: shape2
 });
 
 canvas.addConnection(connection1, root);


### PR DESCRIPTION
It seems that the example leads to confusion in some place since when moving one of the shapes (visually) connected by the example connection, the connection didn't get updated (cf. [forum thread](https://forum.bpmn.io/t/diagram-js-with-connectors/3360)):

![May-02-2019 09-33-12](https://user-images.githubusercontent.com/9433996/57061503-5ad46b00-6cbd-11e9-84ef-1b2ebafc4a86.gif)

This is _correct_ by design since the connection didn't get a `target` nor a `source` on creation. This pull request adds it to avoid confusion.

![May-02-2019 09-36-11](https://user-images.githubusercontent.com/9433996/57061601-c3234c80-6cbd-11e9-87ba-222c2c9245ce.gif)
 