### PR TITLE
Improve connection preview

### DIFF
--- a/lib/features/bendpoints/BendpointMovePreview.js
+++ b/lib/features/bendpoints/BendpointMovePreview.js
@@ -17,7 +17,8 @@ import { translate } from '../../util/SvgTransformUtil';
 var MARKER_OK = 'connect-ok',
     MARKER_NOT_OK = 'connect-not-ok',
     MARKER_CONNECT_HOVER = 'connect-hover',
-    MARKER_CONNECT_UPDATING = 'djs-updating';
+    MARKER_CONNECT_UPDATING = 'djs-updating',
+    MARKER_ELEMENT_HIDDEN = 'djs-element-hidden';
 
 var COMMAND_RECONNECT_START = 'connection.reconnectStart',
     COMMAND_RECONNECT_END = 'connection.reconnectEnd';
@@ -58,6 +59,7 @@ export default function BendpointMovePreview(injector, eventBus, canvas) {
     svgClasses(context.draggerGfx).add('djs-dragging');
 
     canvas.addMarker(connection, MARKER_CONNECT_UPDATING);
+    canvas.addMarker(connection, MARKER_ELEMENT_HIDDEN);
   });
 
   eventBus.on('bendpoint.move.hover', function(e) {
@@ -159,6 +161,7 @@ export default function BendpointMovePreview(injector, eventBus, canvas) {
     svgRemove(context.draggerGfx);
 
     canvas.removeMarker(connection, MARKER_CONNECT_UPDATING);
+    canvas.removeMarker(connection, MARKER_ELEMENT_HIDDEN);
 
     if (hover) {
       canvas.removeMarker(hover, MARKER_OK);

--- a/lib/features/connection-preview/ConnectionPreview.js
+++ b/lib/features/connection-preview/ConnectionPreview.js
@@ -16,6 +16,9 @@ import {
   getMid
 } from '../../layout/LayoutUtil';
 
+
+var MARKER_CONNECTION_PREVIEW = 'djs-connection-preview';
+
 /**
  * Draws connection preview. Optionally, this can use layouter and connection docking to draw
  * better looking previews.
@@ -215,7 +218,7 @@ ConnectionPreview.prototype.createConnectionPreviewGfx = function() {
     pointerEvents: 'none'
   });
 
-  svgClasses(gfx).add('djs-dragger');
+  svgClasses(gfx).add(MARKER_CONNECTION_PREVIEW);
 
   svgAppend(this._canvas.getDefaultLayer(), gfx);
 

--- a/lib/features/create/index.js
+++ b/lib/features/create/index.js
@@ -3,7 +3,6 @@ import SelectionModule from '../selection';
 import RulesModule from '../rules';
 
 import Create from './Create';
-import CreateConnectPreview from './CreateConnectPreview';
 
 
 export default {
@@ -12,9 +11,5 @@ export default {
     SelectionModule,
     RulesModule
   ],
-  __init__: [
-    'createConnectPreview'
-  ],
-  create: [ 'type', Create ],
-  createConnectPreview: [ 'type', CreateConnectPreview ]
+  create: [ 'type', Create ]
 };

--- a/test/spec/connection-preview/ConnectionPreviewSpec.js
+++ b/test/spec/connection-preview/ConnectionPreviewSpec.js
@@ -90,7 +90,7 @@ describe('features/connection-preview', function() {
       // when
       connectionPreview.drawPreview(context, true, hints);
 
-      var preview = domQuery('.djs-dragger', testContainer);
+      var preview = domQuery('.djs-connection-preview', testContainer);
 
       // then
       expect(preview).to.exist;
@@ -110,7 +110,7 @@ describe('features/connection-preview', function() {
       // when
       connectionPreview.drawPreview(context, true, hints);
 
-      var preview = domQuery('.djs-dragger', testContainer);
+      var preview = domQuery('.djs-connection-preview', testContainer);
 
       // then
       expect(preview).to.exist;
@@ -131,7 +131,7 @@ describe('features/connection-preview', function() {
       connectionPreview.drawPreview(context, true, hints);
       connectionPreview.cleanUp(context);
 
-      var preview = domQuery('.djs-dragger', testContainer);
+      var preview = domQuery('.djs-connection-preview', testContainer);
 
       // then
       expect(preview).not.to.exist;
@@ -154,7 +154,7 @@ describe('features/connection-preview', function() {
       // when
       connectionPreview.drawPreview(context, false, hints);
 
-      var preview = domQuery('.djs-dragger', testContainer);
+      var preview = domQuery('.djs-connection-preview', testContainer);
 
       // then
       expect(preview).to.exist;
@@ -175,7 +175,7 @@ describe('features/connection-preview', function() {
       // when
       connectionPreview.drawPreview(context, false, hints);
 
-      var preview = domQuery('.djs-dragger', testContainer);
+      var preview = domQuery('.djs-connection-preview', testContainer);
 
       // then
       expect(preview).to.exist;

--- a/test/spec/features/bendpoints/BendpointsMoveSpec.js
+++ b/test/spec/features/bendpoints/BendpointsMoveSpec.js
@@ -6,10 +6,6 @@ import {
 } from 'test/TestHelper';
 
 import {
-  classes as svgClasses
-} from 'tiny-svg';
-
-import {
   createCanvasEvent as canvasEvent
 } from '../../../util/MockEvents';
 
@@ -442,7 +438,6 @@ describe('features/bendpoints - move', function() {
 
       // then
       expect(ctx.data.context.connectionPreviewGfx.parentNode).to.exist;
-      expect(svgClasses(ctx.data.context.connectionPreviewGfx).has('djs-dragger')).to.be.true;
     }));
 
 
@@ -458,7 +453,6 @@ describe('features/bendpoints - move', function() {
 
       // then
       expect(ctx.data.context.connectionPreviewGfx.parentNode).to.exist;
-      expect(svgClasses(ctx.data.context.connectionPreviewGfx).has('djs-dragger')).to.be.true;
     }));
 
 
@@ -473,7 +467,6 @@ describe('features/bendpoints - move', function() {
 
       // then
       expect(ctx.data.context.connectionPreviewGfx.parentNode).to.exist;
-      expect(svgClasses(ctx.data.context.connectionPreviewGfx).has('djs-dragger')).to.be.true;
     }));
 
 
@@ -488,7 +481,6 @@ describe('features/bendpoints - move', function() {
 
       // then
       expect(ctx.data.context.connectionPreviewGfx.parentNode).to.exist;
-      expect(svgClasses(ctx.data.context.connectionPreviewGfx).has('djs-dragger')).to.be.true;
     }));
 
 

--- a/test/spec/features/connect/ConnectSpec.js
+++ b/test/spec/features/connect/ConnectSpec.js
@@ -295,7 +295,6 @@ describe('features/connect', function() {
 
         // then
         expect(ctx.data.context.connectionPreviewGfx.parentNode).to.exist;
-        expect(svgClasses(ctx.data.context.connectionPreviewGfx).has('djs-dragger')).to.be.true;
       })
     );
 
@@ -311,7 +310,6 @@ describe('features/connect', function() {
 
       // then
       expect(ctx.data.context.connectionPreviewGfx.parentNode).to.exist;
-      expect(svgClasses(ctx.data.context.connectionPreviewGfx).has('djs-dragger')).to.be.true;
     }));
 
 
@@ -328,7 +326,6 @@ describe('features/connect', function() {
 
       // then
       expect(ctx.data.context.connectionPreviewGfx.parentNode).to.exist;
-      expect(svgClasses(ctx.data.context.connectionPreviewGfx).has('djs-dragger')).to.be.true;
     }));
 
   });

--- a/test/spec/features/create/CreateSpec.js
+++ b/test/spec/features/create/CreateSpec.js
@@ -336,7 +336,7 @@ describe('features/create - Create', function() {
     }));
 
 
-    describe('connection preview', function() {
+    describe.skip('connection preview', function() {
 
       beforeEach(bootstrapDiagram({
         modules: testModules.concat(connectionPreviewModule)


### PR DESCRIPTION
This PR:
* removes dependency on css class in several tests
* recolors connection preview to black
* hides modified connection
* disables connection preview when dragging a new element