### PR TITLE
Segment Dragger fixes

### DIFF
--- a/lib/features/bendpoints/Bendpoints.js
+++ b/lib/features/bendpoints/Bendpoints.js
@@ -78,6 +78,10 @@ export default function Bendpoints(
     var waypoints = connection.waypoints,
         relevantSegment, alignment, segmentLength, threshold;
 
+    if (intersection.index <= 0 || intersection.bendpoint) {
+      return null;
+    }
+
     // segment relative to connection intersection
     relevantSegment = {
       start: waypoints[intersection.index - 1],
@@ -87,8 +91,7 @@ export default function Bendpoints(
     alignment = pointsAligned(relevantSegment.start, relevantSegment.end);
 
     if (!alignment) {
-      // default to 10px threshold for non-aligned segments
-      return 10;
+      return null;
     }
 
     if (alignment === 'h') {

--- a/lib/features/bendpoints/Bendpoints.js
+++ b/lib/features/bendpoints/Bendpoints.js
@@ -320,11 +320,16 @@ export default function Bendpoints(
 
       intersection = getConnectionIntersection(canvas, waypoints, event.originalEvent);
 
-      if (intersection) {
-        updateFloatingBendpointPosition(bendpointsGfx, intersection);
+      if (!intersection) {
+        return;
+      }
 
+      updateFloatingBendpointPosition(bendpointsGfx, intersection);
+
+      if (!intersection.bendpoint) {
         updateSegmentDraggerPosition(bendpointsGfx, intersection, waypoints);
       }
+
     }
   });
 
@@ -382,6 +387,7 @@ export default function Bendpoints(
   this.addHandles = addHandles;
   this.updateHandles = updateHandles;
   this.getBendpointsContainer = getBendpointsContainer;
+  this.getSegmentDragger = getSegmentDragger;
 }
 
 Bendpoints.$inject = [

--- a/test/spec/features/bendpoints/BendpointsSpec.js
+++ b/test/spec/features/bendpoints/BendpointsSpec.js
@@ -19,6 +19,9 @@ import {
   queryAll as domQueryAll
 } from 'min-dom';
 
+import {
+  getVisual
+} from '../../../../lib/util/GraphicsUtil';
 
 describe('features/bendpoints', function() {
 
@@ -400,6 +403,100 @@ describe('features/bendpoints', function() {
         // then
         // bendpoint container references element with updated ID
         expect(bendpointContainer.dataset.elementId).to.equal('foo');
+      }
+    ));
+
+
+    it('should update floating bendpoint position on mousemove', inject(
+      function(selection, canvas, eventBus, elementRegistry) {
+
+        // given
+        var layer = canvas.getLayer('overlays');
+
+        selection.select(connection);
+
+        var bendpointContainer = domQuery('.djs-bendpoints', layer),
+            floatingBendpointGfx = domQuery('.floating', bendpointContainer),
+            oldBounds = floatingBendpointGfx.getBoundingClientRect();
+
+        // when
+        eventBus.fire('element.hover', {
+          element: connection,
+          gfx: elementRegistry.getGraphics(connection)
+        });
+        eventBus.fire('element.mousemove', {
+          element: connection,
+          originalEvent: canvasEvent({ x: 525, y: 250 })
+        });
+
+        var newBounds = floatingBendpointGfx.getBoundingClientRect();
+
+        // then
+        expect(newBounds).to.not.eql(oldBounds);
+        expect(newBounds.left).to.equal(525);
+      }
+    ));
+
+
+    it('should update segment dragger position on mousemove', inject(
+      function(selection, canvas, eventBus, elementRegistry, bendpoints) {
+
+        // given
+        var layer = canvas.getLayer('overlays');
+
+        selection.select(connection);
+
+        var bendpointContainer = domQuery('.djs-bendpoints', layer),
+            draggerGfx = bendpoints.getSegmentDragger(1, bendpointContainer),
+            draggerVisual = getVisual(draggerGfx),
+            oldBounds = draggerVisual.getBoundingClientRect();
+
+        // when
+        eventBus.fire('element.hover', {
+          element: connection,
+          gfx: elementRegistry.getGraphics(connection)
+        });
+        eventBus.fire('element.mousemove', {
+          element: connection,
+          originalEvent: canvasEvent({ x: 450, y: 250 })
+        });
+
+        var newBounds = draggerVisual.getBoundingClientRect();
+
+        // then
+        expect(newBounds).to.not.eql(oldBounds);
+        expect(newBounds.left).to.equal(453);
+      }
+    ));
+
+
+    it('should NOT update segment dragger position on bendpoint', inject(
+      function(selection, canvas, eventBus, elementRegistry, bendpoints) {
+
+        // given
+        var layer = canvas.getLayer('overlays');
+
+        selection.select(connection);
+
+        var bendpointContainer = domQuery('.djs-bendpoints', layer),
+            draggerGfx = bendpoints.getSegmentDragger(1, bendpointContainer),
+            draggerVisual = getVisual(draggerGfx),
+            oldBounds = draggerVisual.getBoundingClientRect();
+
+        // when
+        eventBus.fire('element.hover', {
+          element: connection,
+          gfx: elementRegistry.getGraphics(connection)
+        });
+        eventBus.fire('element.mousemove', {
+          element: connection,
+          originalEvent: canvasEvent({ x: 250, y: 250 })
+        });
+
+        var newBounds = draggerVisual.getBoundingClientRect();
+
+        // then
+        expect(newBounds).to.eql(oldBounds);
       }
     ));
 

--- a/test/spec/features/bendpoints/BendpointsSpec.js
+++ b/test/spec/features/bendpoints/BendpointsSpec.js
@@ -129,6 +129,84 @@ describe('features/bendpoints', function() {
     }));
 
 
+    it('should activate bendpoint move on starting waypoint', inject(
+      function(dragging, eventBus, elementRegistry) {
+
+        // when
+        eventBus.fire('element.hover', {
+          element: connection,
+          gfx: elementRegistry.getGraphics(connection)
+        });
+        eventBus.fire('element.mousemove', {
+          element: connection,
+          originalEvent: canvasEvent({ x: 250, y: 250 })
+        });
+        eventBus.fire('element.mousedown', {
+          element: connection,
+          originalEvent: canvasEvent({ x: 250, y: 250 })
+        });
+
+        var draggingContext = dragging.context();
+
+        // then
+        expect(draggingContext).to.exist;
+        expect(draggingContext.prefix).to.eql('bendpoint.move');
+      }
+    ));
+
+
+    it('should activate bendpoint move on intermediate waypoint', inject(
+      function(dragging, eventBus, elementRegistry) {
+
+        // when
+        eventBus.fire('element.hover', {
+          element: connection,
+          gfx: elementRegistry.getGraphics(connection)
+        });
+        eventBus.fire('element.mousemove', {
+          element: connection,
+          originalEvent: canvasEvent({ x: 550, y: 250 })
+        });
+        eventBus.fire('element.mousedown', {
+          element: connection,
+          originalEvent: canvasEvent({ x: 550, y: 250 })
+        });
+
+        var draggingContext = dragging.context();
+
+        // then
+        expect(draggingContext).to.exist;
+        expect(draggingContext.prefix).to.eql('bendpoint.move');
+      }
+    ));
+
+
+    it('should active bendpoint move on non-aligned segment', inject(
+      function(dragging, eventBus, elementRegistry) {
+
+        // when
+        eventBus.fire('element.hover', {
+          element: connection2,
+          gfx: elementRegistry.getGraphics(connection)
+        });
+        eventBus.fire('element.mousemove', {
+          element: connection2,
+          originalEvent: canvasEvent({ x: 361, y: 351 })
+        });
+        eventBus.fire('element.mousedown', {
+          element: connection2,
+          originalEvent: canvasEvent({ x: 327, y: 300 })
+        });
+
+        var draggingContext = dragging.context();
+
+        // then
+        expect(draggingContext).to.exist;
+        expect(draggingContext.prefix).to.eql('bendpoint.move');
+      }
+    ));
+
+
     describe('horizontal', function() {
 
       it('should activate bendpoint move outside two-third-region', inject(
@@ -141,7 +219,7 @@ describe('features/bendpoints', function() {
           });
           eventBus.fire('element.mousemove', {
             element: connection,
-            originalEvent: canvasEvent({ x: 525, y: 200 })
+            originalEvent: canvasEvent({ x: 525, y: 250 })
           });
           eventBus.fire('element.mousedown', {
             element: connection,


### PR DESCRIPTION
This prevents updating the segment dragger and starting segment move on bendpoint intersections (cf. `intersection.bendpoint === true`). 

Closes bpmn-io/bpmn-js#1096
Closes #369 