### PR TITLE
Select All Elements after Creating Elements

### DIFF
--- a/lib/features/selection/SelectionBehavior.js
+++ b/lib/features/selection/SelectionBehavior.js
@@ -3,7 +3,7 @@ import {
 } from '../../util/Mouse';
 
 import {
-  find
+  find, isArray
 } from 'min-dash';
 
 
@@ -13,10 +13,27 @@ export default function SelectionBehavior(
 
   eventBus.on('create.end', 500, function(e) {
 
-    // select the created shape after a
-    // successful create operation
-    if (e.context.canExecute) {
-      selection.select(e.context.shape);
+    var context = e.context,
+        canExecute = context.canExecute,
+        elements = context.elements,
+        hints = context.hints || {},
+        autoSelect = hints.autoSelect;
+
+    // select elements after they have been created
+    if (canExecute) {
+      if (autoSelect === false) {
+
+        // select no elements
+        return;
+      }
+
+      if (isArray(autoSelect)) {
+        selection.select(autoSelect);
+      } else {
+
+        // select all elements by default
+        selection.select(elements);
+      }
     }
   });
 

--- a/test/spec/features/selection/SelectionSpec.js
+++ b/test/spec/features/selection/SelectionSpec.js
@@ -6,6 +6,7 @@ import {
 } from 'test/TestHelper';
 
 import coreModule from 'lib/core';
+import createModule from 'lib/features/create';
 import draggingModule from 'lib/features/dragging';
 import modelingModule from 'lib/features/modeling';
 import moveModule from 'lib/features/move';
@@ -23,6 +24,7 @@ describe('features/selection/Selections', function() {
       coreModule,
       draggingModule,
       modelingModule,
+      createModule,
       moveModule,
       selectionModule
     ]
@@ -193,6 +195,114 @@ describe('features/selection/Selections', function() {
       expect(selection._selectedElements).to.be.empty;
 
       expect(changedSpy).to.have.been.called;
+    }));
+
+  });
+
+
+  describe('hints', function() {
+
+    var newElements,
+        shape1,
+        shape2,
+        rootShape,
+        rootGfx;
+
+    beforeEach(inject(function(elementFactory, canvas) {
+
+      rootShape = canvas.getRootElement(),
+
+      rootGfx = canvas.getGraphics(rootShape);
+
+      newElements = [];
+
+      shape1 = elementFactory.createShape({
+        id: 'newShape1',
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100
+      });
+
+      newElements.push(shape1);
+
+      shape2 = elementFactory.createShape({
+        id: 'newShape2',
+        x: 200,
+        y: 0,
+        width: 100,
+        height: 100
+      });
+
+      newElements.push(shape2);
+    }));
+
+
+    it('should select all created elements', inject(function(create, dragging, selection) {
+
+      // given
+      create.start(canvasEvent({ x: 0, y: 0 }), newElements);
+
+      dragging.hover({ element: rootShape, gfx: rootGfx });
+
+      dragging.move(canvasEvent({ x: 100, y: 100 }));
+
+      // when
+      dragging.end();
+
+      // then
+      var selected = selection.get();
+
+      expect(selected).to.exist;
+      expect(selected).to.eql(newElements);
+    }));
+
+
+    it('should NOT select all created elements', inject(function(create, dragging, selection) {
+
+      // given
+      create.start(canvasEvent({ x: 0, y: 0 }), newElements, {
+        hints: {
+          autoSelect: [ shape1 ]
+        }
+      });
+
+      dragging.hover({ element: rootShape, gfx: rootGfx });
+
+      dragging.move(canvasEvent({ x: 100, y: 100 }));
+
+      // when
+      dragging.end();
+
+      // then
+      var selected = selection.get();
+
+      expect(selected).to.exist;
+      expect(selected).to.eql([ shape1 ]);
+    }));
+
+
+    it('should NOT select created elements', inject(function(create, dragging, selection) {
+
+      // given
+      create.start(canvasEvent({ x: 0, y: 0 }), newElements, {
+        hints: {
+          autoSelect: false
+        }
+      });
+
+      dragging.hover({ element: rootShape, gfx: rootGfx });
+
+      dragging.move(canvasEvent({ x: 100, y: 100 }));
+
+      // when
+      dragging.end();
+
+      // then
+      var selected = selection.get();
+
+      expect(selected).to.exist;
+      expect(selected).to.be.empty;
     }));
 
   });

--- a/test/spec/features/selection/SelectionSpec.js
+++ b/test/spec/features/selection/SelectionSpec.js
@@ -105,7 +105,7 @@ describe('features/selection/Selections', function() {
 
 
     it('should select moved element if previously not in selection',
-      inject(function(dragging, elementRegistry, modeling, move, selection) {
+      inject(function(dragging, elementRegistry, move, selection) {
 
         // given
         selection.select(shape1);


### PR DESCRIPTION
Adds `autoSelect` hint for specifying elements that should be selected after create. Setting `autoSelect` to `false` will not select any elements.

Related to bpmn-io/bpmn-js#1152

![Aug-08-2019 10-44-00](https://user-images.githubusercontent.com/9433996/62708308-6d182080-b9f3-11e9-9645-b58a4bbd50b1.gif)
