### PR TITLE
Allow setting and sharing of hints between create and commandStack.shape.create events

### DIFF
--- a/lib/features/create/Create.js
+++ b/lib/features/create/Create.js
@@ -271,7 +271,8 @@ export default function Create(
         shape: shape,
         context: {
           shape: shape,
-          source: source
+          source: source,
+          hints: {}
         }
       }
     });

--- a/lib/features/create/Create.js
+++ b/lib/features/create/Create.js
@@ -13,6 +13,8 @@ import {
   remove as svgRemove
 } from 'tiny-svg';
 
+import { assign } from 'min-dash';
+
 import {
   translate
 } from '../../util/SvgTransformUtil';
@@ -217,6 +219,7 @@ export default function Create(
   eventBus.on('create.end', function(event) {
     var context = event.context,
         source = context.source,
+        hints = context.hints,
         shape = context.shape,
         target = context.target,
         canExecute = context.canExecute,
@@ -239,9 +242,12 @@ export default function Create(
       });
     } else {
       // invoke create, if connect is not set
-      shape = modeling.createShape(shape, position, target, {
-        attach: attach
-      });
+      shape = modeling.createShape(shape, position, target, assign(
+        {},
+        hints, {
+          attach: attach
+        }
+      ));
     }
 
     // make sure we provide the actual attached

--- a/test/spec/features/create/CreateSpec.js
+++ b/test/spec/features/create/CreateSpec.js
@@ -483,6 +483,34 @@ describe('features/create - Create', function() {
       }
     ));
 
+
+    it('should pass hints to commandStack.shape.create event context', inject(
+      function(create, eventBus, dragging) {
+
+        // given
+        var spy = sinon.spy(function(event) {
+          expect(event.context.hints.foo).to.exist;
+        });
+
+        eventBus.once('create.start', function(event) {
+          event.context.hints.foo = 'foo';
+        });
+
+        eventBus.once('commandStack.shape.create.execute', spy);
+
+        // when
+        create.start(canvasEvent({ x: 0, y: 0 }), newShape);
+
+        dragging.move(canvasEvent({ x: 50, y: 50 }));
+        dragging.hover({ element: parentShape });
+        dragging.move(canvasEvent({ x: 100, y: 100 }));
+        dragging.end();
+
+        // then
+        expect(spy).to.have.been.called;
+      }
+    ));
+
   });
 
 });

--- a/test/spec/features/create/CreateSpec.js
+++ b/test/spec/features/create/CreateSpec.js
@@ -1,3 +1,5 @@
+/* global sinon */
+
 import {
   bootstrapDiagram,
   inject
@@ -431,6 +433,56 @@ describe('features/create - Create', function() {
         expect(ctx.data.context.connectionPreviewGfx.parentNode).not.to.exist;
       }));
     });
+  });
+
+
+  describe('hints', function() {
+
+    afterEach(sinon.restore);
+
+
+    it('should provide hints object in create.start event handler', inject(
+      function(create, eventBus) {
+
+        // given
+        var spy = sinon.spy(function(event) {
+          expect(event.context.hints).to.exist;
+        });
+
+        eventBus.once('create.start', spy);
+
+        // when
+        create.start(canvasEvent({ x: 0, y: 0 }), newShape);
+
+        // then
+        expect(spy).to.have.been.called;
+      }
+    ));
+
+
+    it('should provide hints object in create.end event handler', inject(
+      function(create, eventBus, dragging) {
+
+        // given
+        var spy = sinon.spy(function(event) {
+          expect(event.context.hints).to.exist;
+        });
+
+        eventBus.once('create.end', spy);
+
+        // when
+        create.start(canvasEvent({ x: 0, y: 0 }), newShape);
+
+        dragging.move(canvasEvent({ x: 50, y: 50 }));
+        dragging.hover({ element: parentShape });
+        dragging.move(canvasEvent({ x: 100, y: 100 }));
+        dragging.end();
+
+        // then
+        expect(spy).to.have.been.called;
+      }
+    ));
+
   });
 
 });


### PR DESCRIPTION
This is useful for two cases:

1. Accessing and setting properties on the hints object in event handlers for create commands.

2. Sharing metadata between both event types.