### PR TITLE
Allow to replace element without connection layout

### DIFF
--- a/lib/features/modeling/Modeling.js
+++ b/lib/features/modeling/Modeling.js
@@ -447,21 +447,23 @@ Modeling.prototype.updateWaypoints = function(connection, newWaypoints, hints) {
   this._commandStack.execute('connection.updateWaypoints', context);
 };
 
-Modeling.prototype.reconnectStart = function(connection, newSource, dockingOrPoints) {
+Modeling.prototype.reconnectStart = function(connection, newSource, dockingOrPoints, hints) {
   var context = {
     connection: connection,
     newSource: newSource,
-    dockingOrPoints: dockingOrPoints
+    dockingOrPoints: dockingOrPoints,
+    hints: hints || {}
   };
 
   this._commandStack.execute('connection.reconnectStart', context);
 };
 
-Modeling.prototype.reconnectEnd = function(connection, newTarget, dockingOrPoints) {
+Modeling.prototype.reconnectEnd = function(connection, newTarget, dockingOrPoints, hints) {
   var context = {
     connection: connection,
     newTarget: newTarget,
-    dockingOrPoints: dockingOrPoints
+    dockingOrPoints: dockingOrPoints,
+    hints: hints || {}
   };
 
   this._commandStack.execute('connection.reconnectEnd', context);

--- a/lib/features/modeling/cmd/ReconnectConnectionHandler.js
+++ b/lib/features/modeling/cmd/ReconnectConnectionHandler.js
@@ -49,7 +49,12 @@ ReconnectConnectionHandler.prototype.postExecute = function(context) {
       newSource = context.newSource,
       movedEnd = newSource ? 'connectionStart' : 'connectionEnd',
       newWaypoint,
-      hints = {};
+      hints = context.hints,
+      layoutHints = {};
+
+  if (hints.layoutConnection === false) {
+    return;
+  }
 
   if (isArray(dockingOrPoints)) {
     newWaypoint = newSource ? dockingOrPoints[0] : dockingOrPoints[dockingOrPoints.length - 1];
@@ -57,9 +62,9 @@ ReconnectConnectionHandler.prototype.postExecute = function(context) {
     newWaypoint = dockingOrPoints;
   }
 
-  hints[movedEnd] = getDocking(newWaypoint);
+  layoutHints[movedEnd] = getDocking(newWaypoint);
 
-  this._modeling.layoutConnection(connection, hints);
+  this._modeling.layoutConnection(connection, layoutHints);
 };
 
 ReconnectConnectionHandler.prototype.revert = function(context) {

--- a/lib/features/modeling/cmd/ReplaceShapeHandler.js
+++ b/lib/features/modeling/cmd/ReplaceShapeHandler.js
@@ -93,7 +93,7 @@ ReplaceShapeHandler.prototype.preExecute = function(context) {
         allowed = canReconnect('connection.reconnectEnd', source, newShape, connection);
 
     if (allowed) {
-      self.reconnectEnd(connection, newShape, docking);
+      self.reconnectEnd(connection, newShape, docking, { layoutConnection: hints.layoutConnection });
     }
   });
 
@@ -104,7 +104,7 @@ ReplaceShapeHandler.prototype.preExecute = function(context) {
         allowed = canReconnect('connection.reconnectStart', newShape, target, connection);
 
     if (allowed) {
-      self.reconnectStart(connection, newShape, docking);
+      self.reconnectStart(connection, newShape, docking, { layoutConnection: hints.layoutConnection });
     }
 
   });
@@ -115,16 +115,19 @@ ReplaceShapeHandler.prototype.postExecute = function(context) {
   var modeling = this._modeling;
 
   var oldShape = context.oldShape,
-      newShape = context.newShape;
+      newShape = context.newShape,
+      layoutConnection = context.hints.layoutConnection;
 
-  // if an element gets resized on replace, layout the connection again
-  forEach(newShape.incoming, function(c) {
-    modeling.layoutConnection(c, { endChanged: true });
-  });
+  // do not layout if explicitly excluded
+  if (layoutConnection !== false) {
+    forEach(newShape.incoming, function(c) {
+      modeling.layoutConnection(c, { endChanged: true });
+    });
 
-  forEach(newShape.outgoing, function(c) {
-    modeling.layoutConnection(c, { startChanged: true });
-  });
+    forEach(newShape.outgoing, function(c) {
+      modeling.layoutConnection(c, { startChanged: true });
+    });
+  }
 
   modeling.removeShape(oldShape);
 };
@@ -136,18 +139,15 @@ ReplaceShapeHandler.prototype.revert = function(context) {};
 
 
 ReplaceShapeHandler.prototype.createShape = function(shape, position, target, hints) {
-  var modeling = this._modeling;
-  return modeling.createShape(shape, position, target, hints);
+  return this._modeling.createShape(shape, position, target, hints);
 };
 
 
-ReplaceShapeHandler.prototype.reconnectStart = function(connection, newSource, dockingPoint) {
-  var modeling = this._modeling;
-  modeling.reconnectStart(connection, newSource, dockingPoint);
+ReplaceShapeHandler.prototype.reconnectStart = function(connection, newSource, dockingPoint, hints) {
+  this._modeling.reconnectStart(connection, newSource, dockingPoint, hints);
 };
 
 
-ReplaceShapeHandler.prototype.reconnectEnd = function(connection, newTarget, dockingPoint) {
-  var modeling = this._modeling;
-  modeling.reconnectEnd(connection, newTarget, dockingPoint);
+ReplaceShapeHandler.prototype.reconnectEnd = function(connection, newTarget, dockingPoint, hints) {
+  this._modeling.reconnectEnd(connection, newTarget, dockingPoint, hints);
 };

--- a/test/spec/features/modeling/ReplaceShapeSpec.js
+++ b/test/spec/features/modeling/ReplaceShapeSpec.js
@@ -123,19 +123,36 @@ describe('features/modeling - replace shape', function() {
     }));
 
 
-    it('should relayout connection when replacing elements with different size', inject(function(elementFactory, modeling) {
+    it('should relayout connection when replacing elements with different size',
+      inject(function(modeling) {
 
-      // given
-      var newShapeData = { x: 130, y: 130, width: 200, height: 200 };
+        // given
+        var newShapeData = { x: 130, y: 130, width: 200, height: 200 };
 
-      // when
-      modeling.replaceShape(child2, newShapeData);
+        // when
+        modeling.replaceShape(child2, newShapeData);
 
-      // then
-      expect(connection.waypoints[0]).to.be.eql({ x: 385, y: 55 });
-      expect(connection.waypoints[1]).to.be.eql({ x: 130, y: 130 });
-    }));
+        // then
+        expect(connection.waypoints[0]).to.be.eql({ x: 385, y: 55 });
+        expect(connection.waypoints[1]).to.be.eql({ x: 130, y: 130 });
+      })
+    );
 
+
+    it('should NOT relayout connection when layoutConnection=false',
+      inject(function(modeling) {
+
+        // given
+        var newShapeData = { x: 130, y: 130, width: 200, height: 200 };
+
+        // when
+        modeling.replaceShape(child2, newShapeData, { layoutConnection: false });
+
+        // then
+        expect(connection.waypoints[0]).to.be.eql({ x: 385, y: 55 });
+        expect(connection.waypoints[1]).to.be.eql({ x: 80, y: 80 });
+      })
+    );
   });
 
 });


### PR DESCRIPTION
Simply pass hints with `layoutConnection=false` as the last param of `Modeling#replaceShape`.