### PR TITLE
Ensure firing out event

### DIFF
--- a/lib/features/dragging/HoverFix.js
+++ b/lib/features/dragging/HoverFix.js
@@ -6,20 +6,19 @@ import {
   toPoint
 } from '../../util/Event';
 
-function getGfx(target) {
-  var node = domClosest(target, 'svg, .djs-element', true);
-  return node;
-}
+var HIGH_PRIORITY = 1500;
 
 
 /**
- * Browsers may swallow the hover event if users are to
+ * Browsers may swallow certain events (hover, out ...) if users are to
  * fast with the mouse.
  *
  * @see http://stackoverflow.com/questions/7448468/why-cant-i-reliably-capture-a-mouseout-event
  *
  * The fix implemented in this component ensure that we
- * have a hover state after a successive drag.move event.
+ *
+ * 1) have a hover state after a successive drag.move event
+ * 2) have an out event when dragging leaves an element
  *
  * @param {EventBus} eventBus
  * @param {Dragging} dragging
@@ -29,15 +28,16 @@ export default function HoverFix(eventBus, dragging, elementRegistry) {
 
   var self = this;
 
-  // we wait for a specific sequence of events before
-  // emitting a fake drag.hover event.
-  //
-  // Event Sequence:
-  //
-  // drag.start
-  // drag.move
-  // drag.move >> ensure we are hovering
-  //
+  /**
+   * We wait for a specific sequence of events before
+   * emitting a fake drag.hover event.
+   *
+   * Event Sequence:
+   *
+   * drag.start
+   * drag.move
+   * drag.move >> ensure we are hovering
+   */
   eventBus.on('drag.start', function(event) {
 
     eventBus.once('drag.move', function() {
@@ -47,7 +47,65 @@ export default function HoverFix(eventBus, dragging, elementRegistry) {
         self.ensureHover(event);
       });
     });
+
   });
+
+
+  /**
+   * We make sure that drag.out is always fired, even if the
+   * browser swallows an element.out event.
+   *
+   * Event sequence:
+   *
+   * drag.hover
+   * (element.out >> sometimes swallowed)
+   * element.hover >> ensure we fired drag.out
+   */
+  eventBus.on('drag.init', function() {
+
+    var hover, hoverGfx;
+
+    function setDragHover(event) {
+      hover = event.hover;
+      hoverGfx = event.hoverGfx;
+    }
+
+    function unsetHover() {
+      hover = null;
+      hoverGfx = null;
+    }
+
+    function ensureOut() {
+
+      if (!hover) {
+        return;
+      }
+
+      var element = hover,
+          gfx = hoverGfx;
+
+      hover = null;
+      hoverGfx = null;
+
+      // emit synthetic out event
+      dragging.out({
+        element: element,
+        gfx: gfx
+      });
+    }
+
+    eventBus.on('drag.hover', setDragHover);
+    eventBus.on('element.out', unsetHover);
+    eventBus.on('element.hover', HIGH_PRIORITY, ensureOut);
+
+    eventBus.once('drag.cleanup', function() {
+      eventBus.off('drag.hover', setDragHover);
+      eventBus.off('element.out', unsetHover);
+      eventBus.off('element.hover', ensureOut);
+    });
+
+  });
+
 
   /**
    * Make sure we are god damn hovering!
@@ -91,3 +149,10 @@ HoverFix.$inject = [
   'dragging',
   'elementRegistry'
 ];
+
+
+// helpers /////////////////////
+
+function getGfx(target) {
+  return domClosest(target, 'svg, .djs-element', true);
+}

--- a/test/spec/features/dragging/HoverFixSpec.js
+++ b/test/spec/features/dragging/HoverFixSpec.js
@@ -1,7 +1,11 @@
+/* global sinon */
+
 import {
   bootstrapDiagram,
   inject
 } from 'test/TestHelper';
+
+import { assign } from 'min-dash';
 
 import { createCanvasEvent as canvasEvent } from '../../../util/MockEvents';
 
@@ -12,12 +16,35 @@ describe('features/dragging - HoverFix', function() {
 
   beforeEach(bootstrapDiagram({ modules: [ dragModule ] }));
 
-  beforeEach(inject(function(canvas) {
-    canvas.addShape({ id: 'shape', x: 10, y: 10, width: 50, height: 50 });
+  var shape1,
+      shape2;
+
+  beforeEach(inject(function(canvas, elementFactory) {
+
+    shape1 = elementFactory.createShape({
+      id: 'shape1',
+      x: 10,
+      y: 10,
+      width: 50,
+      height: 50
+    });
+
+    canvas.addShape(shape1);
+
+    shape2 = elementFactory.createShape({
+      id: 'shape2',
+      x: 100,
+      y: 10,
+      width: 50,
+      height: 50
+    });
+
+    canvas.addShape(shape2);
+
   }));
 
 
-  describe('behavior', function() {
+  describe('hover fix', function() {
 
     beforeEach(inject(function(dragging) {
       dragging.setOptions({ manual: true });
@@ -44,4 +71,94 @@ describe('features/dragging - HoverFix', function() {
 
   });
 
+
+  describe('out fix', function() {
+
+    it('should ensure out', inject(function(dragging, canvas, eventBus) {
+
+      // given
+      var listener = sinon.spy(function(event) {
+        expect(event.hover).to.eql(shape1);
+        expect(event.hoverGfx).to.eql(canvas.getGraphics(shape1));
+      });
+
+      eventBus.on('drag.out', listener);
+
+      // when
+      dragging.init(canvasEvent({ x: 10, y: 10 }), 'foo');
+      eventBus.fire('element.hover', { element: shape1, gfx: canvas.getGraphics(shape1) });
+
+      // (no out)
+      eventBus.fire('element.hover', { element: shape2, gfx: canvas.getGraphics(shape2) });
+
+      // then
+      expect(listener).to.have.been.calledOnce;
+    }));
+
+
+    it('should keep event order', inject(function(dragging, canvas, eventBus) {
+
+      // given
+      var eventNames = [
+            'drag.hover',
+            'drag.out'
+          ],
+          events = recordEvents(eventNames, eventBus);
+
+      // when
+      dragging.init(canvasEvent({ x: 10, y: 10 }), 'foo');
+      eventBus.fire('element.hover', { element: shape1, gfx: canvas.getGraphics(shape1) });
+
+      // (no out)
+      eventBus.fire('element.hover', { element: shape2, gfx: canvas.getGraphics(shape2) });
+
+      // then
+      expect(events).to.eql([
+        { type: 'drag.hover', hover: shape1 },
+        { type: 'drag.out', hover: shape1 },
+        { type: 'drag.hover', hover: shape2 }
+      ]);
+    }));
+
+
+    it('should prevent additional out', inject(function(dragging, canvas, eventBus) {
+
+      // given
+      var listener = sinon.spy(function(event) {
+        expect(event.hover).to.eql(shape1);
+        expect(event.hoverGfx).to.eql(canvas.getGraphics(shape1));
+      });
+
+      eventBus.on('drag.out', listener);
+
+      // when
+      dragging.init(canvasEvent({ x: 10, y: 10 }), 'foo');
+      eventBus.fire('element.hover', { element: shape1, gfx: canvas.getGraphics(shape1) });
+      eventBus.fire('element.out', { element: shape1, gfx: canvas.getGraphics(shape1) });
+      eventBus.fire('element.hover', { element: shape2, gfx: canvas.getGraphics(shape2) });
+
+      // then
+      expect(listener).to.have.been.calledOnce;
+    }));
+
+  });
+
 });
+
+// helpers /////////////////////
+
+function recordEvents(eventNames, eventBus) {
+
+  var events = [];
+
+  eventNames.forEach(function(eventName) {
+    eventBus.on(eventName, function(e) {
+      events.push(assign({}, {
+        type: e.type,
+        hover: e.hover
+      }));
+    });
+  });
+
+  return events;
+}


### PR DESCRIPTION
This ensures we definitely fire an `element.out` event between two `hover` for different elements. This way we make sure cursor and marker cleanup really got to run, despite the fact [some browsers swallow certain `mouseout` events](http://stackoverflow.com/questions/7448468/why-cant-i-reliably-capture-a-mouseout-event).

Related to camunda/camunda-modeler#1383