### PR TITLE
fix(geometry): reverse truthy return values of `pointsAligned()`

### DIFF
--- a/lib/features/bendpoints/BendpointUtil.js
+++ b/lib/features/bendpoints/BendpointUtil.js
@@ -112,7 +112,7 @@ function createParallelDragger(parentGfx, position, alignment) {
 
   svgAppend(draggerGfx, hit);
 
-  rotate(draggerGfx, alignment === 'h' ? 90 : 0, 0, 0);
+  rotate(draggerGfx, alignment === 'v' ? 90 : 0, 0, 0);
 
   return draggerGfx;
 }
@@ -129,7 +129,7 @@ export function addSegmentDragger(parentGfx, segmentStart, segmentEnd) {
   createParallelDragger(groupGfx, mid, alignment);
 
   svgClasses(groupGfx).add(SEGMENT_DRAGGER_CLS);
-  svgClasses(groupGfx).add(alignment === 'h' ? 'vertical' : 'horizontal');
+  svgClasses(groupGfx).add(alignment === 'h' ? 'horizontal' : 'vertical');
 
   translate(groupGfx, mid.x, mid.y);
 

--- a/lib/features/bendpoints/ConnectionSegmentMove.js
+++ b/lib/features/bendpoints/ConnectionSegmentMove.js
@@ -112,7 +112,7 @@ export default function ConnectionSegmentMove(
     }
 
     // the axis where we are going to move things
-    axis = direction === 'v' ? 'y' : 'x';
+    axis = direction === 'v' ? 'x' : 'y';
 
     if (segmentStartIndex === 0) {
       segmentStart = getDocking(segmentStart, connection.source, axis);

--- a/lib/layout/ManhattanLayout.js
+++ b/lib/layout/ManhattanLayout.js
@@ -544,11 +544,11 @@ function _tryRepairConnectionSide(moved, other, newDocking, points) {
 
     switch (alignment) {
     case 'v':
-      // repair vertical alignment
-      return { x: candidate.x, y: newPeer.y };
-    case 'h':
       // repair horizontal alignment
       return { x: newPeer.x, y: candidate.y };
+    case 'h':
+      // repair vertical alignment
+      return { x: candidate.x, y: newPeer.y };
     }
 
     return { x: candidate.x, y: candidate. y };

--- a/lib/util/Geometry.js
+++ b/lib/util/Geometry.js
@@ -60,11 +60,11 @@ var ALIGNED_THRESHOLD = 2;
  */
 export function pointsAligned(a, b) {
   if (Math.abs(a.x - b.x) <= ALIGNED_THRESHOLD) {
-    return 'h';
+    return 'v';
   }
 
   if (Math.abs(a.y - b.y) <= ALIGNED_THRESHOLD) {
-    return 'v';
+    return 'h';
   }
 
   return false;

--- a/test/spec/util/GeometrySpec.js
+++ b/test/spec/util/GeometrySpec.js
@@ -1,5 +1,6 @@
 import {
-  pointsOnLine
+  pointsOnLine,
+  pointsAligned
 } from 'lib/util/Geometry';
 
 
@@ -32,6 +33,107 @@ describe('util/Geometry', function() {
       expect(pointsOnLine(p, null, z)).to.be.false;
       expect(pointsOnLine(null, q, z)).to.be.false;
     });
+
+  });
+
+
+  describe('#pointsAligned', function() {
+
+    it('should return h for exact horizontal line', function() {
+
+      // given
+      var p0 = { x: 200, y: 200 },
+          p1 = { x: 400, y: 200 };
+
+      // then
+      expect(pointsAligned(p0, p1)).to.equal('h');
+    });
+
+
+    it('should return h for horizontal line in alignment threshold',
+      function() {
+
+        // given
+        var p0 = { x: 200, y: 200 },
+            p1 = { x: 400, y: 202 },
+            p2 = { x: 200, y: 200 },
+            p3 = { x: 400, y: 198 };
+
+        // then
+        expect(pointsAligned(p0, p1)).to.equal('h');
+        expect(pointsAligned(p2, p3)).to.equal('h');
+      }
+    );
+
+
+    it('should return v for exact vertical line', function() {
+
+      // given
+      var p0 = { x: 200, y: 200 },
+          p1 = { x: 200, y: 400 };
+
+      // then
+      expect(pointsAligned(p0, p1)).to.equal('v');
+    });
+
+
+    it('should return v for vertical line within alignment threshold',
+      function() {
+
+        // given
+        var p0 = { x: 200, y: 200 },
+            p1 = { x: 202, y: 400 },
+            p2 = { x: 200, y: 200 },
+            p3 = { x: 198, y: 400 };
+
+        // then
+        expect(pointsAligned(p0, p1)).to.equal('v');
+        expect(pointsAligned(p2, p3)).to.equal('v');
+      }
+    );
+
+
+    it('should return false for non-aligned line', function() {
+
+      // given
+      var p0 = { x: 200, y: 200 },
+          p1 = { x: 400, y: 400 };
+
+      // then
+      expect(pointsAligned(p0, p1)).to.be.false;
+    });
+
+
+    it('should return false for horizontal line outside alignment threshold',
+      function() {
+
+        // given
+        var p0 = { x: 200, y: 200 },
+            p1 = { x: 400, y: 203 },
+            p2 = { x: 200, y: 200 },
+            p3 = { x: 400, y: 197 };
+
+        // then
+        expect(pointsAligned(p0, p1)).to.be.false;
+        expect(pointsAligned(p2, p3)).to.be.false;
+      }
+    );
+
+
+    it('should return false for vertical line outside alignment threshold',
+      function() {
+
+        // given
+        var p0 = { x: 200, y: 200 },
+            p1 = { x: 203, y: 400 },
+            p2 = { x: 200, y: 200 },
+            p3 = { x: 197, y: 400 };
+
+        // then
+        expect(pointsAligned(p0, p1)).to.be.false;
+        expect(pointsAligned(p2, p3)).to.be.false;
+      }
+    );
 
   });
 


### PR DESCRIPTION
This was returning 'v' for horizontally-aligned lines and 'h' for vertically-aligned lines.

Added missing tests for `pointsAligned()`.

Also takes care of the width/height of the yellow parallel dragger SVG element and the direction of the dragger cursor when hovering over a line's parallel dragger area.