### PR TITLE
fix(modeling): prevent fractional coordinates after create

### DIFF
--- a/lib/features/modeling/cmd/CreateElementsHandler.js
+++ b/lib/features/modeling/cmd/CreateElementsHandler.js
@@ -12,6 +12,7 @@ import {
   getParents
 } from '../../../util/Elements';
 
+var round = Math.round;
 
 export default function CreateElementsHandler(modeling) {
   this._modeling = modeling;
@@ -48,15 +49,15 @@ CreateElementsHandler.prototype.preExecute = function(context) {
     if (isConnection(element)) {
       element.waypoints = map(element.waypoints, function(waypoint) {
         return {
-          x: waypoint.x - bbox.x - bbox.width / 2 + position.x,
-          y: waypoint.y - bbox.y - bbox.height / 2 + position.y
+          x: round(waypoint.x - bbox.x - bbox.width / 2 + position.x),
+          y: round(waypoint.y - bbox.y - bbox.height / 2 + position.y)
         };
       });
     }
 
     assign(element, {
-      x: element.x - bbox.x - bbox.width / 2 + position.x,
-      y: element.y - bbox.y - bbox.height / 2 + position.y
+      x: round(element.x - bbox.x - bbox.width / 2 + position.x),
+      y: round(element.y - bbox.y - bbox.height / 2 + position.y)
     });
   });
 

--- a/test/spec/features/modeling/CreateElementsSpec.js
+++ b/test/spec/features/modeling/CreateElementsSpec.js
@@ -212,6 +212,27 @@ describe('features/modeling - create elements', function() {
       expect(elements[0]).to.equal(shape);
     }));
 
+
+    it('should not have fractional coordinates', inject(function(elementFactory, modeling) {
+
+      // given
+      var shape = elementFactory.createShape({
+        id: 'shape',
+        x: 110,
+        y: 110,
+        width: 105,
+        height: 105
+      });
+
+      var elements = modeling.createElements(shape, position, parentShape);
+
+      // then
+      expect(elements[0]).to.have.position({
+        x: 298,
+        y: 198
+      });
+    }));
+
   });
 
 


### PR DESCRIPTION
This ensures created elements will not have fractional coordinates after creating.

Closes bpmn-io/bpmn-js#1167