### PR TITLE
Snap During Resize

### DIFF
--- a/lib/features/create/Create.js
+++ b/lib/features/create/Create.js
@@ -19,6 +19,8 @@ import {
   translate
 } from '../../util/SvgTransformUtil';
 
+import { Shape } from '../../model';
+
 
 /**
  * Adds the ability to create new shapes via drag and drop.
@@ -165,12 +167,13 @@ export default function Create(
   // event handlers
 
   eventBus.on('create.move', function(event) {
-
     var context = event.context,
         hover = event.hover,
         shape = context.shape,
         source = context.source,
         canExecute;
+
+    ensureConstraints(event);
 
     var position = {
       x: event.x,
@@ -224,15 +227,18 @@ export default function Create(
         target = context.target,
         canExecute = context.canExecute,
         attach = canExecute && canExecute.attach,
-        connect = canExecute && canExecute.connect,
-        position = {
-          x: event.x,
-          y: event.y
-        };
+        connect = canExecute && canExecute.connect;
 
     if (!canExecute) {
       return false;
     }
+
+    ensureConstraints(event);
+
+    var position = {
+      x: event.x,
+      y: event.y
+    };
 
     if (connect) {
       // invoke append if connect is set via rules
@@ -268,18 +274,28 @@ export default function Create(
 
   // API
 
-  this.start = function(event, shape, source) {
+  this.start = function(event, shape, sourceOrContext) {
+    var context;
+
+    if (!sourceOrContext || sourceOrContext instanceof Shape) {
+      context = {
+        hints: {},
+        shape: shape,
+        source: sourceOrContext
+      };
+    } else {
+      context = assign({
+        hints: {},
+        shape: shape
+      }, sourceOrContext);
+    }
 
     dragging.init(event, 'create', {
       cursor: 'grabbing',
       autoActivate: true,
       data: {
         shape: shape,
-        context: {
-          shape: shape,
-          source: source,
-          hints: {}
-        }
+        context: context
       }
     });
   };
@@ -294,3 +310,30 @@ Create.$inject = [
   'styles',
   'graphicsFactory'
 ];
+
+// helpers //////////
+
+function ensureConstraints(event) {
+  var context = event.context,
+      createConstraints = context.createConstraints;
+
+  if (!createConstraints) {
+    return;
+  }
+
+  if (createConstraints.left) {
+    event.x = Math.max(event.x, createConstraints.left);
+  }
+
+  if (createConstraints.right) {
+    event.x = Math.min(event.x, createConstraints.right);
+  }
+
+  if (createConstraints.top) {
+    event.y = Math.max(event.y, createConstraints.top);
+  }
+
+  if (createConstraints.bottom) {
+    event.y = Math.min(event.y, createConstraints.bottom);
+  }
+}

--- a/lib/features/grid-snapping/GridSnapping.js
+++ b/lib/features/grid-snapping/GridSnapping.js
@@ -174,30 +174,38 @@ GridSnapping.$inject = [
  *
  * @param {Object} event
  * @param {Object} event.context
- * @param {Object} [event.context.resizeConstraints]
- * @param {number} [event.context.resizeConstraints.min]
- * @param {number} [event.context.resizeConstraints.max]
  * @param {string} axis
  *
  * @returns {Object}
  */
 function getSnapConstraints(event, axis) {
   var context = event.context,
-      resizeConstraints = context.resizeConstraints;
-
-  if (!resizeConstraints) {
-    return null;
-  }
+      createConstraints = context.createConstraints,
+      resizeConstraints = context.resizeConstraints || {};
 
   var direction = context.direction;
 
+  var snapConstraints = null;
+
+  // create
+  if (createConstraints) {
+    snapConstraints = {};
+
+    if (isHorizontal(axis)) {
+      snapConstraints.min = createConstraints.left;
+      snapConstraints.max = createConstraints.right;
+    } else {
+      snapConstraints.min = createConstraints.top;
+      snapConstraints.max = createConstraints.bottom;
+    }
+  }
+
+  // resize
   var minResizeConstraints = resizeConstraints.min,
       maxResizeConstraints = resizeConstraints.max;
 
-  var snapConstraints = {};
-
-  // resize
   if (minResizeConstraints) {
+    snapConstraints = {};
 
     if (isHorizontal(axis)) {
 
@@ -219,6 +227,7 @@ function getSnapConstraints(event, axis) {
   }
 
   if (maxResizeConstraints) {
+    snapConstraints = {};
 
     if (isHorizontal(axis)) {
 

--- a/lib/features/move/Move.js
+++ b/lib/features/move/Move.js
@@ -149,6 +149,12 @@ export default function MoveEvents(
     delta.x = round(delta.x);
     delta.y = round(delta.y);
 
+    if (delta.x === 0 && delta.y === 0) {
+
+      // didn't move
+      return;
+    }
+
     modeling.moveElements(shapes, delta, context.target, {
       primaryShape: context.shape,
       attach: isAttach

--- a/lib/features/resize/Resize.js
+++ b/lib/features/resize/Resize.js
@@ -122,9 +122,16 @@ export default function Resize(eventBus, rules, modeling, dragging) {
         newBounds = context.newBounds;
 
     if (canExecute) {
+
       // ensure we have actual pixel values for new bounds
       // (important when zoom level was > 1 during move)
       newBounds = roundBounds(newBounds);
+
+      if (!boundsChanged(shape, newBounds)) {
+
+        // no resize necessary
+        return;
+      }
 
       // perform the actual resize
       modeling.resizeShape(shape, newBounds);
@@ -230,3 +237,12 @@ Resize.$inject = [
   'modeling',
   'dragging'
 ];
+
+// helpers //////////
+
+function boundsChanged(shape, newBounds) {
+  return shape.x !== newBounds.x ||
+    shape.y !== newBounds.y ||
+    shape.width !== newBounds.width ||
+    shape.height !== newBounds.height;
+}

--- a/lib/features/snapping/CreateMoveSnapping.js
+++ b/lib/features/snapping/CreateMoveSnapping.js
@@ -1,0 +1,194 @@
+import SnapContext from './SnapContext';
+
+import {
+  bottomRight,
+  getChildren,
+  isSnapped,
+  mid,
+  topLeft
+} from './SnapUtil';
+
+import { isCmd } from '../keyboard/KeyboardUtil';
+
+import {
+  forEach,
+  isNumber
+} from 'min-dash';
+
+var HIGHER_PRIORITY = 1250;
+
+
+/**
+ * Snap during create and move.
+ *
+ * @param {EventBus} eventBus
+ * @param {Snapping} snapping
+ */
+export default function CreateMoveSnapping(eventBus, snapping) {
+  var self = this;
+
+  eventBus.on([
+    'create.start',
+    'shape.move.start'
+  ], function(event) {
+    self.initSnap(event);
+  });
+
+  eventBus.on([
+    'create.move',
+    'create.end',
+    'shape.move.move',
+    'shape.move.end'
+  ], HIGHER_PRIORITY, function(event) {
+    var context = event.context,
+        shape = context.shape,
+        snapContext = context.snapContext,
+        target = context.target;
+
+    if (event.originalEvent && isCmd(event.originalEvent)) {
+      return;
+    }
+
+    if (isSnapped(event) || !target) {
+      return;
+    }
+
+    var snapPoints = snapContext.pointsForTarget(target);
+
+    if (!snapPoints.initialized) {
+      snapPoints = self.addSnapTargetPoints(snapPoints, shape, target);
+
+      snapPoints.initialized = true;
+    }
+
+    snapping.snap(event, snapPoints);
+  });
+
+  eventBus.on([
+    'create.cleanup',
+    'shape.move.cleanup'
+  ], function() {
+    snapping.hide();
+  });
+}
+
+CreateMoveSnapping.$inject = [
+  'eventBus',
+  'snapping'
+];
+
+CreateMoveSnapping.prototype.initSnap = function(event) {
+  var context = event.context,
+      shape = context.shape,
+      snapContext = context.snapContext;
+
+  if (!snapContext) {
+    snapContext = context.snapContext = new SnapContext();
+  }
+
+  var shapeMid = mid(shape, event),
+      shapeTopLeft = {
+        x: shapeMid.x - shape.width / 2,
+        y: shapeMid.y - shape.height / 2
+      },
+      shapeBottomRight = {
+        x: shapeMid.x + shape.width / 2,
+        y: shapeMid.y + shape.height / 2
+      };
+
+  snapContext.setSnapOrigin('mid', {
+    x: shapeMid.x - event.x,
+    y: shapeMid.y - event.y
+  });
+
+  // snap labels to mid only
+  if (isLabel(shape)) {
+    return snapContext;
+  }
+
+  snapContext.setSnapOrigin('top-left', {
+    x: shapeTopLeft.x - event.x,
+    y: shapeTopLeft.y - event.y
+  });
+
+  snapContext.setSnapOrigin('bottom-right', {
+    x: shapeBottomRight.x - event.x,
+    y: shapeBottomRight.y - event.y
+  });
+
+  return snapContext;
+};
+
+CreateMoveSnapping.prototype.addSnapTargetPoints = function(snapPoints, shape, target) {
+  var snapTargets = this.getSnapTargets(shape, target);
+
+  forEach(snapTargets, function(snapTarget) {
+
+    // handle labels
+    if (isLabel(snapTarget)) {
+
+      if (isLabel(shape)) {
+        snapPoints.add('mid', mid(snapTarget));
+      }
+
+      return;
+    }
+
+    // handle connections
+    if (isConnection(snapTarget)) {
+
+      // ignore single segment connections
+      if (snapTarget.waypoints.length < 3) {
+        return;
+      }
+
+      // ignore first and last waypoint
+      var waypoints = snapTarget.waypoints.slice(1, -1);
+
+      forEach(waypoints, function(waypoint) {
+        snapPoints.add('mid', waypoint);
+      });
+
+      return;
+    }
+
+    // handle shapes
+    snapPoints.add('mid', mid(snapTarget));
+    snapPoints.add('top-left', topLeft(snapTarget));
+    snapPoints.add('top-left', bottomRight(snapTarget));
+    snapPoints.add('bottom-right', topLeft(snapTarget));
+    snapPoints.add('bottom-right', bottomRight(snapTarget));
+  });
+
+  if (!isNumber(shape.x) || !isNumber(shape.y)) {
+    return snapPoints;
+  }
+
+  snapPoints.add('mid', mid(shape));
+  snapPoints.add('top-left', topLeft(shape));
+  snapPoints.add('top-left', bottomRight(shape));
+  snapPoints.add('bottom-right', topLeft(shape));
+  snapPoints.add('bottom-right', bottomRight(shape));
+
+  return snapPoints;
+};
+
+CreateMoveSnapping.prototype.getSnapTargets = function(shape, target) {
+  return getChildren(target).filter(function(child) {
+    return !isHidden(child);
+  });
+};
+
+// helpers //////////
+
+function isConnection(element) {
+  return !!element.waypoints;
+}
+
+function isHidden(element) {
+  return !!element.hidden;
+}
+
+function isLabel(element) {
+  return !!element.labelTarget;
+}

--- a/lib/features/snapping/ResizeSnapping.js
+++ b/lib/features/snapping/ResizeSnapping.js
@@ -1,0 +1,141 @@
+import SnapContext from './SnapContext';
+
+import {
+  bottomLeft,
+  bottomRight,
+  getChildren,
+  isSnapped,
+  topLeft,
+  topRight
+} from './SnapUtil';
+
+import { isCmd } from '../keyboard/KeyboardUtil';
+
+import { forEach } from 'min-dash';
+
+var HIGHER_PRIORITY = 1250;
+
+
+/**
+ * Snap during resize.
+ *
+ * @param {EventBus} eventBus
+ * @param {Snapping} snapping
+ */
+export default function ResizeSnapping(eventBus, snapping) {
+  var self = this;
+
+  eventBus.on([ 'resize.start' ], function(event) {
+    self.initSnap(event);
+  });
+
+  eventBus.on([
+    'resize.move',
+    'resize.end',
+  ], HIGHER_PRIORITY, function(event) {
+    var context = event.context,
+        shape = context.shape,
+        parent = shape.parent,
+        direction = context.direction,
+        snapContext = context.snapContext;
+
+    if (event.originalEvent && isCmd(event.originalEvent)) {
+      return;
+    }
+
+    if (isSnapped(event)) {
+      return;
+    }
+
+    var snapPoints = snapContext.pointsForTarget(parent);
+
+    if (!snapPoints.initialized) {
+      snapPoints = self.addSnapTargetPoints(snapPoints, shape, parent, direction);
+
+      snapPoints.initialized = true;
+    }
+
+    snapping.snap(event, snapPoints);
+  });
+
+  eventBus.on([ 'resize.cleanup' ], function() {
+    snapping.hide();
+  });
+}
+
+ResizeSnapping.prototype.initSnap = function(event) {
+  var context = event.context,
+      shape = context.shape,
+      direction = context.direction,
+      snapContext = context.snapContext;
+
+  if (!snapContext) {
+    snapContext = context.snapContext = new SnapContext();
+  }
+
+  var snapCorner = getCorner(shape, direction);
+
+  snapContext.setSnapOrigin('corner', {
+    x: snapCorner.x - event.x,
+    y: snapCorner.y - event.y
+  });
+
+  return snapContext;
+};
+
+ResizeSnapping.prototype.addSnapTargetPoints = function(snapPoints, shape, target, direction) {
+  var snapTargets = this.getSnapTargets(shape, target);
+
+  forEach(snapTargets, function(snapTarget) {
+    snapPoints.add('corner', bottomRight(snapTarget));
+    snapPoints.add('corner', topLeft(snapTarget));
+  });
+
+  snapPoints.add('corner', getCorner(shape, direction));
+
+  return snapPoints;
+};
+
+ResizeSnapping.$inject = [
+  'eventBus',
+  'snapping'
+];
+
+ResizeSnapping.prototype.getSnapTargets = function(shape, target) {
+  return getChildren(target).filter(function(child) {
+    return !isAttached(child, shape)
+      && !isConnection(child)
+      && !isHidden(child)
+      && !isLabel(child);
+  });
+};
+
+// helpers //////////
+
+function getCorner(shape, direction) {
+  if (direction === 'nw') {
+    return topLeft(shape);
+  } else if (direction === 'ne') {
+    return topRight(shape);
+  } else if (direction === 'sw') {
+    return bottomLeft(shape);
+  } else {
+    return bottomRight(shape);
+  }
+}
+
+function isAttached(element, host) {
+  return element.host === host;
+}
+
+function isConnection(element) {
+  return !!element.waypoints;
+}
+
+function isHidden(element) {
+  return !!element.hidden;
+}
+
+function isLabel(element) {
+  return !!element.labelTarget;
+}

--- a/lib/features/snapping/SnapContext.js
+++ b/lib/features/snapping/SnapContext.js
@@ -118,7 +118,7 @@ SnapContext.prototype.pointsForTarget = function(target) {
  *
  * @param {Object<String, Array<Point>>} [defaultPoints]
  */
-function SnapPoints(defaultSnaps) {
+export function SnapPoints(defaultSnaps) {
 
   /**
    * Map<String, Map<(x|y), Array<Number>>> mapping snap locations,

--- a/lib/features/snapping/SnapUtil.js
+++ b/lib/features/snapping/SnapUtil.js
@@ -33,6 +33,26 @@ export function topLeft(bounds) {
   };
 }
 
+export function topRight(bounds) {
+  return {
+    x: bounds.x + bounds.width,
+    y: bounds.y
+  };
+}
+
+export function bottomLeft(bounds) {
+  return {
+    x: bounds.x,
+    y: bounds.y + bounds.height
+  };
+}
+
+export function bottomRight(bounds) {
+  return {
+    x: bounds.x + bounds.width,
+    y: bounds.y + bounds.height
+  };
+}
 
 export function mid(bounds, defaultValue) {
 
@@ -43,14 +63,6 @@ export function mid(bounds, defaultValue) {
   return {
     x: round(bounds.x + bounds.width / 2),
     y: round(bounds.y + bounds.height / 2)
-  };
-}
-
-
-export function bottomRight(bounds) {
-  return {
-    x: bounds.x + bounds.width,
-    y: bounds.y + bounds.height
   };
 }
 
@@ -118,4 +130,15 @@ export function setSnapped(event, axis, value) {
   }
 
   return previousValue;
+}
+
+/**
+ * Get children of a shape.
+ *
+ * @param {djs.model.Shape} parent
+ *
+ * @returns {Array<djs.model.Shape|djs.model.Connection>}
+ */
+export function getChildren(parent) {
+  return parent.children || [];
 }

--- a/lib/features/snapping/Snapping.js
+++ b/lib/features/snapping/Snapping.js
@@ -1,19 +1,15 @@
 import {
-  filter,
-  forEach,
+  bind,
   debounce,
-  bind
+  forEach,
+  isNumber,
+  isObject
 } from 'min-dash';
 
-import SnapContext from './SnapContext';
-
 import {
-  mid,
   isSnapped,
   setSnapped
 } from './SnapUtil';
-
-var HIGHER_PRIORITY = 1250;
 
 import {
   append as svgAppend,
@@ -24,97 +20,41 @@ import {
 
 var SNAP_TOLERANCE = 7;
 
+export var SNAP_LINE_HIDE_DELAY = 1000;
+
 
 /**
- * A general purpose snapping component for diagram elements.
+ * Generic snapping feature.
  *
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
  */
-export default function Snapping(eventBus, canvas) {
-
+export default function Snapping(canvas) {
   this._canvas = canvas;
 
-  var self = this;
-
-  eventBus.on([ 'shape.move.start', 'create.start' ], function(event) {
-    self.initSnap(event);
-  });
-
-  eventBus.on([ 'shape.move.move', 'shape.move.end', 'create.move', 'create.end' ], HIGHER_PRIORITY, function(event) {
-
-    if (event.originalEvent && event.originalEvent.ctrlKey) {
-      return;
-    }
-
-    if (isSnapped(event)) {
-      return;
-    }
-
-    self.snap(event);
-  });
-
-  eventBus.on([ 'shape.move.cleanup', 'create.cleanup' ], function(event) {
-    self.hide();
-  });
-
-  // delay hide by 1000 seconds since last match
-  this._asyncHide = debounce(bind(this.hide, this), 1000);
+  // delay hide by 1000 seconds since last snap
+  this._asyncHide = debounce(bind(this.hide, this), SNAP_LINE_HIDE_DELAY);
 }
 
-Snapping.$inject = [ 'eventBus', 'canvas' ];
+Snapping.$inject = [ 'canvas' ];
 
-
-Snapping.prototype.initSnap = function(event) {
-
-  var context = event.context,
-      shape = context.shape,
-      snapContext = context.snapContext;
-
-  if (!snapContext) {
-    snapContext = context.snapContext = new SnapContext();
-  }
-
-  var snapMid = mid(shape, event);
-
-  snapContext.setSnapOrigin('mid', {
-    x: snapMid.x - event.x,
-    y: snapMid.y - event.y
-  });
-
-  return snapContext;
-};
-
-
-Snapping.prototype.snap = function(event) {
-
+/**
+ * Snap an event to given snap points.
+ *
+ * @param {Event} event
+ * @param {SnapPoints} snapPoints
+ */
+Snapping.prototype.snap = function(event, snapPoints) {
   var context = event.context,
       snapContext = context.snapContext,
-      shape = context.shape,
-      target = context.target,
       snapLocations = snapContext.getSnapLocations();
-
-  if (!target) {
-    return;
-  }
-
-  var snapPoints = snapContext.pointsForTarget(target);
-
-  if (!snapPoints.initialized) {
-    this.addTargetSnaps(snapPoints, shape, target);
-
-    snapPoints.initialized = true;
-  }
-
 
   var snapping = {
     x: isSnapped(event, 'x'),
     y: isSnapped(event, 'y')
   };
 
-
   forEach(snapLocations, function(location) {
-
     var snapOrigin = snapContext.getSnapOrigin(location);
 
     var snapCurrent = {
@@ -122,7 +62,7 @@ Snapping.prototype.snap = function(event) {
       y: event.y + snapOrigin.y
     };
 
-    // snap on both axis, if not snapped already
+    // snap both axis if not snapped already
     forEach([ 'x', 'y' ], function(axis) {
       var locationSnapping;
 
@@ -138,40 +78,33 @@ Snapping.prototype.snap = function(event) {
       }
     });
 
-    // no more need to snap, drop out of interation
+    // no need to continue snapping
     if (snapping.x && snapping.y) {
       return false;
     }
   });
 
-
-  // show snap visuals
-
+  // show snap lines
   this.showSnapLine('vertical', snapping.x && snapping.x.value);
   this.showSnapLine('horizontal', snapping.y && snapping.y.value);
 
-
-  // adjust event { x, y, dx, dy } and mark as snapping
+  // snap event
   forEach([ 'x', 'y' ], function(axis) {
-
     var axisSnapping = snapping[axis];
 
-    if (typeof axisSnapping === 'object') {
-      // set as snapped and adjust the x and/or y position of the event
+    if (isObject(axisSnapping)) {
       setSnapped(event, axis, axisSnapping.originValue);
     }
   });
 };
 
-
 Snapping.prototype._createLine = function(orientation) {
-
   var root = this._canvas.getLayer('snap');
 
-  // var line = root.path('M0,0 L0,0').addClass('djs-snap-line');
-
   var line = svgCreate('path');
+
   svgAttr(line, { d: 'M0,0 L0,0' });
+
   svgClasses(line).add('djs-snap-line');
 
   svgAppend(root, line);
@@ -179,7 +112,7 @@ Snapping.prototype._createLine = function(orientation) {
   return {
     update: function(position) {
 
-      if (typeof position !== 'number') {
+      if (!isNumber(position)) {
         svgAttr(line, { display: 'none' });
       } else {
         if (orientation === 'horizontal') {
@@ -198,9 +131,7 @@ Snapping.prototype._createLine = function(orientation) {
   };
 };
 
-
 Snapping.prototype._createSnapLines = function() {
-
   this._snapLines = {
     horizontal: this._createLine('horizontal'),
     vertical: this._createLine('vertical')
@@ -227,25 +158,7 @@ Snapping.prototype.getSnapLine = function(orientation) {
 };
 
 Snapping.prototype.hide = function() {
-  forEach(this._snapLines, function(l) {
-    l.update();
-  });
-};
-
-Snapping.prototype.addTargetSnaps = function(snapPoints, shape, target) {
-
-  var siblings = this.getSiblings(shape, target);
-
-  forEach(siblings, function(s) {
-    snapPoints.add('mid', mid(s));
-  });
-
-};
-
-Snapping.prototype.getSiblings = function(element, target) {
-
-  // snap to all siblings that are not hidden, labels, attached to element or element itself
-  return target && filter(target.children, function(e) {
-    return !e.hidden && !e.labelTarget && e.host !== element && e !== element;
+  forEach(this._snapLines, function(snapLine) {
+    snapLine.update();
   });
 };

--- a/lib/features/snapping/index.js
+++ b/lib/features/snapping/index.js
@@ -1,6 +1,14 @@
+import CreateMoveSnapping from './CreateMoveSnapping';
+import ResizeSnapping from './ResizeSnapping';
 import Snapping from './Snapping';
 
 export default {
-  __init__: [ 'snapping' ],
+  __init__: [
+    'createMoveSnapping',
+    'resizeSnapping',
+    'snapping'
+  ],
+  createMoveSnapping: [ 'type', CreateMoveSnapping ],
+  resizeSnapping: [ 'type', ResizeSnapping ],
   snapping: [ 'type', Snapping ]
 };

--- a/test/spec/features/create/CreateSpec.js
+++ b/test/spec/features/create/CreateSpec.js
@@ -21,6 +21,7 @@ import {
   classes as svgClasses
 } from 'tiny-svg';
 
+import { getMid } from 'lib/layout/LayoutUtil';
 
 var testModules = [
   createModule,
@@ -105,7 +106,7 @@ describe('features/create - Create', function() {
 
   describe('basics', function() {
 
-    it('should create', inject(function(create, elementRegistry, elementFactory, dragging) {
+    it('should create', inject(function(create, elementRegistry, dragging) {
 
       // given
       var parentGfx = elementRegistry.getGraphics('parentShape');
@@ -129,7 +130,7 @@ describe('features/create - Create', function() {
     }));
 
 
-    it('should append', inject(function(create, elementRegistry, elementFactory, dragging) {
+    it('should append', inject(function(create, elementRegistry, dragging) {
 
       // given
       var parentGfx = elementRegistry.getGraphics('parentShape');
@@ -154,7 +155,7 @@ describe('features/create - Create', function() {
     }));
 
 
-    it('should attach', inject(function(create, elementRegistry, elementFactory, dragging) {
+    it('should attach', inject(function(create, elementRegistry, dragging) {
 
       // given
       var hostShapeGfx = elementRegistry.getGraphics('hostShape');
@@ -174,7 +175,7 @@ describe('features/create - Create', function() {
     }));
 
 
-    it('should append + attach', inject(function(create, elementRegistry, elementFactory, dragging) {
+    it('should append + attach', inject(function(create, elementRegistry, dragging) {
 
       // given
       var hostShapeGfx = elementRegistry.getGraphics('hostShape');
@@ -201,7 +202,7 @@ describe('features/create - Create', function() {
 
   describe('visuals', function() {
 
-    it('should add visuals', inject(function(create, elementRegistry, dragging) {
+    it('should add visuals', inject(function(create, dragging) {
 
       // when
       create.start(canvasEvent({ x: 50, y: 50 }), newShape);
@@ -215,7 +216,7 @@ describe('features/create - Create', function() {
     }));
 
 
-    it('should remove visuals', inject(function(create, elementRegistry, dragging, eventBus) {
+    it('should remove visuals', inject(function(create, elementRegistry, dragging) {
       var parentGfx = elementRegistry.getGraphics('parentShape');
 
       // when
@@ -238,7 +239,7 @@ describe('features/create - Create', function() {
 
   describe('rules', function() {
 
-    it('should not allow shape create', inject(function(canvas, create, elementRegistry, dragging) {
+    it('should not allow shape create', inject(function(create, elementRegistry, dragging) {
       // given
       var targetGfx = elementRegistry.getGraphics('rootShape');
 
@@ -510,6 +511,80 @@ describe('features/create - Create', function() {
         expect(spy).to.have.been.called;
       }
     ));
+
+  });
+
+
+  describe('constraints', function() {
+
+    beforeEach(inject(function(create, dragging, elementRegistry) {
+      // given
+      var parentGfx = elementRegistry.getGraphics('parentShape');
+
+      // when
+      create.start(canvasEvent({ x: 0, y: 0 }), newShape, {
+        createConstraints: {
+          top: 10,
+          right: 110,
+          bottom: 110,
+          left: 10
+        }
+      });
+
+      dragging.hover({ element: parentShape, gfx: parentGfx });
+    }));
+
+
+    it('top left', inject(function(dragging, elementRegistry) {
+
+      dragging.move(canvasEvent({ x: 0, y: 0 }));
+
+      dragging.end();
+
+      var createdShape = elementRegistry.get('newShape');
+
+      // then
+      expect(getMid(createdShape)).to.eql({ x: 10, y: 10 });
+    }));
+
+
+    it('top right', inject(function(dragging, elementRegistry) {
+
+      dragging.move(canvasEvent({ x: 120, y: 0 }));
+
+      dragging.end();
+
+      var createdShape = elementRegistry.get('newShape');
+
+      // then
+      expect(getMid(createdShape)).to.eql({ x: 110, y: 10 });
+    }));
+
+
+    it('left bottom', inject(function(dragging, elementRegistry) {
+
+      dragging.move(canvasEvent({ x: 0, y: 120 }));
+
+      dragging.end();
+
+      var createdShape = elementRegistry.get('newShape');
+
+      // then
+      expect(getMid(createdShape)).to.eql({ x: 10, y: 110 });
+    }));
+
+
+    it('right bottom', inject(function(dragging, elementRegistry) {
+
+      dragging.move(canvasEvent({ x: 120, y: 120 }));
+
+      dragging.end();
+
+      var createdShape = elementRegistry.get('newShape');
+
+      // then
+      expect(getMid(createdShape)).to.eql({ x: 110, y: 110 });
+    }));
 
   });
 

--- a/test/spec/features/grid-snapping/GridSnappingSpec.js
+++ b/test/spec/features/grid-snapping/GridSnappingSpec.js
@@ -286,41 +286,89 @@ describe('features/grid-snapping', function() {
     });
 
 
-    it('<create>', inject(function(create, dragging, eventBus) {
+    describe('<create>', function() {
 
-      // given
-      var events = recordEvents(eventBus, [
-        'create.move',
-        'create.end'
-      ]);
+      it('without constraints', inject(function(create, dragging, eventBus) {
 
-      create.start(canvasEvent({ x: 150, y: 250 }), newShape);
+        // given
+        var events = recordEvents(eventBus, [
+          'create.move',
+          'create.end'
+        ]);
 
-      // when
-      dragging.hover({ element: rootShape, gfx: rootShapeGfx });
+        create.start(canvasEvent({ x: 150, y: 250 }), newShape);
 
-      dragging.move(canvasEvent({ x: 156, y: 253 }));
-      dragging.move(canvasEvent({ x: 162, y: 256 }));
-      dragging.move(canvasEvent({ x: 168, y: 259 }));
-      dragging.move(canvasEvent({ x: 174, y: 262 }));
-      dragging.move(canvasEvent({ x: 180, y: 265 }));
+        // when
+        dragging.hover({ element: rootShape, gfx: rootShapeGfx });
 
-      dragging.end();
+        dragging.move(canvasEvent({ x: 156, y: 253 }));
+        dragging.move(canvasEvent({ x: 162, y: 256 }));
+        dragging.move(canvasEvent({ x: 168, y: 259 }));
+        dragging.move(canvasEvent({ x: 174, y: 262 }));
+        dragging.move(canvasEvent({ x: 180, y: 265 }));
 
-      // then
-      expect(events.map(position)).to.eql([
-        { x: 150, y: 250 }, // move (triggered on create.start thanks to autoActivate)
-        { x: 160, y: 250 }, // move
-        { x: 160, y: 260 }, // move
-        { x: 170, y: 260 }, // move
-        { x: 170, y: 260 }, // move
-        { x: 180, y: 270 }, // move
-        { x: 180, y: 270 } // end
-      ]);
+        dragging.end();
 
-      expect(newShape.x + newShape.width / 2).to.equal(180);
-      expect(newShape.y + newShape.height / 2).to.equal(270);
-    }));
+        // then
+        expect(events.map(position)).to.eql([
+          { x: 150, y: 250 }, // move (triggered on create.start thanks to autoActivate)
+          { x: 160, y: 250 }, // move
+          { x: 160, y: 260 }, // move
+          { x: 170, y: 260 }, // move
+          { x: 170, y: 260 }, // move
+          { x: 180, y: 270 }, // move
+          { x: 180, y: 270 } // end
+        ]);
+
+        expect(newShape.x + newShape.width / 2).to.equal(180);
+        expect(newShape.y + newShape.height / 2).to.equal(270);
+      }));
+
+
+      it('with constraints', inject(function(create, dragging, eventBus) {
+
+        // given
+        var events = recordEvents(eventBus, [
+          'create.move',
+          'create.end'
+        ]);
+
+        create.start(canvasEvent({ x: 150, y: 250 }), newShape, {
+          createConstraints: {
+            top: 250,
+            right: 170,
+            bottom: 260,
+            left: 150
+          }
+        });
+
+        // when
+        dragging.hover({ element: rootShape, gfx: rootShapeGfx });
+
+        dragging.move(canvasEvent({ x: 156, y: 253 }));
+        dragging.move(canvasEvent({ x: 162, y: 256 }));
+        dragging.move(canvasEvent({ x: 168, y: 259 }));
+        dragging.move(canvasEvent({ x: 174, y: 262 }));
+        dragging.move(canvasEvent({ x: 180, y: 265 }));
+
+        dragging.end();
+
+        // then
+        expect(events.map(position)).to.eql([
+          { x: 150, y: 250 }, // move (triggered on create.start thanks to autoActivate)
+          { x: 160, y: 250 }, // move
+          { x: 160, y: 260 }, // move
+          { x: 170, y: 260 }, // move
+          { x: 170, y: 260 }, // move
+          { x: 170, y: 260 }, // move
+          { x: 170, y: 260 } // end
+        ]);
+
+        expect(newShape.x + newShape.width / 2).to.equal(170);
+        expect(newShape.y + newShape.height / 2).to.equal(260);
+      }));
+
+    });
 
 
     it('<connect>', inject(function(connect, dragging, eventBus) {

--- a/test/spec/features/move/MoveSpec.js
+++ b/test/spec/features/move/MoveSpec.js
@@ -1,3 +1,5 @@
+/* global sinon */
+
 import {
   bootstrapDiagram,
   inject
@@ -14,6 +16,8 @@ import {
 
 import modelingModule from 'lib/features/modeling';
 import moveModule from 'lib/features/move';
+
+var spy = sinon.spy;
 
 
 describe('features/move - Move', function() {
@@ -106,6 +110,7 @@ describe('features/move - Move', function() {
 
   });
 
+
   describe('modeling', function() {
 
     it('should round movement to pixels', inject(function(move, dragging, elementRegistry) {
@@ -143,6 +148,35 @@ describe('features/move - Move', function() {
       // then
       expect(dragging.context().data.context).to.include(context);
     }));
+
+
+    it('should NOT move if no delta', inject(
+      function(dragging, elementRegistry, modeling, move) {
+
+        // given
+        var moveElementsSpy = spy(modeling, 'moveElements');
+
+        move.start(canvasEvent({ x: 0, y: 0 }), childShape);
+
+        // when
+        dragging.move(canvasEvent({ x: 20, y: 20 }));
+
+        dragging.hover({
+          element: parentShape,
+          gfx: elementRegistry.getGraphics(parentShape)
+        });
+
+        dragging.move(canvasEvent({ x: 0, y: 0 }));
+
+        dragging.end();
+
+        // then
+        expect(moveElementsSpy).not.to.have.been.called;
+
+        expect(childShape.x).to.eql(110);
+        expect(childShape.y).to.eql(110);
+      }
+    ));
 
   });
 

--- a/test/spec/features/resize/ResizeSpec.js
+++ b/test/spec/features/resize/ResizeSpec.js
@@ -1,3 +1,5 @@
+/* global sinon */
+
 import {
   bootstrapDiagram,
   inject
@@ -24,6 +26,8 @@ import { classes as svgClasses } from 'tiny-svg';
 function bounds(b) {
   return pick(b, [ 'x', 'y', 'width', 'height' ]);
 }
+
+var spy = sinon.spy;
 
 describe('features/resize - Resize', function() {
 
@@ -202,6 +206,45 @@ describe('features/resize - Resize', function() {
 
       expect(shapeBounds).to.eql({ x: 100, y: 100, width: 80, height: 110 });
     }));
+
+
+    it('should NOT resize if bounds have not changed', inject(
+      function(canvas, dragging, elementFactory, modeling, resize) {
+
+        // given
+        var resizeShapeSpy = spy(modeling, 'resizeShape');
+
+        var shape = elementFactory.createShape({
+          id: 'shapeA',
+          resizable: 'always',
+          x: 100,
+          y: 100,
+          width: 100,
+          height: 100
+        });
+
+        shape = canvas.addShape(shape);
+
+        // when
+        resize.activate(canvasEvent({ x: 200, y: 200 }), shape, 'se');
+
+        dragging.move(canvasEvent({ x: 205, y: 205 }));
+
+        dragging.move(canvasEvent({ x: 200, y: 200 }));
+
+        dragging.end();
+
+        // then
+        expect(resizeShapeSpy).not.to.have.been.called;
+
+        expect(shape).to.have.bounds({
+          x: 100,
+          y: 100,
+          width: 100,
+          height: 100
+        });
+      }
+    ));
 
   });
 

--- a/test/spec/snapping/CreateMoveSnappingSpec.js
+++ b/test/spec/snapping/CreateMoveSnappingSpec.js
@@ -1,0 +1,623 @@
+import {
+  bootstrapDiagram,
+  inject
+} from 'test/TestHelper';
+
+import createModule from 'lib/features/create';
+import modelingModule from 'lib/features/modeling';
+import moveModule from 'lib/features/move';
+import snappingModule from 'lib/features/snapping';
+
+import SnapContext from 'lib/features/snapping/SnapContext';
+
+import {
+  bottomRight,
+  mid,
+  topLeft
+} from 'lib/features/snapping/SnapUtil';
+
+import {
+  createCanvasEvent as canvasEventMid
+} from '../../util/MockEvents';
+
+
+describe('features/snapping - CreateMoveSnapping', function() {
+
+  beforeEach(bootstrapDiagram({
+    modules: [
+      createModule,
+      modelingModule,
+      moveModule,
+      snappingModule
+    ]
+  }));
+
+  beforeEach(inject(function(dragging) {
+    dragging.setOptions({ manual: true });
+  }));
+
+  var rootElement,
+      rootElementGfx,
+      shape1;
+
+  beforeEach(inject(function(canvas, elementFactory) {
+    rootElement = elementFactory.createRoot({
+      id: 'root'
+    });
+
+    canvas.setRootElement(rootElement);
+
+    rootElementGfx = canvas.getGraphics(rootElement);
+
+    shape1 = elementFactory.createShape({
+      id: 'shape1',
+      x: 100,
+      y: 100,
+      width: 100,
+      height: 100
+    });
+
+    canvas.addShape(shape1, rootElement);
+  }));
+
+
+  describe('#initSnap', function() {
+
+    it('should create snap context', inject(function(createMoveSnapping, eventBus) {
+
+      // given
+      var event = eventBus.createEvent({
+        x: 100,
+        y: 100,
+        context: {
+          shape: shape1
+        }
+      });
+
+      // when
+      var snapContext = createMoveSnapping.initSnap(event);
+
+      // then
+      expect(snapContext).to.exist;
+      expect(event.context.snapContext).to.equal(snapContext);
+    }));
+
+
+    it('should NOT create snap context', inject(function(createMoveSnapping) {
+
+      // given
+      var originalSnapContext = new SnapContext();
+
+      var event = {
+        x: 100,
+        y: 100,
+        context: {
+          shape: shape1,
+          snapContext: originalSnapContext
+        }
+      };
+
+      // when
+      var snapContext = createMoveSnapping.initSnap(event);
+
+      // then
+      expect(snapContext).to.equal(originalSnapContext);
+    }));
+
+  });
+
+
+  describe('snapping', function() {
+
+    var connection,
+        label1,
+        label2,
+        shape2;
+
+    beforeEach(inject(function(canvas, elementFactory) {
+      label1 = elementFactory.createLabel({
+        id: 'label1',
+        x: 325,
+        y: 325,
+        width: 50,
+        height: 50,
+        labelTarget: shape1
+      });
+
+      canvas.addShape(label1, rootElement);
+
+      shape2 = elementFactory.createShape({
+        id: 'shape2',
+        x: 500,
+        y: 500,
+        width: 100,
+        height: 100
+      });
+
+      canvas.addShape(shape2, rootElement);
+
+      label2 = elementFactory.createLabel({
+        id: 'label2',
+        x: 725,
+        y: 725,
+        width: 50,
+        height: 50,
+        labelTarget: shape2
+      });
+
+      canvas.addShape(label2, rootElement);
+
+      connection = elementFactory.createConnection({
+        id: 'connection',
+        source: shape1,
+        target: shape2,
+        waypoints: [
+          { x: 900, y: 900 },
+          { x: 1000, y: 1000 },
+          { x: 1100, y: 1100 }
+        ]
+      });
+
+      canvas.addConnection(connection, rootElement);
+    }));
+
+
+    describe('create', function() {
+
+      var shape3;
+
+      beforeEach(inject(function(create, dragging, elementFactory) {
+        shape3 = elementFactory.createShape({
+          id: 'shape3',
+          width: 50,
+          height: 50
+        });
+
+        create.start(canvasEventMid({ x: 0, y: 0 }), shape3);
+
+        dragging.hover({ element: rootElement, gfx: rootElementGfx });
+      }));
+
+
+      it('should init on create.start', inject(function(eventBus) {
+
+        // given
+        var event = eventBus.createEvent({
+          x: 100,
+          y: 100,
+          shape: shape1,
+          context: {
+            shape: shape1
+          }
+        });
+
+        // when
+        eventBus.fire('create.start', event);
+
+        // then
+        expect(event.context.snapContext).to.exist;
+      }));
+
+
+      describe('snap to shape', function() {
+
+        it('should snap top-left', inject(function(dragging) {
+
+          // when
+          dragging.move(canvasEventTopLeft({ x: 95, y: 495 }, shape3));
+
+          dragging.end();
+
+          // then
+          expect(topLeft(shape3)).to.have.eql({
+            x: 100, // 95 snapped to 100 (left of shape1)
+            y: 500 // 495 snapped to 500 (top of shape2)
+          });
+        }));
+
+
+        it('should snap mid, mid', inject(function(dragging) {
+
+          // when
+          dragging.move(canvasEventMid({ x: 145, y: 545 }));
+
+          dragging.end();
+
+          // then
+          expect(mid(shape3)).to.have.eql({
+            x: 150, // 145 snapped to 150 (mid of shape1)
+            y: 550 // 545 snapped to 550 (mid of shape2)
+          });
+        }));
+
+
+        it('should snap bottom, right', inject(function(dragging) {
+
+          // when
+          dragging.move(canvasEventBottomRight({ x: 195, y: 595 }, shape3));
+
+          dragging.end();
+
+          // then
+          expect(bottomRight(shape3)).to.have.eql({
+            x: 200, // 195 snapped to 200 (right of shape1)
+            y: 600 // 595 snapped to 600 (bottom of shape2)
+          });
+        }));
+
+      });
+
+
+      describe('snap to connection', function() {
+
+        it('should NOT snap mid, mid (1st waypoint)', inject(function(dragging) {
+
+          // when
+          dragging.move(canvasEventMid({ x: 895, y: 895 }));
+
+          dragging.end();
+
+          // then
+          expect(mid(shape3)).to.have.eql({
+            x: 895, // NOT snapped
+            y: 895 // NOT snapped
+          });
+        }));
+
+
+        it('should snap mid, mid', inject(function(dragging) {
+
+          // when
+          dragging.move(canvasEventMid({ x: 995, y: 995 }));
+
+          dragging.end();
+
+          // then
+          expect(mid(shape3)).to.have.eql({
+            x: 1000, // 995 snapped to 1000 (2nd waypoint of connection)
+            y: 1000 // 995 snapped to 1000 (2nd waypoint of connection)
+          });
+        }));
+
+
+        it('should NOT snap mid, mid (last waypoint)', inject(function(dragging) {
+
+          // when
+          dragging.move(canvasEventMid({ x: 1095, y: 1095 }));
+
+          dragging.end();
+
+          // then
+          expect(mid(shape3)).to.have.eql({
+            x: 1095, // NOT snapped
+            y: 1095 // NOT snapped
+          });
+        }));
+
+      });
+
+
+      describe('snap to label', function() {
+
+        it('should NOT snap mid, mid', inject(function(dragging) {
+
+          // when
+          dragging.move(canvasEventMid({ x: 345, y: 345 }));
+
+          dragging.end();
+
+          // then
+          expect(mid(shape3)).to.have.eql({
+            x: 345, // NOT snapped
+            y: 345 // NOT snapped
+          });
+        }));
+
+      });
+
+    });
+
+
+    describe('move', function() {
+
+      it('should init on shape.move.start', inject(function(eventBus) {
+
+        // given
+        var event = eventBus.createEvent({
+          x: 100,
+          y: 100,
+          shape: shape1,
+          context: {}
+        });
+
+        // when
+        eventBus.fire('shape.move.start', event);
+
+        // then
+        expect(event.context.snapContext).to.exist;
+      }));
+
+
+      describe('shape', function() {
+
+        var shape3;
+
+        beforeEach(inject(function(canvas, dragging, elementFactory, move) {
+          shape3 = elementFactory.createShape({
+            id: 'shape3',
+            x: 0,
+            y: 0,
+            width: 50,
+            height: 50
+          });
+
+          canvas.addShape(shape3, rootElement);
+
+          move.start(canvasEventMid({ x: 25, y: 25 }), shape3, true);
+
+          dragging.hover({ element: rootElement, gfx: rootElementGfx });
+
+          dragging.move(canvasEventMid({ x: 0, y: 0 }));
+        }));
+
+
+        describe('snap to self', function() {
+
+          it('should snap mid, mid', inject(function(dragging) {
+
+            // when
+            dragging.move(canvasEventMid({ x: 20, y: 20 }));
+
+            dragging.end();
+
+            // then
+            expect(mid(shape3)).to.have.eql({
+              x: 25, // 20 snapped to 25 (mid of shape3)
+              y: 25 // 20 snapped to 25 (mid of shape3)
+            });
+          }));
+
+        });
+
+
+        describe('snap to shape', function() {
+
+          it('should snap top-left', inject(function(dragging) {
+
+            // when
+            dragging.move(canvasEventTopLeft({ x: 95, y: 495 }, shape3));
+
+            dragging.end();
+
+            // then
+            expect(topLeft(shape3)).to.have.eql({
+              x: 100, // 95 snapped to 100 (left of shape1)
+              y: 500 // 495 snapped to 500 (top of shape2)
+            });
+          }));
+
+
+          it('should snap mid, mid', inject(function(dragging) {
+
+            // when
+            dragging.move(canvasEventMid({ x: 145, y: 545 }));
+
+            dragging.end();
+
+            // then
+            expect(mid(shape3)).to.have.eql({
+              x: 150, // 145 snapped to 150 (mid of shape1)
+              y: 550 // 545 snapped to 550 (mid of shape2)
+            });
+          }));
+
+
+          it('should snap bottom, right', inject(function(dragging) {
+
+            // when
+            dragging.move(canvasEventBottomRight({ x: 195, y: 595 }, shape3));
+
+            dragging.end();
+
+            // then
+            expect(bottomRight(shape3)).to.have.eql({
+              x: 200, // 195 snapped to 200 (right of shape1)
+              y: 600 // 595 snapped to 600 (bottom of shape2)
+            });
+          }));
+
+        });
+
+
+        describe('snap to connection', function() {
+
+          it('should snap mid, mid', inject(function(dragging) {
+
+            // when
+            dragging.move(canvasEventMid({ x: 995, y: 995 }));
+
+            dragging.end();
+
+            // then
+            expect(mid(shape3)).to.have.eql({
+              x: 1000, // 995 snapped to 1000 (2nd waypoint of connection)
+              y: 1000 // 995 snapped to 1000 (2nd waypoint of connection)
+            });
+          }));
+
+        });
+
+
+        describe('snap to label', function() {
+
+          it('should NOT snap to mid, mid', inject(function(dragging) {
+
+            // when
+            dragging.move(canvasEventMid({ x: 345, y: 745 }, shape3));
+
+            dragging.end();
+
+            // then
+            expect(mid(shape3)).to.have.eql({
+              x: 345, // NOT snapped
+              y: 745 // NOT snapped
+            });
+          }));
+
+        });
+
+      });
+
+
+      describe('label', function() {
+
+        var label3;
+
+        beforeEach(inject(function(canvas, dragging, elementFactory, move) {
+          label3 = elementFactory.createLabel({
+            id: 'label3',
+            x: 0,
+            y: 0,
+            width: 50,
+            height: 50,
+            labelTarget: shape1
+          });
+
+          canvas.addShape(label3, rootElement);
+
+          move.start(canvasEventMid({ x: 25, y: 25 }), label3, true);
+
+          dragging.hover({ element: rootElement, gfx: rootElementGfx });
+
+          dragging.move(canvasEventMid({ x: 0, y: 0 }));
+        }));
+
+
+        describe('snap to self', function() {
+
+          it('should snap mid, mid', inject(function(dragging) {
+
+            // when
+            dragging.move(canvasEventMid({ x: 20, y: 20 }));
+
+            dragging.end();
+
+            // then
+            expect(mid(label3)).to.have.eql({
+              x: 25, // 20 snapped to 25 (mid of label3)
+              y: 25 // 20 snapped to 25 (mid of label3)
+            });
+          }));
+
+        });
+
+
+        describe('snap to shape', function() {
+
+          it('should NOT snap top, left', inject(function(dragging) {
+
+            // when
+            dragging.move(canvasEventTopLeft({ x: 95, y: 495 }, label3));
+
+            dragging.end();
+
+            // then
+            expect(topLeft(label3)).to.have.eql({
+              x: 95, // NOT snapped
+              y: 495 // NOT snapped
+            });
+          }));
+
+
+          it('should snap mid, mid', inject(function(dragging) {
+
+            // when
+            dragging.move(canvasEventMid({ x: 145, y: 545 }));
+
+            dragging.end();
+
+            // then
+            expect(mid(label3)).to.have.eql({
+              x: 150, // 145 snapped to 150 (mid of shape1)
+              y: 550 // 545 snapped to 550 (mid of shape2)
+            });
+          }));
+
+
+          it('should NOT snap bottom, right', inject(function(dragging) {
+
+            // when
+            dragging.move(canvasEventBottomRight({ x: 195, y: 595 }, label3));
+
+            dragging.end();
+
+            // then
+            expect(bottomRight(label3)).to.have.eql({
+              x: 195, // NOT snapped
+              y: 595 // NOT snapped
+            });
+          }));
+
+        });
+
+
+        describe('snap to connection', function() {
+
+          it('should snap mid, mid', inject(function(dragging) {
+
+            // when
+            dragging.move(canvasEventMid({ x: 995, y: 995 }));
+
+            dragging.end();
+
+            // then
+            expect(mid(label3)).to.have.eql({
+              x: 1000, // 995 snapped to 1000
+              y: 1000 // 995 snapped to 1000
+            });
+          }));
+
+        });
+
+
+        describe('snap to label', function() {
+
+          it('should snap mid, mid', inject(function(dragging) {
+
+            // when
+            dragging.move(canvasEventMid({ x: 345, y: 745 }));
+
+            dragging.end();
+
+            // then
+            expect(mid(label3)).to.have.eql({
+              x: 350, // 345 snapped to 350 (mid of label1)
+              y: 750 // 745 snapped to 750 (mid of label2)
+            });
+          }));
+
+        });
+
+      });
+
+    });
+
+  });
+
+});
+
+// helpers //////////
+
+function canvasEventTopLeft(position, shape) {
+  return canvasEventMid({
+    x: position.x + shape.width / 2,
+    y: position.y + shape.height / 2
+  });
+}
+
+function canvasEventBottomRight(position, shape) {
+  return canvasEventMid({
+    x: position.x - shape.width / 2,
+    y: position.y - shape.height / 2
+  });
+}

--- a/test/spec/snapping/ResizeSnappingSpec.js
+++ b/test/spec/snapping/ResizeSnappingSpec.js
@@ -1,0 +1,247 @@
+import {
+  bootstrapDiagram,
+  inject
+} from 'test/TestHelper';
+
+import modelingModule from 'lib/features/modeling';
+import resizeModule from 'lib/features/resize';
+import snappingModule from 'lib/features/snapping';
+
+import SnapContext from 'lib/features/snapping/SnapContext';
+
+import {
+  createCanvasEvent as canvasEvent
+} from '../../util/MockEvents';
+
+
+describe('features/snapping - ResizeSnapping', function() {
+
+  beforeEach(bootstrapDiagram({
+    modules: [
+      modelingModule,
+      resizeModule,
+      snappingModule
+    ]
+  }));
+
+  beforeEach(inject(function(dragging) {
+    dragging.setOptions({ manual: true });
+  }));
+
+  var rootElement,
+      shape1;
+
+  beforeEach(inject(function(canvas, elementFactory) {
+    rootElement = elementFactory.createRoot({
+      id: 'root'
+    });
+
+    canvas.setRootElement(rootElement);
+
+    shape1 = elementFactory.createShape({
+      id: 'shape1',
+      x: 100,
+      y: 100,
+      width: 100,
+      height: 100,
+      resizable: 'always'
+    });
+
+    canvas.addShape(shape1, rootElement);
+
+    var shape2 = elementFactory.createShape({
+      id: 'shape2',
+      x: 300,
+      y: 300,
+      width: 100,
+      height: 100
+    });
+
+    canvas.addShape(shape2, rootElement);
+
+    var connection = elementFactory.createConnection({
+      id: 'connection',
+      source: shape1,
+      target: shape2,
+      waypoints: [
+        { x: 500, y: 500 },
+        { x: 600, y: 600 },
+        { x: 700, y: 700 }
+      ]
+    });
+
+    canvas.addConnection(connection, rootElement);
+
+    var label = elementFactory.createLabel({
+      id: 'label',
+      x: 800,
+      y: 800,
+      width: 100,
+      height: 100,
+      labelTarget: shape2
+    });
+
+    canvas.addShape(label, rootElement);
+  }));
+
+
+  describe('#initSnap', function() {
+
+    it('should create snap context', inject(function(resizeSnapping, eventBus) {
+
+      // given
+      var event = eventBus.createEvent({
+        x: 100,
+        y: 100,
+        shape: shape1,
+        context: {
+          shape: shape1
+        }
+      });
+
+      // when
+      var snapContext = resizeSnapping.initSnap(event);
+
+      // then
+      expect(snapContext).to.exist;
+      expect(event.context.snapContext).to.equal(snapContext);
+    }));
+
+
+    it('should NOT create snap context', inject(function(resizeSnapping) {
+
+      // given
+      var originalSnapContext = new SnapContext();
+
+      var event = {
+        x: 100,
+        y: 100,
+        shape: shape1,
+        context: {
+          shape: shape1,
+          snapContext: originalSnapContext
+        }
+      };
+
+      // when
+      var snapContext = resizeSnapping.initSnap(event);
+
+      // then
+      expect(snapContext).to.equal(originalSnapContext);
+    }));
+
+  });
+
+
+  describe('snapping', function() {
+
+    it('should init on resize.start', inject(function(eventBus) {
+
+      // given
+      var event = eventBus.createEvent({
+        x: 100,
+        y: 100,
+        shape: shape1,
+        context: {
+          shape: shape1
+        }
+      });
+
+      // when
+      eventBus.fire('resize.start', event);
+
+      // then
+      expect(event.context.snapContext).to.exist;
+    }));
+
+
+    it('snap to self', inject(function(dragging, resize) {
+
+      // when
+      resize.activate(canvasEvent({ x: 200, y: 200 }), shape1, 'se');
+
+      dragging.move(canvasEvent({ x: 205, y: 205 }));
+
+      dragging.end();
+
+      // then
+      expect(shape1).to.have.bounds({
+        x: 100,
+        y: 100,
+        width: 100,
+        height: 100
+      });
+    }));
+
+
+    describe('snap to shape', function() {
+
+      it('should snap', inject(function(dragging, resize) {
+
+        // when
+        resize.activate(canvasEvent({ x: 200, y: 200 }), shape1, 'se');
+
+        dragging.move(canvasEvent({ x: 305, y: 305 }));
+
+        dragging.end();
+
+        // then
+        expect(shape1).to.have.bounds({
+          x: 100,
+          y: 100,
+          width: 200, // 205 snapped to 200 (left of shape2)
+          height: 200 // 205 snapped to 200 (top of shape2)
+        });
+      }));
+
+    });
+
+
+    describe('snap to connection', function() {
+
+      it('should NOT snap', inject(function(dragging, resize) {
+
+        // when
+        resize.activate(canvasEvent({ x: 200, y: 200 }), shape1, 'se');
+
+        dragging.move(canvasEvent({ x: 605, y: 605 }));
+
+        dragging.end();
+
+        // then
+        expect(shape1).to.have.bounds({
+          x: 100,
+          y: 100,
+          width: 505, // NOT snapped
+          height: 505 // NOT snapped
+        });
+      }));
+
+    });
+
+
+    describe('snap to label', function() {
+
+      it('should NOT snap', inject(function(dragging, resize) {
+
+        // when
+        resize.activate(canvasEvent({ x: 200, y: 200 }), shape1, 'se');
+
+        dragging.move(canvasEvent({ x: 805, y: 805 }));
+
+        dragging.end();
+
+        // then
+        expect(shape1).to.have.bounds({
+          x: 100,
+          y: 100,
+          width: 705, // NOT snapped
+          height: 705 // NOT snapped
+        });
+      }));
+
+    });
+
+  });
+
+});

--- a/test/spec/snapping/SnapUtilSpec.js
+++ b/test/spec/snapping/SnapUtilSpec.js
@@ -1,0 +1,82 @@
+import {
+  bootstrapDiagram,
+  inject
+} from 'test/TestHelper';
+
+import modelingModule from 'lib/features/modeling';
+
+import { getChildren } from 'lib/features/snapping/SnapUtil';
+
+
+describe('features/snapping - SnapUtil', function() {
+
+  beforeEach(bootstrapDiagram({
+    modules: [
+      modelingModule
+    ]
+  }));
+
+  var rootElement, shape1, shape2, connection;
+
+  beforeEach(inject(function(canvas, elementFactory) {
+    rootElement = elementFactory.createRoot({
+      id: 'root'
+    });
+
+    canvas.setRootElement(rootElement);
+
+    shape1 = canvas.addShape(elementFactory.createShape({
+      id: 'shape1',
+      x: 100, y: 100, width: 100, height: 100
+    }));
+
+    shape2 = canvas.addShape(elementFactory.createShape({
+      id: 'shape2',
+      x: 300, y: 100, width: 100, height: 100
+    }));
+
+    connection = canvas.addConnection(elementFactory.createConnection({
+      id: 'connection',
+      source: shape1,
+      target: shape2,
+      waypoints: [
+        { x: 150, y: 200 },
+        { x: 150, y: 300 }
+      ]
+    }));
+  }));
+
+
+  describe('#getChildren', function() {
+
+    it('root', function() {
+
+      // when
+      var children = getChildren(rootElement);
+
+      // then
+      expect(children).to.have.length(3);
+    });
+
+
+    it('shape', function() {
+
+      // when
+      var children = getChildren(shape1);
+
+      // then
+      expect(children).to.have.length(0);
+    });
+
+
+    it('connection', function() {
+
+      // when
+      var children = getChildren(connection);
+
+      // then
+      expect(children).to.have.length(0);
+    });
+  });
+
+});


### PR DESCRIPTION
* allow constraining create (required by https://github.com/bpmn-io/bpmn-js/pull/1046/commits/5c83fbfa18b2a5b9d6a8bd24984c99a617f0b71e)
* prevent move/resize if unnecessary
* snap to borders on create/move
* add resize snapping
* separate create/move snapping integration from core snapping

Required by https://github.com/bpmn-io/bpmn-js/pull/1046.
Related to https://github.com/camunda/camunda-modeler/issues/1290.