### PR TITLE
feat(util): properly escape html entities

### DIFF
--- a/lib/util/EscapeUtil.js
+++ b/lib/util/EscapeUtil.js
@@ -3,12 +3,17 @@ export {
 } from 'css.escape';
 
 var HTML_ESCAPE_MAP = {
-  '<': '&lt',
-  '>': '&gt'
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  '\'': '&#39;'
 };
 
 export function escapeHTML(str) {
-  return str.replace(/[<>]/g, function(match) {
+  str = '' + str;
+
+  return str && str.replace(/[&<>"']/g, function(match) {
     return HTML_ESCAPE_MAP[match];
   });
 }

--- a/test/spec/util/EscapeUtilSpec.js
+++ b/test/spec/util/EscapeUtilSpec.js
@@ -11,10 +11,12 @@ describe('util/EscapeUtil', function() {
   });
 
 
-  it('escapeHTML', function() {
-    var htmlStr = '<video src=1 onerror=alert(\'hueh\')>';
+  it('should escape HTML', function() {
+    var htmlStr = '<video src=1 onerror=alert(\'hueh\')>',
+        htmlStr2 = '" onfocus=alert(1) "';
 
-    expect(escapeHTML(htmlStr)).to.eql('&ltvideo src=1 onerror=alert(\'hueh\')&gt');
+    expect(escapeHTML(htmlStr)).to.eql('&lt;video src=1 onerror=alert(&#39;hueh&#39;)&gt;');
+    expect(escapeHTML(htmlStr2)).to.eql('&quot; onfocus=alert(1) &quot;');
   });
 
 });


### PR DESCRIPTION
This PR introduces `EscapeUtil` improvement which is part of https://github.com/bpmn-io/diagram-js/pull/366 but without the i18n changes. 