### PR TITLE
Consistently layout connections previews

### DIFF
--- a/lib/features/bendpoints/BendpointMove.js
+++ b/lib/features/bendpoints/BendpointMove.js
@@ -3,44 +3,23 @@ import {
   pointsOnLine
 } from '../../util/Geometry';
 
-import {
-  addBendpoint
-} from './BendpointUtil';
-
-var MARKER_OK = 'connect-ok',
-    MARKER_NOT_OK = 'connect-not-ok',
-    MARKER_CONNECT_HOVER = 'connect-hover',
-    MARKER_CONNECT_UPDATING = 'djs-updating';
-
 var COMMAND_BENDPOINT_UPDATE = 'connection.updateWaypoints',
     COMMAND_RECONNECT_START = 'connection.reconnectStart',
     COMMAND_RECONNECT_END = 'connection.reconnectEnd';
 
 var round = Math.round;
 
-import {
-  classes as svgClasses,
-  remove as svgRemove
-} from 'tiny-svg';
-
-import { translate } from '../../util/SvgTransformUtil';
-
 
 /**
  * A component that implements moving of bendpoints
  */
-export default function BendpointMove(
-    injector, eventBus, canvas,
-    dragging, graphicsFactory, rules,
-    modeling) {
-
+export default function BendpointMove(injector, eventBus, canvas, dragging, rules, modeling) {
 
   // optional connection docking integration
   var connectionDocking = injector.get('connectionDocking', false);
 
 
   // API
-
   this.start = function(event, connection, bendpointIndex, insert) {
 
     var type,
@@ -75,12 +54,6 @@ export default function BendpointMove(
 
 
   // DRAGGING IMPLEMENTATION
-
-
-  function redrawConnection(data) {
-    graphicsFactory.update('connection', data.connection, data.connectionGfx);
-  }
-
   function filterRedundantWaypoints(waypoints) {
 
     // alter copy of waypoints, not original
@@ -110,164 +83,81 @@ export default function BendpointMove(
     return waypoints;
   }
 
-  eventBus.on('bendpoint.move.start', function(e) {
-
-    var context = e.context,
-        connection = context.connection,
-        originalWaypoints = connection.waypoints,
-        waypoints = originalWaypoints.slice(),
-        insert = context.insert,
-        idx = context.bendpointIndex;
-
-    context.originalWaypoints = originalWaypoints;
-
-    if (insert) {
-      // insert placeholder for bendpoint to-be-added
-      waypoints.splice(idx, 0, null);
-    }
-
-    connection.waypoints = waypoints;
-
-    // add dragger gfx
-    context.draggerGfx = addBendpoint(canvas.getLayer('overlays'));
-    svgClasses(context.draggerGfx).add('djs-dragging');
-
-    canvas.addMarker(connection, MARKER_CONNECT_UPDATING);
-  });
-
   eventBus.on('bendpoint.move.hover', function(e) {
     var context = e.context;
 
     context.hover = e.hover;
 
     if (e.hover) {
-      canvas.addMarker(e.hover, MARKER_CONNECT_HOVER);
-
       // asks whether reconnect / bendpoint move / bendpoint add
       // is allowed at the given position
       var allowed = context.allowed = rules.allowed(context.type, context);
 
       if (allowed) {
-        canvas.removeMarker(context.hover, MARKER_NOT_OK);
-        canvas.addMarker(context.hover, MARKER_OK);
-
         context.target = context.hover;
       } else if (allowed === false) {
-        canvas.removeMarker(context.hover, MARKER_OK);
-        canvas.addMarker(context.hover, MARKER_NOT_OK);
-
         context.target = null;
       }
-    }
-  });
-
-  eventBus.on([
-    'bendpoint.move.out',
-    'bendpoint.move.cleanup'
-  ], function(e) {
-
-    // remove connect marker
-    // if it was added
-    var hover = e.context.hover;
-
-    if (hover) {
-      canvas.removeMarker(hover, MARKER_CONNECT_HOVER);
-      canvas.removeMarker(hover, e.context.target ? MARKER_OK : MARKER_NOT_OK);
-    }
-  });
-
-  eventBus.on('bendpoint.move.move', function(e) {
-
-    var context = e.context,
-        moveType = context.type,
-        connection = e.connection,
-        source, target;
-
-    connection.waypoints[context.bendpointIndex] = { x: e.x, y: e.y };
-
-    if (connectionDocking) {
-
-      if (context.hover) {
-        if (moveType === COMMAND_RECONNECT_START) {
-          source = context.hover;
-        }
-
-        if (moveType === COMMAND_RECONNECT_END) {
-          target = context.hover;
-        }
-      }
-
-      connection.waypoints = connectionDocking.getCroppedWaypoints(connection, source, target);
-    }
-
-    // add dragger gfx
-    translate(context.draggerGfx, e.x, e.y);
-
-    redrawConnection(e);
-  });
-
-  eventBus.on([
-    'bendpoint.move.end',
-    'bendpoint.move.cancel'
-  ], function(e) {
-
-    var context = e.context,
-        hover = context.hover,
-        connection = context.connection;
-
-    // remove dragger gfx
-    svgRemove(context.draggerGfx);
-    context.newWaypoints = connection.waypoints.slice();
-    connection.waypoints = context.originalWaypoints;
-    canvas.removeMarker(connection, MARKER_CONNECT_UPDATING);
-
-    if (hover) {
-      canvas.removeMarker(hover, MARKER_OK);
-      canvas.removeMarker(hover, MARKER_NOT_OK);
     }
   });
 
   eventBus.on('bendpoint.move.end', function(e) {
 
     var context = e.context,
-        waypoints = context.newWaypoints,
+        connection = context.connection,
+        originalWaypoints = connection.waypoints,
+        newWaypoints = originalWaypoints.slice(),
         bendpointIndex = context.bendpointIndex,
-        bendpoint = waypoints[bendpointIndex],
         allowed = context.allowed,
+        insert = context.insert,
+        bendpoint,
         hints;
 
     // ensure we have actual pixel values bendpoint
     // coordinates (important when zoom level was > 1 during move)
-    bendpoint.x = round(bendpoint.x);
-    bendpoint.y = round(bendpoint.y);
+    bendpoint = {
+      x: round(e.x),
+      y: round(e.y)
+    };
 
     if (allowed && context.type === COMMAND_RECONNECT_START) {
       modeling.reconnectStart(context.connection, context.target, bendpoint);
-    } else
-    if (allowed && context.type === COMMAND_RECONNECT_END) {
+    } else if (allowed && context.type === COMMAND_RECONNECT_END) {
       modeling.reconnectEnd(context.connection, context.target, bendpoint);
-    } else
-    if (allowed !== false && context.type === COMMAND_BENDPOINT_UPDATE) {
+    } else if (allowed !== false && context.type === COMMAND_BENDPOINT_UPDATE) {
+      if (insert) {
+        // insert new bendpoint
+        newWaypoints.splice(bendpointIndex, 0, bendpoint);
+      } else {
+        // swap previous waypoint with the moved one
+        newWaypoints[bendpointIndex] = bendpoint;
+      }
 
       // pass hints on the actual moved bendpoint
       // this is useful for connection and label layouting
       hints = {
         bendpointMove: {
-          insert: e.context.insert,
+          insert: insert,
           bendpointIndex: bendpointIndex
         }
       };
 
-      modeling.updateWaypoints(context.connection, filterRedundantWaypoints(waypoints), hints);
-    } else {
-      redrawConnection(e);
+      if (connectionDocking) {
+        // (0) temporarily assign new waypoints
+        connection.waypoints = newWaypoints;
 
+        // (1) crop connection with new waypoints and save them
+        connection.waypoints = connectionDocking.getCroppedWaypoints(connection);
+        newWaypoints = connection.waypoints;
+
+        // (2) restore original waypoints to not mutate connection directly
+        connection.waypoints = originalWaypoints;
+      }
+
+      modeling.updateWaypoints(context.connection, filterRedundantWaypoints(newWaypoints), hints);
+    } else {
       return false;
     }
-  });
-
-  eventBus.on('bendpoint.move.cancel', function(e) {
-    redrawConnection(e);
   });
 }
 
@@ -276,7 +166,6 @@ BendpointMove.$inject = [
   'eventBus',
   'canvas',
   'dragging',
-  'graphicsFactory',
   'rules',
   'modeling'
 ];

--- a/lib/features/bendpoints/BendpointMove.js
+++ b/lib/features/bendpoints/BendpointMove.js
@@ -95,10 +95,15 @@ export default function BendpointMove(injector, eventBus, canvas, dragging, rule
 
       if (allowed) {
         context.target = context.hover;
-      } else if (allowed === false) {
-        context.target = null;
       }
     }
+  });
+
+  eventBus.on([ 'bendpoint.move.out', 'bendpoint.move.cleanup' ], function(event) {
+    var context = event.context;
+
+    context.target = null;
+    context.allowed = false;
   });
 
   eventBus.on('bendpoint.move.end', function(e) {

--- a/lib/features/bendpoints/BendpointMovePreview.js
+++ b/lib/features/bendpoints/BendpointMovePreview.js
@@ -84,7 +84,7 @@ export default function BendpointMove(injector, eventBus, canvas, graphicsFactor
   eventBus.on([
     'bendpoint.move.out',
     'bendpoint.move.cleanup'
-  ], function(e) {
+  ], HIGH_PRIORITY, function(e) {
 
     // remove connect marker
     // if it was added

--- a/lib/features/bendpoints/BendpointMovePreview.js
+++ b/lib/features/bendpoints/BendpointMovePreview.js
@@ -1,0 +1,159 @@
+import {
+  classes as svgClasses,
+  remove as svgRemove
+} from 'tiny-svg';
+
+import {
+  addBendpoint
+} from './BendpointUtil';
+
+import { translate } from '../../util/SvgTransformUtil';
+
+
+var MARKER_OK = 'connect-ok',
+    MARKER_NOT_OK = 'connect-not-ok',
+    MARKER_CONNECT_HOVER = 'connect-hover',
+    MARKER_CONNECT_UPDATING = 'djs-updating';
+
+var COMMAND_RECONNECT_START = 'connection.reconnectStart',
+    COMMAND_RECONNECT_END = 'connection.reconnectEnd';
+
+var HIGH_PRIORITY = 1100;
+
+/**
+ * A component that implements moving of bendpoints
+ */
+export default function BendpointMove(injector, eventBus, canvas, graphicsFactory) {
+
+  // optional connection docking integration
+  var connectionDocking = injector.get('connectionDocking', false);
+
+
+  // DRAGGING IMPLEMENTATION
+
+
+  function redrawConnection(data) {
+    graphicsFactory.update('connection', data.connection, data.connectionGfx);
+  }
+
+  eventBus.on('bendpoint.move.start', function(e) {
+
+    var context = e.context,
+        connection = context.connection,
+        originalWaypoints = connection.waypoints,
+        waypoints = originalWaypoints.slice(),
+        insert = context.insert,
+        idx = context.bendpointIndex;
+
+    // save waypoints to restore at the end
+    context.originalWaypoints = originalWaypoints;
+
+    if (insert) {
+      // insert placeholder for bendpoint to-be-added
+      waypoints.splice(idx, 0, { x: e.x, y: e.y });
+    }
+
+    connection.waypoints = waypoints;
+
+    // add dragger gfx
+    context.draggerGfx = addBendpoint(canvas.getLayer('overlays'));
+    svgClasses(context.draggerGfx).add('djs-dragging');
+
+    canvas.addMarker(connection, MARKER_CONNECT_UPDATING);
+  });
+
+  eventBus.on('bendpoint.move.hover', function(e) {
+    var context = e.context,
+        allowed = context.allowed,
+        hover = context.hover;
+
+    if (e.hover) {
+      canvas.addMarker(hover, MARKER_CONNECT_HOVER);
+
+      if (allowed) {
+        canvas.removeMarker(hover, MARKER_NOT_OK);
+        canvas.addMarker(hover, MARKER_OK);
+      } else if (allowed === false) {
+        canvas.removeMarker(hover, MARKER_OK);
+        canvas.addMarker(hover, MARKER_NOT_OK);
+      }
+    }
+  });
+
+  eventBus.on([
+    'bendpoint.move.out',
+    'bendpoint.move.cleanup'
+  ], function(e) {
+
+    // remove connect marker
+    // if it was added
+    var hover = e.context.hover;
+
+    if (hover) {
+      canvas.removeMarker(hover, MARKER_CONNECT_HOVER);
+      canvas.removeMarker(hover, e.context.target ? MARKER_OK : MARKER_NOT_OK);
+    }
+  });
+
+  eventBus.on('bendpoint.move.move', function(e) {
+
+    var context = e.context,
+        moveType = context.type,
+        connection = e.connection,
+        source, target;
+
+    connection.waypoints[context.bendpointIndex] = { x: e.x, y: e.y };
+
+    if (connectionDocking) {
+
+      if (context.hover) {
+        if (moveType === COMMAND_RECONNECT_START) {
+          source = context.hover;
+        }
+
+        if (moveType === COMMAND_RECONNECT_END) {
+          target = context.hover;
+        }
+      }
+
+      connection.waypoints = connectionDocking.getCroppedWaypoints(connection, source, target);
+    }
+
+    // add dragger gfx
+    translate(context.draggerGfx, e.x, e.y);
+
+    redrawConnection(e);
+  });
+
+  eventBus.on([
+    'bendpoint.move.end',
+    'bendpoint.move.cancel'
+  ], HIGH_PRIORITY, function(e) {
+
+    var context = e.context,
+        hover = context.hover,
+        connection = context.connection;
+
+    // reassign original waypoints
+    connection.waypoints = context.originalWaypoints;
+
+    // remove dragger gfx
+    svgRemove(context.draggerGfx);
+
+    canvas.removeMarker(connection, MARKER_CONNECT_UPDATING);
+
+    if (hover) {
+      canvas.removeMarker(hover, MARKER_OK);
+      canvas.removeMarker(hover, context.target ? MARKER_OK : MARKER_NOT_OK);
+    }
+
+    redrawConnection(e);
+  });
+}
+
+BendpointMove.$inject = [
+  'injector',
+  'eventBus',
+  'canvas',
+  'graphicsFactory'
+];

--- a/lib/features/bendpoints/BendpointMovePreview.js
+++ b/lib/features/bendpoints/BendpointMovePreview.js
@@ -25,8 +25,9 @@ var HIGH_PRIORITY = 1100;
  */
 export default function BendpointMove(injector, eventBus, canvas, graphicsFactory) {
 
-  // optional connection docking integration
-  var connectionDocking = injector.get('connectionDocking', false);
+  // optional components
+  var connectionDocking = injector.get('connectionDocking', false),
+      layouter = injector.get('layouter', false);
 
 
   // DRAGGING IMPLEMENTATION
@@ -100,18 +101,34 @@ export default function BendpointMove(injector, eventBus, canvas, graphicsFactor
     var context = e.context,
         moveType = context.type,
         connection = e.connection,
-        source, target;
+        bendpoint = { x: e.x, y: e.y },
+        source, target, hints;
 
-    connection.waypoints[context.bendpointIndex] = { x: e.x, y: e.y };
+    connection.waypoints = context.originalWaypoints.slice();
+
+    if (layouter && context.target) {
+      hints = {};
+
+      if (moveType === COMMAND_RECONNECT_START) {
+        hints.source = context.target;
+        hints.connectionStart = bendpoint;
+      } else if (moveType === COMMAND_RECONNECT_END) {
+        hints.target = context.target;
+        hints.connectionEnd = bendpoint;
+      }
+
+      connection.waypoints = layouter.layoutConnection(connection, hints);
+    } else {
+      connection.waypoints[context.bendpointIndex] = bendpoint;
+    }
 
     if (connectionDocking) {
 
       if (context.hover) {
+
         if (moveType === COMMAND_RECONNECT_START) {
           source = context.hover;
-        }
-
-        if (moveType === COMMAND_RECONNECT_END) {
+        } else if (moveType === COMMAND_RECONNECT_END) {
           target = context.hover;
         }
       }

--- a/lib/features/bendpoints/BendpointMovePreview.js
+++ b/lib/features/bendpoints/BendpointMovePreview.js
@@ -23,19 +23,11 @@ var HIGH_PRIORITY = 1100;
 /**
  * A component that implements moving of bendpoints
  */
-export default function BendpointMove(injector, eventBus, canvas, graphicsFactory) {
+export default function BendpointMovePreview(injector, eventBus, canvas) {
 
-  // optional components
-  var connectionDocking = injector.get('connectionDocking', false),
-      layouter = injector.get('layouter', false);
-
+  var connectionPreview = injector.get('connectionPreview', false);
 
   // DRAGGING IMPLEMENTATION
-
-
-  function redrawConnection(data) {
-    graphicsFactory.update('connection', data.connection, data.connectionGfx);
-  }
 
   eventBus.on('bendpoint.move.start', function(e) {
 
@@ -101,13 +93,15 @@ export default function BendpointMove(injector, eventBus, canvas, graphicsFactor
     var context = e.context,
         moveType = context.type,
         connection = e.connection,
+        waypoints = connection.waypoints.slice(),
         bendpoint = { x: e.x, y: e.y },
-        source, target, hints;
+        hints;
 
-    connection.waypoints = context.originalWaypoints.slice();
-
-    if (layouter && context.target) {
-      hints = {};
+    if (connectionPreview) {
+      hints = {
+        source: connection.source,
+        target: connection.target
+      };
 
       if (moveType === COMMAND_RECONNECT_START) {
         hints.source = context.target;
@@ -115,31 +109,18 @@ export default function BendpointMove(injector, eventBus, canvas, graphicsFactor
       } else if (moveType === COMMAND_RECONNECT_END) {
         hints.target = context.target;
         hints.connectionEnd = bendpoint;
+      } else {
+        hints.noLayout = true;
+        waypoints[context.bendpointIndex] = bendpoint;
       }
 
-      connection.waypoints = layouter.layoutConnection(connection, hints);
-    } else {
-      connection.waypoints[context.bendpointIndex] = bendpoint;
-    }
+      hints.waypoints = waypoints;
 
-    if (connectionDocking) {
-
-      if (context.hover) {
-
-        if (moveType === COMMAND_RECONNECT_START) {
-          source = context.hover;
-        } else if (moveType === COMMAND_RECONNECT_END) {
-          target = context.hover;
-        }
-      }
-
-      connection.waypoints = connectionDocking.getCroppedWaypoints(connection, source, target);
+      connectionPreview.drawPreview(context, context.allowed, hints);
     }
 
     // add dragger gfx
     translate(context.draggerGfx, e.x, e.y);
-
-    redrawConnection(e);
   });
 
   eventBus.on([
@@ -164,13 +145,14 @@ export default function BendpointMove(injector, eventBus, canvas, graphicsFactor
       canvas.removeMarker(hover, context.target ? MARKER_OK : MARKER_NOT_OK);
     }
 
-    redrawConnection(e);
+    if (connectionPreview) {
+      connectionPreview.cleanUp(context);
+    }
   });
 }
 
-BendpointMove.$inject = [
+BendpointMovePreview.$inject = [
   'injector',
   'eventBus',
-  'canvas',
-  'graphicsFactory'
+  'canvas'
 ];

--- a/lib/features/bendpoints/BendpointSnapping.js
+++ b/lib/features/bendpoints/BendpointSnapping.js
@@ -159,7 +159,7 @@ export default function BendpointSnapping(eventBus) {
   }
 
 
-  eventBus.on('bendpoint.move.move', 1500, function(event) {
+  eventBus.on([ 'bendpoint.move.move', 'bendpoint.move.end' ], 1500, function(event) {
 
     var context = event.context,
         snapPoints = getBendpointSnaps(context),

--- a/lib/features/bendpoints/index.js
+++ b/lib/features/bendpoints/index.js
@@ -3,6 +3,7 @@ import RulesModule from '../rules';
 
 import Bendpoints from './Bendpoints';
 import BendpointMove from './BendpointMove';
+import BendpointMovePreview from './BendpointMovePreview';
 import ConnectionSegmentMove from './ConnectionSegmentMove';
 import BendpointSnapping from './BendpointSnapping';
 
@@ -12,9 +13,10 @@ export default {
     DraggingModule,
     RulesModule
   ],
-  __init__: [ 'bendpoints', 'bendpointSnapping' ],
+  __init__: [ 'bendpoints', 'bendpointSnapping', 'bendpointMovePreview' ],
   bendpoints: [ 'type', Bendpoints ],
   bendpointMove: [ 'type', BendpointMove ],
+  bendpointMovePreview: [ 'type', BendpointMovePreview ],
   connectionSegmentMove: [ 'type', ConnectionSegmentMove ],
   bendpointSnapping: [ 'type', BendpointSnapping ]
 };

--- a/lib/features/connect/ConnectPreview.js
+++ b/lib/features/connect/ConnectPreview.js
@@ -1,20 +1,3 @@
-import {
-  append as svgAppend,
-  attr as svgAttr,
-  classes as svgClasses,
-  clear as svgClear,
-  create as svgCreate,
-  remove as svgRemove
-} from 'tiny-svg';
-
-import {
-  isObject
-} from 'min-dash';
-
-import {
-  getElementLineIntersection
-} from '../../layout/LayoutUtil';
-
 var HIGH_PRIORITY = 1100,
     LOW_PRIORITY = 900;
 
@@ -24,127 +7,31 @@ var MARKER_OK = 'connect-ok',
 /**
  * Shows connection preview during connect.
  *
- * @param {Canvas} canvas
- * @param {ElementFactory} elementFactory
- * @param {EventBus} eventBus
- * @param {GraphicsFactory} graphicsFactory
  * @param {didi.Injector} injector
+ * @param {EventBus} eventBus
+ * @param {Canvas} canvas
  */
-export default function ConnectPreview(
-    canvas,
-    elementFactory,
-    eventBus,
-    graphicsFactory,
-    injector
-) {
-  var self = this;
-
-  this._elementFactory = elementFactory;
-
-  var connectionDocking = injector.get('connectionDocking', false),
-      layouter = injector.get('layouter', false);
-
-  /**
-   * Add and return preview graphics.
-   *
-   * @returns {SVGElement}
-   */
-  function createConnectionPreviewGfx() {
-    var gfx = svgCreate('g');
-
-    svgAttr(gfx, {
-      pointerEvents: 'none'
-    });
-
-    svgClasses(gfx).add('djs-dragger');
-
-    svgAppend(canvas.getDefaultLayer(), gfx);
-
-    return gfx;
-  }
-
-  /**
-   * Return cropped waypoints.
-   *
-   * @param {Point} start
-   * @param {Point} end
-   * @param {djs.model.shape} source
-   * @param {djs.model.shape} target
-   *
-   * @returns {Array}
-   */
-  function cropWaypoints(start, end, source, target) {
-    var sourcePath = graphicsFactory.getShapePath(source),
-        targetPath = target && graphicsFactory.getShapePath(target),
-        connectionPath = graphicsFactory.getConnectionPath({ waypoints: [ start, end ] });
-
-    start = getElementLineIntersection(sourcePath, connectionPath, true) || start;
-    end = (target && getElementLineIntersection(targetPath, connectionPath, false)) || end;
-
-    return [ start, end ];
-  }
+export default function ConnectPreview(injector, eventBus, canvas) {
+  var connectionPreview = injector.get('connectionPreview', false);
 
   eventBus.on('connect.move', function(event) {
     var context = event.context,
         source = context.source,
         target = context.target,
-        connectionPreviewGfx = context.connectionPreviewGfx,
-        canConnect = context.canExecute,
-        getConnection = context.getConnection,
-        sourcePosition = context.sourcePosition,
-        connection,
-        waypoints;
+        canConnect = context.canExecute;
 
     var endPosition = {
       x: event.x,
       y: event.y
     };
 
-    if (!connectionPreviewGfx) {
-      connectionPreviewGfx = context.connectionPreviewGfx = createConnectionPreviewGfx();
-    }
 
-    svgClear(connectionPreviewGfx);
-
-    if (!getConnection) {
-      getConnection = context.getConnection = cacheReturnValues(function(canConnect, source, target) {
-        return self.getConnection(canConnect, source, target);
+    if (connectionPreview) {
+      connectionPreview.drawPreview(context, canConnect, {
+        source: source,
+        target: target,
+        connectionEnd: endPosition
       });
-    }
-
-    if (canConnect) {
-      connection = getConnection(canConnect, source, target);
-    }
-
-    if (connection) {
-      if (layouter) {
-        connection.waypoints = [];
-
-        connection.waypoints = layouter.layoutConnection(connection, {
-          source: source,
-          target: target,
-          connectionEnd: endPosition
-        });
-      } else {
-        connection.waypoints = [
-          { x: source.x + source.width / 2, y: source.y + source.height / 2 },
-          endPosition
-        ];
-      }
-
-      if (connectionDocking) {
-        connection.waypoints = connectionDocking.getCroppedWaypoints(connection, source, target);
-      }
-
-      graphicsFactory.drawConnection(connectionPreviewGfx, connection);
-    } else {
-
-      // fall back to noop connection
-      waypoints = cropWaypoints(sourcePosition, endPosition, source, target);
-
-      connection = createNoopConnection(waypoints[0], waypoints[1]);
-
-      svgAppend(connectionPreviewGfx, connection);
     }
   });
 
@@ -171,101 +58,14 @@ export default function ConnectPreview(
   });
 
   eventBus.on('connect.cleanup', function(event) {
-    var context = event.context;
-
-    if (context.connectionPreviewGfx) {
-      svgRemove(context.connectionPreviewGfx);
+    if (connectionPreview) {
+      connectionPreview.cleanUp(event.context);
     }
   });
 }
-
-/**
- * Get connection that connect source and target once connect is finished.
- *
- * @param {djs.model.shape} source
- * @param {djs.model.shape} target
- * @param {Object|boolean} canConnect
- *
- * @returns {djs.model.connection}
- */
-ConnectPreview.prototype.getConnection = function(canConnect, source, target) {
-  var attrs = ensureConnectionAttrs(canConnect);
-
-  return this._elementFactory.createConnection(attrs);
-};
 
 ConnectPreview.$inject = [
-  'canvas',
-  'elementFactory',
+  'injector',
   'eventBus',
-  'graphicsFactory',
-  'injector'
+  'canvas'
 ];
-
-// helpers //////////
-
-/**
- * Returns function that returns cached return values referenced by stringfied first argument.
- *
- * @param {Function} fn
- *
- * @return {Function}
- */
-function cacheReturnValues(fn) {
-  var returnValues = {};
-
-  /**
-   * Return cached return value referenced by stringified first argument.
-   *
-   * @returns {*}
-   */
-  return function(firstArgument) {
-    var key = JSON.stringify(firstArgument);
-
-    var returnValue = returnValues[key];
-
-    if (!returnValue) {
-      returnValue = returnValues[key] = fn.apply(null, arguments);
-    }
-
-    return returnValue;
-  };
-}
-
-/**
- * Create and return simple connection.
- *
- * @param {Point} start
- * @param {Point} end
- *
- * @returns {SVGElement}
- */
-function createNoopConnection(start, end) {
-  var connection = svgCreate('polyline');
-
-  svgAttr(connection, {
-    'stroke': '#333',
-    'strokeDasharray': [ 1 ],
-    'strokeWidth': 2,
-    'pointer-events': 'none'
-  });
-
-  svgAttr(connection, { 'points': [ start.x, start.y, end.x, end.y ] });
-
-  return connection;
-}
-
-/**
- * Ensure connection attributes is object.
- *
- * @param {Object|boolean} canConnect
- *
- * @returns {Object}
- */
-function ensureConnectionAttrs(canConnect) {
-  if (isObject(canConnect)) {
-    return canConnect;
-  } else {
-    return {};
-  }
-}

--- a/lib/features/connection-preview/ConnectionPreview.js
+++ b/lib/features/connection-preview/ConnectionPreview.js
@@ -1,0 +1,291 @@
+import {
+  append as svgAppend,
+  attr as svgAttr,
+  classes as svgClasses,
+  create as svgCreate,
+  remove as svgRemove,
+  clear as svgClear
+} from 'tiny-svg';
+
+import {
+  isObject
+} from 'min-dash';
+
+import {
+  getElementLineIntersection,
+  getMid
+} from '../../layout/LayoutUtil';
+
+/**
+ * Draws connection preview. Optionally, this can use layouter and connection docking to draw
+ * better looking previews.
+ *
+ * @param {didi.Injector} injector
+ * @param {Canvas} canvas
+ * @param {GraphicsFactory} graphicsFactory
+ * @param {ElementFactory} elementFactory
+ */
+export default function ConnectionPreview(
+    injector,
+    canvas,
+    graphicsFactory,
+    elementFactory
+) {
+  this._canvas = canvas;
+  this._graphicsFactory = graphicsFactory;
+  this._elementFactory = elementFactory;
+
+  // optional components
+  this._connectionDocking = injector.get('connectionDocking', false);
+  this._layouter = injector.get('layouter', false);
+}
+
+ConnectionPreview.$inject = [
+  'injector',
+  'canvas',
+  'graphicsFactory',
+  'elementFactory'
+];
+
+/**
+ * Draw connection preview.
+ *
+ * Provide at least one of <source, connectionStart> and <target, connectionEnd> to create a preview.
+ * In the clean up stage, call `connectionPreview#cleanUp` with the context to remove preview.
+ *
+ * @param {Object} context
+ * @param {Object|boolean} canConnect
+ * @param {Object} hints
+ * @param {djs.model.shape} [hints.source] source element
+ * @param {djs.model.shape} [hints.target] target element
+ * @param {Point} [hints.connectionStart] connection preview start
+ * @param {Point} [hints.connectionEnd] connection preview end
+ * @param {Array<Point>} [hints.waypoints] provided waypoints for preview
+ * @param {boolean} [hints.noLayout] true if preview should not be laid out
+ * @param {boolean} [hints.noNoop] true if simple connection should not be drawn
+ */
+ConnectionPreview.prototype.drawPreview = function(context, canConnect, hints) {
+
+  hints = hints || {};
+
+  var connectionPreviewGfx = context.connectionPreviewGfx,
+      getConnection = context.getConnection,
+      source = hints.source,
+      target = hints.target,
+      waypoints = hints.waypoints,
+      connectionStart = hints.connectionStart,
+      connectionEnd = hints.connectionEnd,
+      noLayout = hints.noLayout,
+      noNoop = hints.noNoop,
+      connection;
+
+  var self = this;
+
+  if (!connectionPreviewGfx) {
+    connectionPreviewGfx = context.connectionPreviewGfx = this.createConnectionPreviewGfx();
+  }
+
+  svgClear(connectionPreviewGfx);
+
+  if (!getConnection) {
+    getConnection = context.getConnection = cacheReturnValues(function(canConnect, source, target) {
+      return self.getConnection(canConnect, source, target);
+    });
+  }
+
+  if (canConnect !== false) {
+    connection = getConnection(canConnect, source, target);
+  }
+
+  if (!connection) {
+    !noNoop && this.drawNoopPreview(connectionPreviewGfx, hints);
+    return;
+  }
+
+  connection.waypoints = waypoints || [];
+
+  // optional layout
+  if (this._layouter && !noLayout) {
+    connection.waypoints = this._layouter.layoutConnection(connection, {
+      source: source,
+      target: target,
+      connectionStart: connectionStart,
+      connectionEnd: connectionEnd
+    });
+  }
+
+  // fallback if no waypoints were provided nor created with layouter
+  if (!connection.waypoints || !connection.waypoints.length) {
+    connection.waypoints = [
+      source ? getMid(source) : connectionStart,
+      target ? getMid(target) : connectionEnd
+    ];
+  }
+
+  // optional cropping
+  if (this._connectionDocking && (source || target)) {
+    connection.waypoints = this._connectionDocking.getCroppedWaypoints(connection, source, target);
+  }
+
+  this._graphicsFactory.drawConnection(connectionPreviewGfx, connection);
+};
+
+/**
+ * Draw simple connection between source and target or provided points.
+ *
+ * @param {SVGElement} connectionPreviewGfx container for the connection
+ * @param {Object} hints
+ * @param {djs.model.shape} [hints.source] source element
+ * @param {djs.model.shape} [hints.target] target element
+ * @param {Point} [hints.connectionStart] required if source is not provided
+ * @param {Point} [hints.connectionEnd] required if target is not provided
+ */
+ConnectionPreview.prototype.drawNoopPreview = function(connectionPreviewGfx, hints) {
+  var source = hints.source,
+      target = hints.target,
+      start = hints.connectionStart || getMid(source),
+      end = hints.connectionEnd || getMid(target);
+
+  var waypoints = this.cropWaypoints(start, end, source, target);
+
+  var connection = this.createNoopConnection(waypoints[0], waypoints[1]);
+
+  svgAppend(connectionPreviewGfx, connection);
+};
+
+/**
+ * Return cropped waypoints.
+ *
+ * @param {Point} start
+ * @param {Point} end
+ * @param {djs.model.shape} source
+ * @param {djs.model.shape} target
+ *
+ * @returns {Array}
+ */
+ConnectionPreview.prototype.cropWaypoints = function(start, end, source, target) {
+  var graphicsFactory = this._graphicsFactory,
+      sourcePath = source && graphicsFactory.getShapePath(source),
+      targetPath = target && graphicsFactory.getShapePath(target),
+      connectionPath = graphicsFactory.getConnectionPath({ waypoints: [ start, end ] });
+
+  start = (source && getElementLineIntersection(sourcePath, connectionPath, true)) || start;
+  end = (target && getElementLineIntersection(targetPath, connectionPath, false)) || end;
+
+  return [ start, end ];
+};
+
+/**
+ * Remove connection preview container if it exists.
+ *
+ * @param {Object} [context]
+ * @param {SVGElement} [context.connectionPreviewGfx] preview container
+ */
+ConnectionPreview.prototype.cleanUp = function(context) {
+  if (context && context.connectionPreviewGfx) {
+    svgRemove(context.connectionPreviewGfx);
+  }
+};
+
+/**
+ * Get connection that connects source and target.
+ *
+ * @param {Object|boolean} canConnect
+ * @param {djs.model.shape} source
+ * @param {djs.model.shape} target
+ *
+ * @returns {djs.model.connection}
+ */
+ConnectionPreview.prototype.getConnection = function(canConnect, source, target) {
+  var attrs = ensureConnectionAttrs(canConnect);
+
+  return this._elementFactory.createConnection(attrs);
+};
+
+
+/**
+ * Add and return preview graphics.
+ *
+ * @returns {SVGElement}
+ */
+ConnectionPreview.prototype.createConnectionPreviewGfx = function() {
+  var gfx = svgCreate('g');
+
+  svgAttr(gfx, {
+    pointerEvents: 'none'
+  });
+
+  svgClasses(gfx).add('djs-dragger');
+
+  svgAppend(this._canvas.getDefaultLayer(), gfx);
+
+  return gfx;
+};
+
+/**
+ * Create and return simple connection.
+ *
+ * @param {Point} start
+ * @param {Point} end
+ *
+ * @returns {SVGElement}
+ */
+ConnectionPreview.prototype.createNoopConnection = function(start, end) {
+  var connection = svgCreate('polyline');
+
+  svgAttr(connection, {
+    'stroke': '#333',
+    'strokeDasharray': [ 1 ],
+    'strokeWidth': 2,
+    'pointer-events': 'none'
+  });
+
+  svgAttr(connection, { 'points': [ start.x, start.y, end.x, end.y ] });
+
+  return connection;
+};
+
+// helpers //////////
+
+/**
+ * Returns function that returns cached return values referenced by stringified first argument.
+ *
+ * @param {Function} fn
+ *
+ * @return {Function}
+ */
+function cacheReturnValues(fn) {
+  var returnValues = {};
+
+  /**
+   * Return cached return value referenced by stringified first argument.
+   *
+   * @returns {*}
+   */
+  return function(firstArgument) {
+    var key = JSON.stringify(firstArgument);
+
+    var returnValue = returnValues[key];
+
+    if (!returnValue) {
+      returnValue = returnValues[key] = fn.apply(null, arguments);
+    }
+
+    return returnValue;
+  };
+}
+
+/**
+ * Ensure connection attributes is object.
+ *
+ * @param {Object|boolean} canConnect
+ *
+ * @returns {Object}
+ */
+function ensureConnectionAttrs(canConnect) {
+  if (isObject(canConnect)) {
+    return canConnect;
+  } else {
+    return {};
+  }
+}

--- a/lib/features/connection-preview/index.js
+++ b/lib/features/connection-preview/index.js
@@ -1,0 +1,6 @@
+import ConnectionPreview from './ConnectionPreview';
+
+export default {
+  __init__: [ 'connectionPreview' ],
+  connectionPreview: [ 'type', ConnectionPreview ]
+};

--- a/lib/features/create/CreateConnectPreview.js
+++ b/lib/features/create/CreateConnectPreview.js
@@ -1,191 +1,49 @@
-import {
-  append as svgAppend,
-  attr as svgAttr,
-  classes as svgClasses,
-  create as svgCreate,
-  remove as svgRemove,
-  clear as svgClear
-} from 'tiny-svg';
-
-import {
-  isObject
-} from 'min-dash';
-
-
 var LOW_PRIORITY = 740;
 
 
 /**
  * Shows connection preview during create.
  *
- * @param {didi.Injector} injector
  * @param {EventBus} eventBus
- * @param {Canvas} canvas
- * @param {GraphicsFactory} graphicsFactory
- * @param {ElementFactory} elementFactory
+ * @param {ConnectionPreview} connectionPreview
  */
-export default function CreateConnectPreview(
-    canvas,
-    elementFactory,
-    eventBus,
-    graphicsFactory,
-    injector
-) {
-  var self = this;
-
-  this._elementFactory = elementFactory;
-
-  var connectionDocking = injector.get('connectionDocking', false),
-      layouter = injector.get('layouter', false);
-
-  /**
-   * Add and return preview graphics.
-   *
-   * @returns {SVGElement}
-   */
-  function createConnectionPreviewGfx() {
-    var gfx = svgCreate('g');
-
-    svgAttr(gfx, {
-      pointerEvents: 'none'
-    });
-
-    svgClasses(gfx).add('djs-dragger');
-
-    svgAppend(canvas.getDefaultLayer(), gfx);
-
-    return gfx;
-  }
+export default function CreateConnectPreview(injector, eventBus) {
+  var connectionPreview = injector.get('connectionPreview', false);
 
   eventBus.on('create.move', LOW_PRIORITY, function(event) {
     var context = event.context,
         source = context.source,
         shape = context.shape,
-        connectionPreviewGfx = context.connectionPreviewGfx,
         canExecute = context.canExecute,
-        canConnect = canExecute && canExecute.connect,
-        getConnection = context.getConnection,
-        connection;
+        canConnect = canExecute && canExecute.connect;
 
-    if (!connectionPreviewGfx) {
-      connectionPreviewGfx = context.connectionPreviewGfx = createConnectionPreviewGfx();
-    }
-
-    svgClear(connectionPreviewGfx);
-
-    if (!getConnection) {
-      getConnection = context.getConnection = cacheReturnValues(function(canConnect, source, shape) {
-        return self.getConnection(canConnect, source, shape);
-      });
-    }
-
-    if (canConnect) {
-      connection = getConnection(canConnect, source, shape);
-    }
-
-    if (!connection) {
+    // don't draw connection preview if not appending a shape
+    if (!connectionPreview || !source) {
       return;
     }
 
+    // place shape's center on cursor
     shape.x = Math.round(event.x - shape.width / 2);
     shape.y = Math.round(event.y - shape.height / 2);
 
-    if (layouter) {
-      connection.waypoints = [];
-
-      connection.waypoints = layouter.layoutConnection(connection, {
-        source: source,
-        target: shape
-      });
-    } else {
-      connection.waypoints = [
-        { x: source.x + source.width / 2, y: source.y + source.height / 2 },
-        { x: event.x, y: event.y }
-      ];
-    }
-
-    if (connectionDocking) {
-      connection.waypoints = connectionDocking.getCroppedWaypoints(connection, source, shape);
-    }
-
-    graphicsFactory.drawConnection(connectionPreviewGfx, connection);
+    connectionPreview.drawPreview(context, canConnect, {
+      source: source,
+      target: shape,
+      waypoints: [],
+      noNoop: true
+    });
   });
 
 
   eventBus.on('create.cleanup', function(event) {
-    var context = event.context;
-
-    if (context.connectionPreviewGfx) {
-      svgRemove(context.connectionPreviewGfx);
+    if (connectionPreview) {
+      connectionPreview.cleanUp(event.context);
     }
   });
 
 }
 
 CreateConnectPreview.$inject = [
-  'canvas',
-  'elementFactory',
-  'eventBus',
-  'graphicsFactory',
-  'injector'
+  'injector',
+  'eventBus'
 ];
-
-/**
- * Get connection that connect source and target once connect is finished.
- *
- * @param {djs.model.shape} source
- * @param {djs.model.shape} target
- * @param {Object|boolean} canConnect
- *
- * @returns {djs.model.connection}
- */
-CreateConnectPreview.prototype.getConnection = function(canConnect, source, target) {
-  var attrs = ensureConnectionAttrs(canConnect);
-
-  return this._elementFactory.createConnection(attrs);
-};
-
-// helpers //////////
-
-/**
- * Returns function that returns cached return values referenced by stringfied first argument.
- *
- * @param {Function} fn
- *
- * @return {Function}
- */
-function cacheReturnValues(fn) {
-  var returnValues = {};
-
-  /**
-   * Return cached return value referenced by stringified first argument.
-   *
-   * @returns {*}
-   */
-  return function(firstArgument) {
-    var key = JSON.stringify(firstArgument);
-
-    var returnValue = returnValues[key];
-
-    if (!returnValue) {
-      returnValue = returnValues[key] = fn.apply(null, arguments);
-    }
-
-    return returnValue;
-  };
-}
-
-/**
- * Ensure connection attributes is object.
- *
- * @param {Object|boolean} canConnect
- *
- * @returns {Object}
- */
-function ensureConnectionAttrs(canConnect) {
-  if (isObject(canConnect)) {
-    return canConnect;
-  } else {
-    return {};
-  }
-}

--- a/test/spec/connection-preview/ConnectionPreviewSpec.js
+++ b/test/spec/connection-preview/ConnectionPreviewSpec.js
@@ -3,6 +3,8 @@ import {
   inject
 } from 'test/TestHelper';
 
+import TestContainer from 'mocha-test-container-support';
+
 import modelingModule from 'lib/features/modeling';
 import connectionPreviewModule from 'lib/features/connection-preview';
 
@@ -66,6 +68,12 @@ describe('features/connection-preview', function() {
 
   beforeEach(inject(setupDiagram));
 
+  var testContainer;
+
+  beforeEach(function() {
+    testContainer = TestContainer.get(this);
+  });
+
 
   describe('basics', function() {
 
@@ -81,7 +89,7 @@ describe('features/connection-preview', function() {
       // when
       connectionPreview.drawPreview(context, true, hints);
 
-      var preview = domQuery('.djs-dragger');
+      var preview = domQuery('.djs-dragger', testContainer);
 
       // then
       expect(preview).to.exist;
@@ -101,7 +109,7 @@ describe('features/connection-preview', function() {
       // when
       connectionPreview.drawPreview(context, true, hints);
 
-      var preview = domQuery('.djs-dragger');
+      var preview = domQuery('.djs-dragger', testContainer);
 
       // then
       expect(preview).to.exist;
@@ -122,7 +130,7 @@ describe('features/connection-preview', function() {
       connectionPreview.drawPreview(context, true, hints);
       connectionPreview.cleanUp(context);
 
-      var preview = domQuery('.djs-dragger');
+      var preview = domQuery('.djs-dragger', testContainer);
 
       // then
       expect(preview).not.to.exist;
@@ -145,7 +153,7 @@ describe('features/connection-preview', function() {
       // when
       connectionPreview.drawPreview(context, false, hints);
 
-      var preview = domQuery('.djs-dragger');
+      var preview = domQuery('.djs-dragger', testContainer);
 
       // then
       expect(preview).to.exist;
@@ -166,7 +174,7 @@ describe('features/connection-preview', function() {
       // when
       connectionPreview.drawPreview(context, false, hints);
 
-      var preview = domQuery('.djs-dragger');
+      var preview = domQuery('.djs-dragger', testContainer);
 
       // then
       expect(preview).to.exist;

--- a/test/spec/connection-preview/ConnectionPreviewSpec.js
+++ b/test/spec/connection-preview/ConnectionPreviewSpec.js
@@ -1,0 +1,290 @@
+import {
+  bootstrapDiagram,
+  inject
+} from 'test/TestHelper';
+
+import modelingModule from 'lib/features/modeling';
+import connectionPreviewModule from 'lib/features/connection-preview';
+
+import BaseLayouter from 'lib/layout/BaseLayouter';
+import CroppingConnectionDocking from 'lib/layout/CroppingConnectionDocking';
+
+import {
+  query as domQuery
+} from 'min-dom';
+import { isDefined } from 'min-dash';
+
+
+var testModules = [
+  modelingModule,
+  connectionPreviewModule
+];
+
+
+describe('features/connection-preview', function() {
+
+  var rootShape, shape1, shape2, shape3;
+
+  function setupDiagram(elementFactory, canvas) {
+
+    rootShape = elementFactory.createRoot({
+      id: 'root'
+    });
+
+    canvas.setRootElement(rootShape);
+
+    shape1 = elementFactory.createShape({
+      id: 'shape1',
+      type: 'A',
+      x: 100, y: 100, width: 300, height: 300
+    });
+
+    canvas.addShape(shape1, rootShape);
+
+    shape2 = elementFactory.createShape({
+      id: 'shape2',
+      type: 'A',
+      x: 500, y: 100, width: 100, height: 100
+    });
+
+    canvas.addShape(shape2, rootShape);
+
+    shape3 = elementFactory.createShape({
+      id: 'shape3',
+      type: 'B',
+      x: 500, y: 400, width: 100, height: 100
+    });
+
+    canvas.addShape(shape3, rootShape);
+
+  }
+
+
+  beforeEach(bootstrapDiagram({
+    modules: testModules
+  }));
+
+  beforeEach(inject(setupDiagram));
+
+
+  describe('basics', function() {
+
+    it('should display preview between shapes', inject(function(connectionPreview) {
+
+      // given
+      var context = {},
+          hints = {
+            source: shape1,
+            target: shape2
+          };
+
+      // when
+      connectionPreview.drawPreview(context, true, hints);
+
+      var preview = domQuery('.djs-dragger');
+
+      // then
+      expect(preview).to.exist;
+      expect(preview.childNodes).to.have.lengthOf(1);
+    }));
+
+
+    it('should display preview between points', inject(function(connectionPreview) {
+
+      // given
+      var context = {},
+          hints = {
+            connectionStart: { x: 0, y: 0 },
+            connectionEnd: { x: 100, y: 100 }
+          };
+
+      // when
+      connectionPreview.drawPreview(context, true, hints);
+
+      var preview = domQuery('.djs-dragger');
+
+      // then
+      expect(preview).to.exist;
+      expect(preview.childNodes).to.have.lengthOf(1);
+    }));
+
+
+    it('should remove preview', inject(function(connectionPreview) {
+
+      // given
+      var context = {},
+          hints = {
+            source: shape1,
+            target: shape2
+          };
+
+      // when
+      connectionPreview.drawPreview(context, true, hints);
+      connectionPreview.cleanUp(context);
+
+      var preview = domQuery('.djs-dragger');
+
+      // then
+      expect(preview).not.to.exist;
+    }));
+
+  });
+
+
+  describe('noop connection', function() {
+
+    it('should display noop connection by default preview', inject(function(connectionPreview) {
+
+      // given
+      var context = {},
+          hints = {
+            source: shape1,
+            target: shape2
+          };
+
+      // when
+      connectionPreview.drawPreview(context, false, hints);
+
+      var preview = domQuery('.djs-dragger');
+
+      // then
+      expect(preview).to.exist;
+      expect(preview.childNodes).to.have.lengthOf(1);
+    }));
+
+
+    it('should not display noop connection if disabled via config', inject(function(connectionPreview) {
+
+      // given
+      var context = {},
+          hints = {
+            source: shape1,
+            target: shape2,
+            noNoop: true
+          };
+
+      // when
+      connectionPreview.drawPreview(context, false, hints);
+
+      var preview = domQuery('.djs-dragger');
+
+      // then
+      expect(preview).to.exist;
+      expect(preview.childNodes).to.have.lengthOf(0);
+    }));
+
+  });
+
+
+  describe('connection cropping', function() {
+
+    beforeEach(bootstrapDiagram({
+      modules: testModules.concat({
+        connectionDocking: [ 'type', CroppingConnectionDocking ]
+      })
+    }));
+
+    beforeEach(inject(setupDiagram));
+
+
+    it('should crop the connection preview', inject(function(connectionPreview) {
+
+      // given
+      var context = {},
+          hints = {
+            source: shape1,
+            target: shape2
+          };
+
+      // when
+      connectionPreview.drawPreview(context, true, hints);
+
+      var connection = context.getConnection(true),
+          waypoints = connection.waypoints;
+
+      // then
+      expect(waypoints).to.have.lengthOf(2);
+      expect(waypoints[0]).to.have.property('original');
+      expect(waypoints[1]).to.have.property('original');
+    }));
+
+
+    it('should still work when connecting two points', inject(function(connectionPreview) {
+
+      // given
+      var context = {},
+          hints = {
+            connectionStart: { x: 0, y: 0 },
+            connectionEnd: { x: 100, y: 100 }
+          };
+
+      // when
+      connectionPreview.drawPreview(context, true, hints);
+
+      var connection = context.getConnection(true),
+          waypoints = connection.waypoints;
+
+      // then
+      expect(waypoints).to.have.lengthOf(2);
+      expect(waypoints.every(isDefined)).to.be.true;
+    }));
+
+  });
+
+
+  describe('layouting', function() {
+
+    beforeEach(bootstrapDiagram({
+      modules: testModules.concat({
+        layouter: [ 'type', BaseLayouter ]
+      })
+    }));
+
+    beforeEach(inject(setupDiagram));
+
+
+    it('should layout the connection preview', inject(function(layouter, connectionPreview) {
+
+      // given
+      var context = {},
+          hints = {
+            source: shape1,
+            target: shape2
+          };
+
+      // when
+      connectionPreview.drawPreview(context, true, hints);
+
+      var connection = context.getConnection(true),
+          waypoints = connection.waypoints;
+
+      // then
+      expect(waypoints).to.have.lengthOf(2);
+      expect(waypoints.every(isDefined)).to.be.true;
+    }));
+
+
+    it('should not layout connection preview if disabled', inject(function(connectionPreview) {
+
+      // given
+      var context = {},
+          hints = {
+            source: shape1,
+            target: shape2,
+            noLayout: true
+          };
+
+      // when
+      connectionPreview.drawPreview(context, true, hints);
+
+      var connection = context.getConnection(true),
+          waypoints = connection.waypoints;
+
+      // then
+      expect(waypoints).to.have.lengthOf(2);
+      expect(waypoints.every(isDefined)).to.be.true;
+    }));
+
+  });
+
+});

--- a/test/spec/features/bendpoints/BendpointsMoveSpec.js
+++ b/test/spec/features/bendpoints/BendpointsMoveSpec.js
@@ -360,6 +360,27 @@ describe('features/bendpoints - move', function() {
   });
 
 
+  describe('bendpoint snapping', function() {
+
+    it('should snap to the shape center', inject(function(canvas, bendpointMove, dragging) {
+
+      // given
+      bendpointMove.start(canvasEvent({ x: 500, y: 500 }), connection, 2);
+      dragging.hover({ element: shape2, gfx: canvas.getGraphics(shape2) });
+      dragging.move(canvasEvent({ x: 543, y: 143 }));
+
+      // when
+      dragging.end();
+
+      // then
+      var waypoints = connection.waypoints;
+
+      expect(waypoints[waypoints.length - 1]).to.eql({ x: 550, y: 150 });
+    }));
+
+  });
+
+
   describe('connection preview', function() {
 
     beforeEach(bootstrapDiagram({

--- a/test/spec/features/connect/ConnectSpec.js
+++ b/test/spec/features/connect/ConnectSpec.js
@@ -14,26 +14,25 @@ import { createCanvasEvent as canvasEvent } from '../../../util/MockEvents';
 import modelingModule from 'lib/features/modeling';
 import rulesModule from './rules';
 import connectModule from 'lib/features/connect';
+import connectionPreviewModule from 'lib/features/connection-preview';
+
+
+var testModules = [
+  modelingModule,
+  connectModule,
+  rulesModule
+];
 
 
 describe('features/connect', function() {
 
-  beforeEach(bootstrapDiagram({
-    modules: [
-      modelingModule,
-      connectModule,
-      rulesModule
-    ]
-  }));
-
-  beforeEach(inject(function(canvas, dragging) {
-    dragging.setOptions({ manual: true });
-  }));
-
-
   var rootShape, shape1, shape2, shape1child, shapeFrame;
 
-  beforeEach(inject(function(elementFactory, canvas) {
+  function setManualDragging(dragging) {
+    dragging.setOptions({ manual: true });
+  }
+
+  function setupDiagram(elementFactory, canvas) {
 
     rootShape = elementFactory.createRoot({
       id: 'root'
@@ -71,7 +70,16 @@ describe('features/connect', function() {
     });
 
     canvas.addShape(shapeFrame, rootShape);
+  }
+
+
+  beforeEach(bootstrapDiagram({
+    modules: testModules
   }));
+
+  beforeEach(inject(setManualDragging));
+
+  beforeEach(inject(setupDiagram));
 
 
   describe('behavior', function() {
@@ -261,6 +269,15 @@ describe('features/connect', function() {
 
 
   describe('connection preview', function() {
+
+    beforeEach(bootstrapDiagram({
+      modules: testModules.concat(connectionPreviewModule)
+    }));
+
+    beforeEach(inject(setManualDragging));
+
+    beforeEach(inject(setupDiagram));
+
 
     it('should display preview when hovering', inject(
       function(connect, dragging) {


### PR DESCRIPTION
This unifies connection preview features already implemented in several components (Bendpoints, Create, Connect/GlobalConnect) within ConnectionPreview. 

Related https://github.com/bpmn-io/bpmn-js/issues/744