### PR TITLE
feat(i18n): escape translations per default

### DIFF
--- a/lib/i18n/translate/translate.js
+++ b/lib/i18n/translate/translate.js
@@ -1,7 +1,10 @@
+import { escapeHTML } from '../../util/EscapeUtil';
+
+
 /**
  * A simple translation stub to be used for multi-language support
  * in diagrams. Can be easily replaced with a more sophisticated
- * solution.
+ * solution. Escapes HTML per default.
  *
  * @example
  *
@@ -13,14 +16,22 @@
  *
  * @param {String} template to interpolate
  * @param {Object} [replacements] a map with substitutes
+ * @param {boolean} [safe] true if should not be escaped
  *
  * @return {String} the translated string
  */
-export default function translate(template, replacements) {
+export default function translate(template, replacements, safe) {
+
+  if (typeof replacements === 'boolean') {
+    safe = replacements;
+    replacements = {};
+  }
 
   replacements = replacements || {};
 
-  return template.replace(/{([^}]+)}/g, function(_, key) {
+  template = template.replace(/{([^}]+)}/g, function(_, key) {
     return replacements[key] || '{' + key + '}';
   });
+
+  return safe ? template : escapeHTML(template);
 }

--- a/lib/util/EscapeUtil.js
+++ b/lib/util/EscapeUtil.js
@@ -3,12 +3,17 @@ export {
 } from 'css.escape';
 
 var HTML_ESCAPE_MAP = {
-  '<': '&lt',
-  '>': '&gt'
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  '\'': '&#39;'
 };
 
 export function escapeHTML(str) {
-  return str.replace(/[<>]/g, function(match) {
+  str = '' + str;
+
+  return str && str.replace(/[&<>"']/g, function(match) {
     return HTML_ESCAPE_MAP[match];
   });
 }

--- a/test/spec/i18n/translate/translateSpec.js
+++ b/test/spec/i18n/translate/translateSpec.js
@@ -38,6 +38,17 @@ describe('i18n - translate', function() {
       expect(translate('FOO {bar}!', {})).to.eql('FOO {bar}!');
     }));
 
+
+    it('should escape HTML per default', inject(function(translate) {
+      expect(translate('<b>Bold</b> statement', {})).to.eql('&lt;b&gt;Bold&lt;/b&gt; statement');
+    }));
+
+
+    it('should not escape HTML for safe=true', inject(function(translate) {
+      expect(translate('<b>Bold</b> statement', true)).to.eql('<b>Bold</b> statement');
+      expect(translate('<b>Bold</b> statement', {}, true)).to.eql('<b>Bold</b> statement');
+    }));
+
   });
 
 

--- a/test/spec/util/EscapeUtilSpec.js
+++ b/test/spec/util/EscapeUtilSpec.js
@@ -11,10 +11,12 @@ describe('util/EscapeUtil', function() {
   });
 
 
-  it('escapeHTML', function() {
-    var htmlStr = '<video src=1 onerror=alert(\'hueh\')>';
+  it('should escape HTML', function() {
+    var htmlStr = '<video src=1 onerror=alert(\'hueh\')>',
+        htmlStr2 = '" onfocus=alert(1) "';
 
-    expect(escapeHTML(htmlStr)).to.eql('&ltvideo src=1 onerror=alert(\'hueh\')&gt');
+    expect(escapeHTML(htmlStr)).to.eql('&lt;video src=1 onerror=alert(&#39;hueh&#39;)&gt;');
+    expect(escapeHTML(htmlStr2)).to.eql('&quot; onfocus=alert(1) &quot;');
   });
 
 });


### PR DESCRIPTION
This makes sure that we escape translations per default to avoid XSS issues with i18n. Pass `safe=true` if the input is already safe.