### PR TITLE
fix(graphics-factory): don't update containments if less than 2 children

### DIFF
--- a/lib/core/GraphicsFactory.js
+++ b/lib/core/GraphicsFactory.js
@@ -157,7 +157,8 @@ GraphicsFactory.prototype.updateContainments = function(elements) {
 
     var children = parent.children;
 
-    if (!children) {
+    // no need to update order if less than two children
+    if (!children || children.length < 2) {
       return;
     }
 

--- a/test/spec/core/GraphicsFactorySpec.js
+++ b/test/spec/core/GraphicsFactorySpec.js
@@ -1,27 +1,20 @@
+/* global sinon */
+
 import {
   bootstrapDiagram,
   inject
 } from 'test/TestHelper';
 
-import { merge } from 'min-dash';
-
 import {
   classes as svgClasses
 } from 'tiny-svg';
 
+var spy = sinon.spy;
+
+
 describe('GraphicsFactory', function() {
 
-  var container;
-
-  function createDiagram(self, options) {
-
-    return bootstrapDiagram(function() {
-      container = self.tests[0].__testcontainer__;
-      return merge({ canvas: { container: container } }, options);
-    }, {});
-  }
-
-  beforeEach(createDiagram(this));
+  beforeEach(bootstrapDiagram());
 
 
   it('should not fail on update root shape', inject(
@@ -38,6 +31,56 @@ describe('GraphicsFactory', function() {
       // expect not to throw an exception
     }
   ));
+
+
+  describe('#updateContainments', function() {
+
+    var parent;
+
+    beforeEach(inject(function(canvas, elementFactory) {
+      var root = elementFactory.createRoot({
+        id: 'root'
+      });
+
+      canvas.setRootElement(root);
+
+      parent = elementFactory.createShape({
+        id: 'parent',
+        x: 100,
+        y: 100,
+        width: 100,
+        height: 100
+      });
+
+      canvas.addShape(parent, root);
+
+      var child = elementFactory.createShape({
+        id: 'child',
+        x: 125,
+        y: 125,
+        width: 50,
+        height: 50
+      });
+
+      canvas.addShape(child, parent);
+    }));
+
+
+    it('should NOT update containments if less than two children', inject(
+      function(elementRegistry, graphicsFactory) {
+
+        // given
+        var getGraphicsSpy = spy(elementRegistry, 'getGraphics');
+
+        // when
+        graphicsFactory.updateContainments([ parent ]);
+
+        // then
+        expect(getGraphicsSpy).not.to.have.been.called;
+      }
+    ));
+
+  });
 
 
   it('should add <djs-frame> class to frames', inject(


### PR DESCRIPTION
Prepending a node to itself blows up in Internet Exploder. 💥 

Related to bpmn-io/bpmn-js#746