### PR TITLE
chore(styles): disable .new-parent overlay for frame elements

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -37,6 +37,10 @@
   fill: #F7F9FF !important;
 }
 
+.djs-frame.new-parent .djs-visual > :nth-child(1) {
+  fill: none !important;
+}
+
 svg.drop-not-ok {
   background: #f9dee5 /* light-red */ !important;
 }


### PR DESCRIPTION
Disables the `.new-parent` overlay for frame elements.

Closes bpmn-io/bpmn-js#1054

![Jun-05-2019 08-17-02](https://user-images.githubusercontent.com/9433996/58934296-54c52480-876a-11e9-8340-4b5da05e1e34.gif)
