### PR TITLE
feat(styles): improve dragger text styles

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -144,14 +144,25 @@ svg.new-parent {
   stroke: rgb(255, 116, 0) !important;
 }
 
+.djs-dragger tspan,
+.djs-dragger text {
+  fill: rgb(255, 116, 0) !important;
+  stroke: none !important;
+}
+
 marker.djs-dragger circle,
 marker.djs-dragger path,
 marker.djs-dragger polygon,
 marker.djs-dragger polyline,
-marker.djs-dragger rect,
-marker.djs-dragger text {
+marker.djs-dragger rect {
   fill: rgb(255, 116, 0) !important;
   stroke: none !important;
+}
+
+marker.djs-dragger text,
+marker.djs-dragger tspan {
+  fill: none !important;
+  stroke: rgb(255, 116, 0) !important;
 }
 
 .djs-dragging {


### PR DESCRIPTION
This improves our drag preview styles for text.

Until now, text is rendered clumsy: 

![bug-before](https://user-images.githubusercontent.com/58601/60152776-422a9200-97e2-11e9-826a-108ee67fe3ee.gif)

With this change, text is rendered crisp when dragging:

![bug-after](https://user-images.githubusercontent.com/58601/60152775-4191fb80-97e2-11e9-9c80-79480c979d21.gif)
