### PR TITLE
chore(palette): use existing parent getter when initializing

### DIFF
--- a/lib/features/palette/Palette.js
+++ b/lib/features/palette/Palette.js
@@ -105,19 +105,19 @@ Palette.prototype.getEntries = function() {
   return entries;
 };
 
-
 /**
  * Initialize
  */
 Palette.prototype._init = function() {
-  var canvas = this._canvas,
-      eventBus = this._eventBus;
+  var self = this;
 
-  var parent = canvas.getContainer(),
-      container = this._container = domify(Palette.HTML_MARKUP),
-      self = this;
+  var eventBus = this._eventBus;
 
-  parent.appendChild(container);
+  var parentContainer = this._getParentContainer();
+
+  var container = this._container = domify(Palette.HTML_MARKUP);
+
+  parentContainer.appendChild(container);
 
   domDelegate.bind(container, ELEMENT_SELECTOR, 'click', function(event) {
 


### PR DESCRIPTION
The current palette implementation is flawed in a way that the parent
it mounts to cannot easily be overridden.

There exists the method Palette#_getParentContainer that serves the
purpose, however it is not being used in the palettes initialization
function.

This PR fixes this behavior.
