### PR TITLE
fix(auto-resize): allow passing hints

### DIFF
--- a/lib/features/auto-resize/AutoResize.js
+++ b/lib/features/auto-resize/AutoResize.js
@@ -194,7 +194,9 @@ AutoResize.prototype._expand = function(elements, target) {
   var resizeDirections = getResizeDirections(pick(target, [ 'x', 'y', 'width', 'height' ]), newBounds);
 
   // resize the parent shape
-  this.resize(target, newBounds, resizeDirections);
+  this.resize(target, newBounds, {
+    autoResize: resizeDirections
+  });
 
   var parent = target.parent;
 
@@ -235,12 +237,11 @@ AutoResize.prototype.getPadding = function(shape) {
  *
  * @param {djs.model.Shape} shape
  * @param {Bounds} newBounds
- * @param {string} resizeDirections
+ * @param {Object} [hints]
+ * @param {string} [hints.autoResize]
  */
-AutoResize.prototype.resize = function(shape, newBounds, resizeDirections) {
-  this._modeling.resizeShape(shape, newBounds, null, {
-    autoResize: resizeDirections
-  });
+AutoResize.prototype.resize = function(shape, newBounds, hints) {
+  this._modeling.resizeShape(shape, newBounds, null, hints);
 };
 
 

--- a/test/spec/features/auto-resize/AutoResizeSpec.js
+++ b/test/spec/features/auto-resize/AutoResizeSpec.js
@@ -798,7 +798,9 @@ describe('features/auto-resize', function() {
 
         // then
         expect(getResizeDirections(resizeSpy)).to.exist;
-        expect(getResizeDirections(resizeSpy)).to.eql('ne');
+        expect(getResizeDirections(resizeSpy)).to.eql({
+          autoResize: 'ne'
+        });
       }));
 
 
@@ -814,7 +816,9 @@ describe('features/auto-resize', function() {
 
         // then
         expect(getResizeDirections(resizeSpy)).to.exist;
-        expect(getResizeDirections(resizeSpy)).to.eql('nwse');
+        expect(getResizeDirections(resizeSpy)).to.eql({
+          autoResize: 'nwse'
+        });
       }));
 
     });


### PR DESCRIPTION
As we've discussed using a generic hints object will allow us to pass more hints in the future.