### PR TITLE
Improve parallel segment moving

### DIFF
--- a/lib/features/bendpoints/BendpointUtil.js
+++ b/lib/features/bendpoints/BendpointUtil.js
@@ -79,7 +79,7 @@ export function addBendpoint(parentGfx, cls) {
   return groupGfx;
 }
 
-function createParallelDragger(parentGfx, position, alignment) {
+function createParallelDragger(parentGfx, segmentStart, segmentEnd, alignment) {
   var draggerGfx = svgCreate('g');
 
   svgAppend(parentGfx, draggerGfx);
@@ -87,7 +87,7 @@ function createParallelDragger(parentGfx, position, alignment) {
   var width = 14,
       height = 3,
       padding = 6,
-      hitWidth = width + padding,
+      hitWidth = calculateHitWidth(segmentStart, segmentEnd, alignment, padding),
       hitHeight = height + padding;
 
   var visual = svgCreate('rect');
@@ -126,7 +126,7 @@ export function addSegmentDragger(parentGfx, segmentStart, segmentEnd) {
 
   svgAppend(parentGfx, groupGfx);
 
-  createParallelDragger(groupGfx, mid, alignment);
+  createParallelDragger(groupGfx, segmentStart, segmentEnd, alignment);
 
   svgClasses(groupGfx).add(SEGMENT_DRAGGER_CLS);
   svgClasses(groupGfx).add(alignment === 'h' ? 'horizontal' : 'vertical');
@@ -134,4 +134,25 @@ export function addSegmentDragger(parentGfx, segmentStart, segmentEnd) {
   translate(groupGfx, mid.x, mid.y);
 
   return groupGfx;
+}
+
+/**
+ * Calculates region for segment move which is 2/3 of the full segment length
+ * @param {Number} segmentLength
+ *
+ * @return {Number}
+ */
+export function calculateSegmentMoveRegion(segmentLength) {
+  return Math.abs(Math.round(segmentLength * 2 / 3));
+}
+
+// helper //////////
+
+function calculateHitWidth(segmentStart, segmentEnd, alignment) {
+  var segmentLengthXAxis = segmentEnd.x - segmentStart.x,
+      segmentLengthYAxis = segmentEnd.y - segmentStart.y;
+
+  return alignment === 'h' ?
+    calculateSegmentMoveRegion(segmentLengthXAxis) :
+    calculateSegmentMoveRegion(segmentLengthYAxis);
 }

--- a/lib/features/bendpoints/BendpointUtil.js
+++ b/lib/features/bendpoints/BendpointUtil.js
@@ -19,6 +19,9 @@ import {
   translate
 } from '../../util/SvgTransformUtil';
 
+import {
+  getApproxIntersection
+} from '../../util/LineIntersection';
 
 export var BENDPOINT_CLS = 'djs-bendpoint';
 export var SEGMENT_DRAGGER_CLS = 'djs-segment-dragger';
@@ -44,6 +47,13 @@ export function toCanvasCoordinates(canvas, event) {
     x: viewbox.x + (position.x - offset.x) / viewbox.scale,
     y: viewbox.y + (position.y - offset.y) / viewbox.scale
   };
+}
+
+export function getConnectionIntersection(canvas, waypoints, event) {
+  var localPosition = toCanvasCoordinates(canvas, event),
+      intersection = getApproxIntersection(waypoints, localPosition);
+
+  return intersection;
 }
 
 export function addBendpoint(parentGfx, cls) {

--- a/lib/features/bendpoints/Bendpoints.js
+++ b/lib/features/bendpoints/Bendpoints.js
@@ -11,8 +11,8 @@ import {
   SEGMENT_DRAGGER_CLS,
   addBendpoint,
   addSegmentDragger,
-  toCanvasCoordinates,
-  calculateSegmentMoveRegion
+  calculateSegmentMoveRegion,
+  getConnectionIntersection
 } from './BendpointUtil';
 
 import {
@@ -27,10 +27,6 @@ import {
   pointsAligned,
   getMidPoint
 } from '../../util/Geometry';
-
-import {
-  getApproxIntersection
-} from '../../util/LineIntersection';
 
 import {
   append as svgAppend,
@@ -51,13 +47,6 @@ import {
 export default function Bendpoints(
     eventBus, canvas, interactionEvents,
     bendpointMove, connectionSegmentMove) {
-
-  function getConnectionIntersection(waypoints, event) {
-    var localPosition = toCanvasCoordinates(canvas, event),
-        intersection = getApproxIntersection(waypoints, localPosition);
-
-    return intersection;
-  }
 
   /**
    * Returns true if intersection point is inside middle region of segment, adjusted by
@@ -116,7 +105,7 @@ export default function Bendpoints(
 
   function activateBendpointMove(event, connection) {
     var waypoints = connection.waypoints,
-        intersection = getConnectionIntersection(waypoints, event),
+        intersection = getConnectionIntersection(canvas, waypoints, event),
         threshold;
 
     if (!intersection) {
@@ -329,7 +318,7 @@ export default function Bendpoints(
     if (waypoints) {
       bendpointsGfx = getBendpointsContainer(element, true);
 
-      intersection = getConnectionIntersection(waypoints, event.originalEvent);
+      intersection = getConnectionIntersection(canvas, waypoints, event.originalEvent);
 
       if (intersection) {
         updateFloatingBendpointPosition(bendpointsGfx, intersection);

--- a/lib/features/bendpoints/Bendpoints.js
+++ b/lib/features/bendpoints/Bendpoints.js
@@ -40,7 +40,9 @@ import {
   remove as svgRemove
 } from 'tiny-svg';
 
-import { translate } from '../../util/SvgTransformUtil';
+import {
+  translate
+} from '../../util/SvgTransformUtil';
 
 
 /**
@@ -161,6 +163,13 @@ export default function Bendpoints(
     return gfx;
   }
 
+  function getSegmentDragger(idx, parentGfx) {
+    return domQuery(
+      '.djs-segment-dragger[data-segment-idx="' + idx + '"]',
+      parentGfx
+    );
+  }
+
   function createBendpoints(gfx, connection) {
     connection.waypoints.forEach(function(p, idx) {
       var bendpoint = addBendpoint(gfx);
@@ -179,7 +188,8 @@ export default function Bendpoints(
     var waypoints = connection.waypoints;
 
     var segmentStart,
-        segmentEnd;
+        segmentEnd,
+        segmentDraggerGfx;
 
     for (var i = 1; i < waypoints.length; i++) {
 
@@ -187,7 +197,11 @@ export default function Bendpoints(
       segmentEnd = waypoints[i];
 
       if (pointsAligned(segmentStart, segmentEnd)) {
-        addSegmentDragger(gfx, segmentStart, segmentEnd);
+        segmentDraggerGfx = addSegmentDragger(gfx, segmentStart, segmentEnd);
+
+        svgAttr(segmentDraggerGfx, { 'data-segment-idx': i });
+
+        bindInteractionEvents(segmentDraggerGfx, 'mousemove', connection);
       }
     }
   }
@@ -230,6 +244,51 @@ export default function Bendpoints(
     }
   }
 
+  function updateFloatingBendpointPosition(parentGfx, intersection) {
+    var floating = domQuery('.floating', parentGfx),
+        point = intersection.point;
+
+    if (!floating) {
+      return;
+    }
+
+    translate(floating, point.x, point.y);
+
+  }
+
+  function updateSegmentDraggerPosition(parentGfx, intersection, waypoints) {
+
+    var draggerGfx = getSegmentDragger(intersection.index, parentGfx),
+        segmentStart = waypoints[intersection.index - 1],
+        segmentEnd = waypoints[intersection.index],
+        point = intersection.point,
+        mid = getMidPoint(segmentStart, segmentEnd),
+        alignment = pointsAligned(segmentStart, segmentEnd),
+        draggerVisual, relativePosition;
+
+    if (!draggerGfx) {
+      return;
+    }
+
+    draggerVisual = getVisual(draggerGfx);
+
+    relativePosition = {
+      x: point.x - mid.x,
+      y: point.y - mid.y
+    };
+
+    if (alignment === 'v') {
+
+      // rotate position
+      relativePosition = {
+        x: relativePosition.y,
+        y: relativePosition.x
+      };
+    }
+
+    translate(draggerVisual, relativePosition.x, relativePosition.y);
+  }
+
   eventBus.on('connection.changed', function(event) {
     updateHandles(event.element);
   });
@@ -265,21 +324,17 @@ export default function Bendpoints(
     var element = event.element,
         waypoints = element.waypoints,
         bendpointsGfx,
-        floating,
         intersection;
 
     if (waypoints) {
       bendpointsGfx = getBendpointsContainer(element, true);
-      floating = domQuery('.floating', bendpointsGfx);
-
-      if (!floating) {
-        return;
-      }
 
       intersection = getConnectionIntersection(waypoints, event.originalEvent);
 
       if (intersection) {
-        translate(floating, intersection.point.x, intersection.point.y);
+        updateFloatingBendpointPosition(bendpointsGfx, intersection);
+
+        updateSegmentDraggerPosition(bendpointsGfx, intersection, waypoints);
       }
     }
   });

--- a/lib/features/bendpoints/Bendpoints.js
+++ b/lib/features/bendpoints/Bendpoints.js
@@ -11,12 +11,17 @@ import {
   SEGMENT_DRAGGER_CLS,
   addBendpoint,
   addSegmentDragger,
-  toCanvasCoordinates
+  toCanvasCoordinates,
+  calculateSegmentMoveRegion
 } from './BendpointUtil';
 
 import {
   escapeCSS
 } from '../../util/EscapeUtil';
+
+import {
+  getVisual
+} from '../../util/GraphicsUtil';
 
 import {
   pointsAligned,
@@ -52,6 +57,10 @@ export default function Bendpoints(
     return intersection;
   }
 
+  /**
+   * Returns true if intersection point is inside middle region of segment, adjusted by
+   * optional threshold
+   */
   function isIntersectionMiddle(intersection, waypoints, treshold) {
     var idx = intersection.index,
         p = intersection.point,
@@ -71,15 +80,50 @@ export default function Bendpoints(
     return aligned && xDelta <= treshold && yDelta <= treshold;
   }
 
+  /**
+   * Calculates the threshold from a connection's middle which fits the two-third-region
+   */
+  function calculateIntersectionThreshold(connection, intersection) {
+    var waypoints = connection.waypoints,
+        relevantSegment, alignment, segmentLength, threshold;
+
+    // segment relative to connection intersection
+    relevantSegment = {
+      start: waypoints[intersection.index - 1],
+      end: waypoints[intersection.index]
+    };
+
+    alignment = pointsAligned(relevantSegment.start, relevantSegment.end);
+
+    if (!alignment) {
+      // default to 10px threshold for non-aligned segments
+      return 10;
+    }
+
+    if (alignment === 'h') {
+      segmentLength = relevantSegment.end.x - relevantSegment.start.x;
+    } else {
+      segmentLength = relevantSegment.end.y - relevantSegment.start.y;
+    }
+
+    // calculate threshold relative to 2/3 of segment length
+    threshold = calculateSegmentMoveRegion(segmentLength) / 2;
+
+    return threshold;
+  }
+
   function activateBendpointMove(event, connection) {
     var waypoints = connection.waypoints,
-        intersection = getConnectionIntersection(waypoints, event);
+        intersection = getConnectionIntersection(waypoints, event),
+        threshold;
 
     if (!intersection) {
       return;
     }
 
-    if (isIntersectionMiddle(intersection, waypoints, 10)) {
+    threshold = calculateIntersectionThreshold(connection, intersection);
+
+    if (isIntersectionMiddle(intersection, waypoints, threshold)) {
       connectionSegmentMove.start(event, connection, intersection.index);
     } else {
       bendpointMove.start(event, connection, intersection.index, !intersection.bendpoint);

--- a/lib/features/bendpoints/ConnectionSegmentMove.js
+++ b/lib/features/bendpoints/ConnectionSegmentMove.js
@@ -4,7 +4,8 @@ import {
 } from '../../util/Geometry';
 
 import {
-  addSegmentDragger
+  addSegmentDragger,
+  getConnectionIntersection
 } from './BendpointUtil';
 
 import {
@@ -83,8 +84,7 @@ function getDocking(point, referenceElement, moveAxis) {
  */
 export default function ConnectionSegmentMove(
     injector, eventBus, canvas,
-    dragging, graphicsFactory, rules,
-    modeling) {
+    dragging, graphicsFactory, modeling) {
 
   // optional connection docking integration
   var connectionDocking = injector.get('connectionDocking', false);
@@ -101,8 +101,8 @@ export default function ConnectionSegmentMove(
         waypoints = connection.waypoints,
         segmentStart = waypoints[segmentStartIndex],
         segmentEnd = waypoints[segmentEndIndex],
-        direction,
-        axis;
+        intersection = getConnectionIntersection(canvas, waypoints, event),
+        direction, axis, dragPosition;
 
     direction = pointsAligned(segmentStart, segmentEnd);
 
@@ -122,19 +122,27 @@ export default function ConnectionSegmentMove(
       segmentEnd = getDocking(segmentEnd, connection.target, axis);
     }
 
+    if (intersection) {
+      dragPosition = intersection.point;
+    } else {
+      // set to segment center as default
+      dragPosition = {
+        x: (segmentStart.x + segmentEnd.x) / 2,
+        y: (segmentStart.y + segmentEnd.y) / 2
+      };
+    }
+
     context = {
       connection: connection,
       segmentStartIndex: segmentStartIndex,
       segmentEndIndex: segmentEndIndex,
       segmentStart: segmentStart,
       segmentEnd: segmentEnd,
-      axis: axis
+      axis: axis,
+      dragPosition: dragPosition
     };
 
-    dragging.init(event, {
-      x: (segmentStart.x + segmentEnd.x)/2,
-      y: (segmentStart.y + segmentEnd.y)/2
-    }, 'connectionSegment.move', {
+    dragging.init(event, dragPosition, 'connectionSegment.move', {
       cursor: axis === 'x' ? 'resize-ew' : 'resize-ns',
       data: {
         connection: connection,
@@ -413,6 +421,5 @@ ConnectionSegmentMove.$inject = [
   'canvas',
   'dragging',
   'graphicsFactory',
-  'rules',
   'modeling'
 ];

--- a/lib/features/interaction-events/InteractionEvents.js
+++ b/lib/features/interaction-events/InteractionEvents.js
@@ -116,6 +116,7 @@ export default function InteractionEvents(eventBus, elementRegistry, styles) {
     click: 'element.click',
     dblclick: 'element.dblclick',
     mousedown: 'element.mousedown',
+    mousemove: 'element.mousemove',
     mouseup: 'element.mouseup',
     contextmenu: 'element.contextmenu'
   };

--- a/test/spec/features/bendpoints/BendpointsSpec.js
+++ b/test/spec/features/bendpoints/BendpointsSpec.js
@@ -111,7 +111,7 @@ describe('features/bendpoints', function() {
     }));
 
 
-    it('should show on select', inject(function(selection, canvas, elementRegistry) {
+    it('should show on select', inject(function(selection, canvas) {
 
       // given
       var layer = canvas.getLayer('overlays');
@@ -126,61 +126,190 @@ describe('features/bendpoints', function() {
     }));
 
 
-    it('should activate bendpoint move', inject(
-      function(dragging, eventBus, elementRegistry, bendpoints) {
+    describe('horizontal', function() {
 
-        // when
-        eventBus.fire('element.hover', {
-          element: connection,
-          gfx: elementRegistry.getGraphics(connection)
-        });
-        eventBus.fire('element.mousemove', {
-          element: connection,
-          originalEvent: canvasEvent({ x: 500, y: 250 })
-        });
-        eventBus.fire('element.mousedown', {
-          element: connection,
-          originalEvent: canvasEvent({ x: 500, y: 250 })
-        });
+      it('should activate bendpoint move outside two-third-region', inject(
+        function(dragging, eventBus, elementRegistry) {
 
-        var draggingContext = dragging.context();
+          // when
+          eventBus.fire('element.hover', {
+            element: connection,
+            gfx: elementRegistry.getGraphics(connection)
+          });
+          eventBus.fire('element.mousemove', {
+            element: connection,
+            originalEvent: canvasEvent({ x: 525, y: 200 })
+          });
+          eventBus.fire('element.mousedown', {
+            element: connection,
+            originalEvent: canvasEvent({ x: 525, y: 250 })
+          });
 
-        // then
-        expect(draggingContext).to.exist;
-        expect(draggingContext.prefix).to.eql('bendpoint.move');
-      }
-    ));
+          var draggingContext = dragging.context();
+
+          // then
+          expect(draggingContext).to.exist;
+          expect(draggingContext.prefix).to.eql('bendpoint.move');
+        }
+      ));
 
 
-    it('should activate parallel move', inject(
-      function(dragging, eventBus, elementRegistry, bendpoints) {
+      it('should activate parallel move on segment center', inject(
+        function(dragging, eventBus, elementRegistry) {
 
-        // precondition
-        var intersectionStart = connection.waypoints[0].x,
-            intersectionEnd = connection.waypoints[1].x,
-            intersectionMid = intersectionEnd - (intersectionEnd - intersectionStart) / 2;
+          // precondition
+          var segmentStart = connection.waypoints[0].x,
+              segmentEnd = connection.waypoints[1].x,
+              segmentCenter = segmentEnd - (segmentEnd - segmentStart) / 2;
 
-        // when
-        eventBus.fire('element.hover', {
-          element: connection,
-          gfx: elementRegistry.getGraphics(connection)
-        });
-        eventBus.fire('element.mousemove', {
-          element: connection,
-          originalEvent: canvasEvent({ x: intersectionMid, y: 250 })
-        });
-        eventBus.fire('element.mousedown', {
-          element: connection,
-          originalEvent: canvasEvent({ x: intersectionMid, y: 250 })
-        });
+          // when
+          eventBus.fire('element.hover', {
+            element: connection,
+            gfx: elementRegistry.getGraphics(connection)
+          });
+          eventBus.fire('element.mousemove', {
+            element: connection,
+            originalEvent: canvasEvent({ x: segmentCenter, y: 250 })
+          });
+          eventBus.fire('element.mousedown', {
+            element: connection,
+            originalEvent: canvasEvent({ x: segmentCenter, y: 250 })
+          });
 
-        var draggingContext = dragging.context();
+          var draggingContext = dragging.context();
 
-        // then
-        expect(draggingContext).to.exist;
-        expect(draggingContext.prefix).to.eql('connectionSegment.move');
-      }
-    ));
+          // then
+          expect(draggingContext).to.exist;
+          expect(draggingContext.prefix).to.eql('connectionSegment.move');
+        }
+      ));
+
+
+      it('should activate parallel move in two-third-region', inject(
+        function(dragging, eventBus, elementRegistry) {
+
+          // precondition
+          var intersectionStart = connection.waypoints[0].x,
+              intersectionEnd = connection.waypoints[1].x,
+              segmentLength = intersectionEnd - intersectionStart,
+              twoThirdStart = intersectionStart + (segmentLength * 0.333) / 2;
+
+          // when
+          eventBus.fire('element.hover', {
+            element: connection,
+            gfx: elementRegistry.getGraphics(connection)
+          });
+          eventBus.fire('element.mousemove', {
+            element: connection,
+            originalEvent: canvasEvent({ x: twoThirdStart, y: 250 })
+          });
+          eventBus.fire('element.mousedown', {
+            element: connection,
+            originalEvent: canvasEvent({ x: twoThirdStart, y: 250 })
+          });
+
+          var draggingContext = dragging.context();
+
+          // then
+          expect(draggingContext).to.exist;
+          expect(draggingContext.prefix).to.eql('connectionSegment.move');
+        }
+      ));
+
+    });
+
+
+    describe('vertical', function() {
+
+      it('should activate bendpoint move outside two-third-region', inject(
+        function(dragging, eventBus, elementRegistry) {
+
+          // when
+          eventBus.fire('element.hover', {
+            element: connection,
+            gfx: elementRegistry.getGraphics(connection)
+          });
+          eventBus.fire('element.mousemove', {
+            element: connection,
+            originalEvent: canvasEvent({ x: 525, y: 250 })
+          });
+          eventBus.fire('element.mousedown', {
+            element: connection,
+            originalEvent: canvasEvent({ x: 525, y: 250 })
+          });
+
+          var draggingContext = dragging.context();
+
+          // then
+          expect(draggingContext).to.exist;
+          expect(draggingContext.prefix).to.eql('bendpoint.move');
+        }
+      ));
+
+
+      it('should activate parallel move on segment center', inject(
+        function(dragging, eventBus, elementRegistry) {
+
+          // precondition
+          var segmentStart = connection.waypoints[1].y,
+              segmentEnd = connection.waypoints[2].y,
+              segmentCenter = segmentEnd - (segmentEnd - segmentStart) / 2;
+
+          // when
+          eventBus.fire('element.hover', {
+            element: connection,
+            gfx: elementRegistry.getGraphics(connection)
+          });
+          eventBus.fire('element.mousemove', {
+            element: connection,
+            originalEvent: canvasEvent({ x: 555, y: segmentCenter })
+          });
+          eventBus.fire('element.mousedown', {
+            element: connection,
+            originalEvent: canvasEvent({ x: 555, y: segmentCenter })
+          });
+
+          var draggingContext = dragging.context();
+
+          // then
+          expect(draggingContext).to.exist;
+          expect(draggingContext.prefix).to.eql('connectionSegment.move');
+        }
+      ));
+
+
+      it('should activate parallel move in two-third-region', inject(
+        function(dragging, eventBus, elementRegistry) {
+
+          // precondition
+          var intersectionStart = connection.waypoints[1].y,
+              intersectionEnd = connection.waypoints[2].y,
+              segmentLength = intersectionEnd - intersectionStart,
+              twoThirdStart = intersectionStart + (segmentLength * 0.333) / 2;
+
+          // when
+          eventBus.fire('element.hover', {
+            element: connection,
+            gfx: elementRegistry.getGraphics(connection)
+          });
+          eventBus.fire('element.mousemove', {
+            element: connection,
+            originalEvent: canvasEvent({ x: 555, y: twoThirdStart })
+          });
+          eventBus.fire('element.mousedown', {
+            element: connection,
+            originalEvent: canvasEvent({ x: 555, y: twoThirdStart })
+          });
+
+          var draggingContext = dragging.context();
+
+          // then
+          expect(draggingContext).to.exist;
+          expect(draggingContext.prefix).to.eql('connectionSegment.move');
+        }
+      ));
+
+    });
 
 
     describe('should trigger interaction events', function() {


### PR DESCRIPTION
Parallel movement was previously possible only when hovering and clicking on the connection's center, within a hard-coded threshold of 10px.

The move region is two-thirds of a connection segment's length measured from the center of that segment.

The move activation threshold is now half of that region.

- [x] Ensure visual cue for segment move is shown on hover within move region
- [x] Ensure segment movement activation is triggered within move region
- [x] Ensure bendpoint creation is possible on start/end of segment
- [x] Ensure position of yellow segment dragger marker is the same as cursor position on segment hover (same as with bendpoint marker)
- [x] Ensure position of yellow segment dragger marker is the same as cursor position on `connectionSegmentMove.start`

<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?_

Related to camunda/camunda-modeler#1197