### PR TITLE
Disable snapping to diagram origin on create

### DIFF
--- a/lib/features/snapping/CreateMoveSnapping.js
+++ b/lib/features/snapping/CreateMoveSnapping.js
@@ -178,7 +178,10 @@ CreateMoveSnapping.prototype.addSnapTargetPoints = function(snapPoints, shape, t
     return snapPoints;
   }
 
-  snapPoints.add('mid', mid(shape));
+  // snap to original position when moving
+  if (this._elementRegistry.get(shape.id)) {
+    snapPoints.add('mid', mid(shape));
+  }
 
   return snapPoints;
 };

--- a/test/spec/snapping/CreateMoveSnappingSpec.js
+++ b/test/spec/snapping/CreateMoveSnappingSpec.js
@@ -224,6 +224,25 @@ describe('features/snapping - CreateMoveSnapping', function() {
       });
 
 
+      describe('snap to diagram origin', function() {
+
+        it('should NOT snap to (0, 0)', inject(function(dragging) {
+
+          // when
+          dragging.move(canvasEventMid({ x: 5, y: 5 }));
+
+          dragging.end();
+
+          // then
+          expect(mid(shape3)).to.have.eql({
+            x: 5, // NOT snapped
+            y: 5 // NOT snapped
+          });
+        }));
+
+      });
+
+
       describe('snap to connection', function() {
 
         it('should NOT snap mid, mid (1st waypoint)', inject(function(dragging) {


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js/issues/1165