### PR TITLE
Remove redundant bendpoints from preview

### DIFF
--- a/lib/features/bendpoints/BendpointMove.js
+++ b/lib/features/bendpoints/BendpointMove.js
@@ -1,7 +1,6 @@
 import {
-  pointDistance,
-  pointsOnLine
-} from '../../util/Geometry';
+  filterRedundantWaypoints
+} from '../../layout/LayoutUtil';
 
 var COMMAND_BENDPOINT_UPDATE = 'connection.updateWaypoints',
     COMMAND_RECONNECT_START = 'connection.reconnectStart',
@@ -57,37 +56,6 @@ export default function BendpointMove(injector, eventBus, canvas, dragging, rule
       }
     });
   };
-
-
-  // DRAGGING IMPLEMENTATION
-  function filterRedundantWaypoints(waypoints) {
-
-    // alter copy of waypoints, not original
-    waypoints = waypoints.slice();
-
-    var idx = 0,
-        point,
-        previousPoint,
-        nextPoint;
-
-    while (waypoints[idx]) {
-      point = waypoints[idx];
-      previousPoint = waypoints[idx - 1];
-      nextPoint = waypoints[idx + 1];
-
-      if (pointDistance(point, nextPoint) === 0 ||
-          pointsOnLine(previousPoint, nextPoint, point)) {
-
-        // remove point, if overlapping with {nextPoint}
-        // or on line with {previousPoint} -> {point} -> {nextPoint}
-        waypoints.splice(idx, 1);
-      } else {
-        idx++;
-      }
-    }
-
-    return waypoints;
-  }
 
   eventBus.on('bendpoint.move.hover', function(e) {
     var context = e.context;

--- a/lib/features/bendpoints/BendpointMovePreview.js
+++ b/lib/features/bendpoints/BendpointMovePreview.js
@@ -7,6 +7,10 @@ import {
   addBendpoint
 } from './BendpointUtil';
 
+import {
+  filterRedundantWaypoints
+} from '../../layout/LayoutUtil';
+
 import { translate } from '../../util/SvgTransformUtil';
 
 
@@ -25,7 +29,8 @@ var HIGH_PRIORITY = 1100;
  */
 export default function BendpointMovePreview(injector, eventBus, canvas) {
 
-  var connectionPreview = injector.get('connectionPreview', false);
+  var connectionPreview = injector.get('connectionPreview', false),
+      connectionDocking = injector.get('connectionDocking', false);
 
   // DRAGGING IMPLEMENTATION
 
@@ -93,7 +98,8 @@ export default function BendpointMovePreview(injector, eventBus, canvas) {
     var context = e.context,
         moveType = context.type,
         connection = e.connection,
-        waypoints = connection.waypoints.slice(),
+        originalWaypoints = connection.waypoints,
+        waypoints = originalWaypoints.slice(),
         bendpoint = { x: e.x, y: e.y },
         hints;
 
@@ -110,11 +116,25 @@ export default function BendpointMovePreview(injector, eventBus, canvas) {
         hints.target = context.target;
         hints.connectionEnd = bendpoint;
       } else {
+        hints.noCropping = true;
         hints.noLayout = true;
         waypoints[context.bendpointIndex] = bendpoint;
       }
 
-      hints.waypoints = waypoints;
+      if (connectionDocking) {
+        // (0) temporarily assign new waypoints
+        connection.waypoints = waypoints;
+
+        // (1) crop connection with new waypoints and save them
+        connection.waypoints = connectionDocking.getCroppedWaypoints(connection);
+        waypoints = connection.waypoints;
+
+        // (2) restore original waypoints to not mutate connection directly
+        connection.waypoints = originalWaypoints;
+      }
+
+      // remove overlapping points
+      hints.waypoints = filterRedundantWaypoints(waypoints);
 
       connectionPreview.drawPreview(context, context.allowed, hints);
     }

--- a/lib/features/connection-preview/ConnectionPreview.js
+++ b/lib/features/connection-preview/ConnectionPreview.js
@@ -62,6 +62,7 @@ ConnectionPreview.$inject = [
  * @param {Point} [hints.connectionEnd] connection preview end
  * @param {Array<Point>} [hints.waypoints] provided waypoints for preview
  * @param {boolean} [hints.noLayout] true if preview should not be laid out
+ * @param {boolean} [hints.noCropping] true if preview should not be cropped
  * @param {boolean} [hints.noNoop] true if simple connection should not be drawn
  */
 ConnectionPreview.prototype.drawPreview = function(context, canConnect, hints) {
@@ -76,6 +77,7 @@ ConnectionPreview.prototype.drawPreview = function(context, canConnect, hints) {
       connectionStart = hints.connectionStart,
       connectionEnd = hints.connectionEnd,
       noLayout = hints.noLayout,
+      noCropping = hints.noCropping,
       noNoop = hints.noNoop,
       connection;
 
@@ -123,7 +125,7 @@ ConnectionPreview.prototype.drawPreview = function(context, canConnect, hints) {
   }
 
   // optional cropping
-  if (this._connectionDocking && (source || target)) {
+  if (this._connectionDocking && (source || target) && !noCropping) {
     connection.waypoints = this._connectionDocking.getCroppedWaypoints(connection, source, target);
   }
 

--- a/lib/layout/LayoutUtil.js
+++ b/lib/layout/LayoutUtil.js
@@ -4,7 +4,8 @@ import {
 } from 'min-dash';
 
 import {
-  pointDistance
+  pointDistance,
+  pointsOnLine
 } from '../util/Geometry';
 
 import intersectPaths from 'path-intersection';
@@ -173,4 +174,34 @@ export function getElementLineIntersection(elementPath, linePath, cropStart) {
 
 export function getIntersections(a, b) {
   return intersectPaths(a, b);
+}
+
+
+export function filterRedundantWaypoints(waypoints) {
+
+  // alter copy of waypoints, not original
+  waypoints = waypoints.slice();
+
+  var idx = 0,
+      point,
+      previousPoint,
+      nextPoint;
+
+  while (waypoints[idx]) {
+    point = waypoints[idx];
+    previousPoint = waypoints[idx - 1];
+    nextPoint = waypoints[idx + 1];
+
+    if (pointDistance(point, nextPoint) === 0 ||
+        pointsOnLine(previousPoint, nextPoint, point)) {
+
+      // remove point, if overlapping with {nextPoint}
+      // or on line with {previousPoint} -> {point} -> {nextPoint}
+      waypoints.splice(idx, 1);
+    } else {
+      idx++;
+    }
+  }
+
+  return waypoints;
 }

--- a/test/spec/connection-preview/ConnectionPreviewSpec.js
+++ b/test/spec/connection-preview/ConnectionPreviewSpec.js
@@ -16,6 +16,7 @@ import {
 } from 'min-dom';
 import { isDefined } from 'min-dash';
 
+import { getMid } from '../../../lib/layout/LayoutUtil';
 
 var testModules = [
   modelingModule,
@@ -235,6 +236,31 @@ describe('features/connection-preview', function() {
       // then
       expect(waypoints).to.have.lengthOf(2);
       expect(waypoints.every(isDefined)).to.be.true;
+    }));
+
+
+    it('should not crop if explicitly disallowed', inject(function(connectionPreview) {
+
+      // given
+      var context = {},
+          hints = {
+            source: shape1,
+            target: shape2,
+            noCropping: true
+          };
+
+      // when
+      connectionPreview.drawPreview(context, true, hints);
+
+      var connection = context.getConnection(true),
+          waypoints = connection.waypoints;
+
+      // then
+      expect(waypoints).to.have.lengthOf(2);
+      expect(waypoints).to.eql([
+        getMid(shape1),
+        getMid(shape2)
+      ]);
     }));
 
   });

--- a/test/spec/features/bendpoints/BendpointsMoveSpec.js
+++ b/test/spec/features/bendpoints/BendpointsMoveSpec.js
@@ -18,6 +18,7 @@ import rulesModule from './rules';
 import modelingModule from 'lib/features/modeling';
 import selectModule from 'lib/features/selection';
 import connectionPreviewModule from 'lib/features/connection-preview';
+import CroppingConnectionDocking from 'lib/layout/CroppingConnectionDocking';
 
 import {
   query as domQuery,
@@ -413,7 +414,10 @@ describe('features/bendpoints - move', function() {
   describe('connection preview', function() {
 
     beforeEach(bootstrapDiagram({
-      modules: testModules.concat(connectionPreviewModule)
+      modules: testModules.concat(
+        connectionPreviewModule,
+        { connectionDocking: [ 'type', CroppingConnectionDocking ] }
+      )
     }));
 
     beforeEach(inject(setManualDragging));
@@ -486,6 +490,22 @@ describe('features/bendpoints - move', function() {
       expect(ctx.data.context.connectionPreviewGfx.parentNode).to.exist;
       expect(svgClasses(ctx.data.context.connectionPreviewGfx).has('djs-dragger')).to.be.true;
     }));
+
+
+    it('should filter out redundant waypoints from preview',
+      inject(function(bendpointMove, dragging) {
+
+        // when
+        bendpointMove.start(canvasEvent({ x: 500, y: 250 }), connection, 1);
+        dragging.move(canvasEvent({ x: 550, y: 250 }));
+
+        var ctx = dragging.context(),
+            preview = ctx.data.context.getConnection(true);
+
+        // then
+        expect(preview.waypoints).to.have.lengthOf(3);
+      })
+    );
   });
 
 });

--- a/test/spec/features/bendpoints/rules/BendpointRules.js
+++ b/test/spec/features/bendpoints/rules/BendpointRules.js
@@ -25,7 +25,7 @@ ConnectRules.prototype.init = function() {
   });
 
   this.addRule('connection.updateWaypoints', function(context) {
-    return null;
+    return true;
   });
 
   this.addRule('connection.reconnectEnd', function(context) {

--- a/test/spec/layout/LayoutUtilSpec.js
+++ b/test/spec/layout/LayoutUtilSpec.js
@@ -1,4 +1,5 @@
 import {
+  filterRedundantWaypoints,
   getOrientation,
   getMid
 } from 'lib/layout/LayoutUtil';
@@ -118,6 +119,56 @@ describe('layout/LayoutUtil', function() {
       expect(getOrientation(b, a)).to.equal('intersect');
     });
 
+  });
+
+
+  describe('#filterRedundantWaypoints', function() {
+
+    it('should remove points on line', function() {
+
+      // given
+      var points = [
+        { x: 0, y: 0 },
+        { x: 0, y: 10 },
+        { x: 10, y: 10 },
+        { x: 25, y: 25 },
+        { x: 50, y: 50 },
+        { x: 50, y: 75 },
+        { x: 50, y: 100 }
+      ];
+
+      // then
+      expect(filterRedundantWaypoints(points)).to.deep.equal([
+        { x: 0, y: 0 },
+        { x: 0, y: 10 },
+        { x: 10, y: 10 },
+        { x: 50, y: 50 },
+        { x: 50, y: 100 }
+      ]);
+    });
+
+
+    it('should remove equal points', function() {
+
+      // given
+      var points = [
+        { x: 0, y: 0 },
+        { x: 0, y: 0 },
+        { x: 0, y: 0 },
+        { x: 10, y: 20 },
+        { x: 50, y: 50 },
+        { x: 50, y: 50 },
+        { x: 50, y: 100 }
+      ];
+
+      // then
+      expect(filterRedundantWaypoints(points)).to.deep.equal([
+        { x: 0, y: 0 },
+        { x: 10, y: 20 },
+        { x: 50, y: 50 },
+        { x: 50, y: 100 }
+      ]);
+    });
   });
 
 });


### PR DESCRIPTION
This PR prevents such behavior:

![redundant](https://user-images.githubusercontent.com/28307541/58781688-e0a94600-85dc-11e9-8561-7bd71194c992.gif)
