### PR TITLE
Ensure visually ignored / always on top movement is possible

### DIFF
--- a/lib/features/create/Create.js
+++ b/lib/features/create/Create.js
@@ -115,6 +115,11 @@ export default function Create(
       };
     }
 
+    // allow to ignore visually
+    if (create === null || attach === null) {
+      return null;
+    }
+
     return false;
   }
 
@@ -229,7 +234,7 @@ export default function Create(
         attach = canExecute && canExecute.attach,
         connect = canExecute && canExecute.connect;
 
-    if (!canExecute) {
+    if (canExecute === false || !target) {
       return false;
     }
 

--- a/lib/features/move/Move.js
+++ b/lib/features/move/Move.js
@@ -140,7 +140,7 @@ export default function MoveEvents(
         isAttach = canExecute === 'attach',
         shapes = context.shapes;
 
-    if (!canExecute) {
+    if (canExecute === false) {
       return false;
     }
 

--- a/test/spec/features/create/CreateSpec.js
+++ b/test/spec/features/create/CreateSpec.js
@@ -40,6 +40,7 @@ describe('features/create - Create', function() {
       hostShape,
       childShape,
       frameShape,
+      ignoreShape,
       newShape;
 
   function setManualDragging(dragging) {
@@ -86,6 +87,14 @@ describe('features/create - Create', function() {
     });
 
     canvas.addShape(frameShape, rootShape);
+
+
+    ignoreShape = elementFactory.createShape({
+      id: 'ignoreShape',
+      x: 600, y: 50, width: 100, height: 100
+    });
+
+    canvas.addShape(ignoreShape, rootShape);
 
 
     newShape = elementFactory.createShape({
@@ -252,6 +261,7 @@ describe('features/create - Create', function() {
 
       dragging.end();
 
+      // then
       expect(elementRegistry.getGraphics('attacher')).not.to.exist;
     }));
 
@@ -267,8 +277,30 @@ describe('features/create - Create', function() {
       dragging.hover({ element: parentShape, gfx: targetGfx });
       dragging.move(canvasEvent({ x: 200, y: 225 }));
 
+      // then
       expect(canvas.hasMarker(parentShape, 'new-parent')).to.be.true;
     }));
+
+
+    it('should ignore hovering', inject(
+      function(canvas, create, elementRegistry, dragging) {
+      // given
+        var targetGfx = elementRegistry.getGraphics('ignoreShape');
+
+        // when
+        create.start(canvasEvent({ x: 0, y: 0 }), newShape);
+
+        dragging.move(canvasEvent({ x: 650, y: 50 }));
+        dragging.hover({ element: ignoreShape, gfx: targetGfx });
+        dragging.move(canvasEvent({ x: 650, y: 60 }));
+
+        // then
+        var ctx = dragging.context();
+        expect(ctx.data.context.canExecute).to.equal(null);
+
+        expect(canvas.hasMarker(ignoreShape, 'new-parent')).to.be.false;
+      })
+    );
 
 
     it('should add "drop-not-ok" marker', inject(function(canvas, create, elementRegistry, dragging) {
@@ -282,6 +314,7 @@ describe('features/create - Create', function() {
       dragging.hover({ element: childShape, gfx: targetGfx });
       dragging.move(canvasEvent({ x: 50, y: 50 }));
 
+      // then
       expect(canvas.hasMarker(childShape, 'drop-not-ok')).to.be.true;
     }));
 
@@ -297,6 +330,7 @@ describe('features/create - Create', function() {
       dragging.hover({ element: frameShape, gfx: targetGfx });
       dragging.move(canvasEvent({ x: 50, y: 50 }));
 
+      // then
       expect(svgClasses(targetGfx).has('djs-frame')).to.be.true;
       expect(canvas.hasMarker(frameShape, 'drop-not-ok')).to.be.true;
     }));
@@ -313,6 +347,7 @@ describe('features/create - Create', function() {
       dragging.hover({ element: hostShape, gfx: hostGfx });
       dragging.move(canvasEvent({ x: 200, y: 350 }));
 
+      // then
       expect(canvas.hasMarker(hostShape, 'attach-ok')).to.be.true;
     }));
 
@@ -332,6 +367,7 @@ describe('features/create - Create', function() {
 
       dragging.end();
 
+      // then
       expect(canvas.hasMarker(parentShape, 'new-parent')).to.be.false;
       expect(canvas.hasMarker(parentShape, 'new-parent')).not.to.eql(hasMarker);
     }));

--- a/test/spec/features/create/rules/CreateRules.js
+++ b/test/spec/features/create/rules/CreateRules.js
@@ -17,6 +17,10 @@ CreateRules.prototype.init = function() {
 
     var target = context.target;
 
+    if (target && /ignore/.test(target.id)) {
+      return null;
+    }
+
     // can attach to host
     if (/host/.test(target.id)) {
       return 'attach';

--- a/test/spec/features/move/MovePreviewSpec.js
+++ b/test/spec/features/move/MovePreviewSpec.js
@@ -41,7 +41,7 @@ describe('features/move - MovePreview', function() {
     }));
 
 
-    var rootShape, parentShape, childShape, childShape2, connection;
+    var rootShape, parentShape, childShape, childShape2, connection, ignoreShape;
 
     beforeEach(inject(function(elementFactory, canvas) {
 
@@ -80,6 +80,14 @@ describe('features/move - MovePreview', function() {
       });
 
       canvas.addConnection(connection, parentShape);
+
+      ignoreShape = elementFactory.createShape({
+        id: 'ignore',
+        x: 450, y: 100, width: 300, height: 300
+      });
+
+      canvas.addShape(ignoreShape);
+
     }));
 
 
@@ -270,6 +278,33 @@ describe('features/move - MovePreview', function() {
           var childGfx = elementRegistry.getGraphics(childShape);
           expect(svgClasses(childGfx).has('drop-new-target')).to.equal(false);
           expect(svgClasses(childGfx).has('drop-not-ok')).to.equal(true);
+        })
+      );
+
+
+      it('should visually ignore new target, if canExecute reveals null',
+        inject(function(move, dragging, elementRegistry) {
+
+          // given
+          move.start(canvasEvent({ x: 10, y: 10 }), childShape);
+
+          var targetGfx = elementRegistry.getGraphics(ignoreShape);
+
+          // when
+          dragging.move(canvasEvent({ x: 450, y: 10 }));
+          dragging.hover(canvasEvent({ x: 450, y: 10 }, {
+            element: ignoreShape,
+            gfx: elementRegistry.getGraphics(childShape)
+          }));
+
+          dragging.move(canvasEvent({ x: 450, y: 12 }));
+
+          // then
+          var ctx = dragging.context();
+          expect(ctx.data.context.canExecute).to.equal(null);
+
+          expect(svgClasses(targetGfx).has('drop-new-target')).to.equal(false);
+
         })
       );
 

--- a/test/spec/features/move/rules/MoveRules.js
+++ b/test/spec/features/move/rules/MoveRules.js
@@ -21,6 +21,10 @@ MoveRules.prototype.init = function() {
     var target = context.target,
         shapes = context.shapes;
 
+    if (target && /ignore/.test(target.id)) {
+      return null;
+    }
+
     // not allowed to move on frame elements
     if (isFrameElement(target)) {
       return false;


### PR DESCRIPTION
Allow ignoring `.new-parent` overlay visually by setting `canExecute` to `null` 

Related to bpmn-io/bpmn-js#1065