### PR TITLE
Set target on create.hover

### DIFF
--- a/lib/features/create/Create.js
+++ b/lib/features/create/Create.js
@@ -133,7 +133,7 @@ export default function Create(
 
   // event handling //////////
 
-  eventBus.on('create.move', function(event) {
+  eventBus.on([ 'create.move', 'create.hover' ], function(event) {
     var context = event.context,
         hover = event.hover,
         elements = context.elements,

--- a/lib/features/dragging/HoverFix.js
+++ b/lib/features/dragging/HoverFix.js
@@ -29,6 +29,26 @@ export default function HoverFix(eventBus, dragging, elementRegistry) {
   var self = this;
 
   /**
+   * Make sure we are god damn hovering!
+   *
+   * @param {Event} dragging event
+   */
+  function ensureHover(event) {
+
+    if (event.hover) {
+      return;
+    }
+
+    var gfx = self.findTargetGfx(event);
+
+    if (gfx) {
+      var element = elementRegistry.get(gfx);
+
+      dragging.hover({ element: element, gfx: gfx });
+    }
+  }
+
+  /**
    * We wait for a specific sequence of events before
    * emitting a fake drag.hover event.
    *
@@ -41,7 +61,7 @@ export default function HoverFix(eventBus, dragging, elementRegistry) {
 
     eventBus.once('drag.move', function(event) {
 
-      self.ensureHover(event);
+      ensureHover(event);
 
     });
 
@@ -103,23 +123,11 @@ export default function HoverFix(eventBus, dragging, elementRegistry) {
 
   });
 
-
-  /**
-   * Make sure we are god damn hovering!
-   *
-   * @param {Event} dragging event
-   */
-  this.ensureHover = function(event) {
-
-    if (event.hover) {
-      return;
-    }
-
+  this.findTargetGfx = function(event) {
     var originalEvent = event.originalEvent,
         position,
-        target,
-        element,
-        gfx;
+        target;
+
 
     if (!(originalEvent instanceof MouseEvent)) {
       return;
@@ -130,13 +138,7 @@ export default function HoverFix(eventBus, dragging, elementRegistry) {
     // damn expensive operation, ouch!
     target = document.elementFromPoint(position.x, position.y);
 
-    gfx = getGfx(target);
-
-    if (gfx) {
-      element = elementRegistry.get(gfx);
-
-      dragging.hover({ element: element, gfx: gfx });
-    }
+    return getGfx(target);
   };
 
 }

--- a/lib/features/dragging/HoverFix.js
+++ b/lib/features/dragging/HoverFix.js
@@ -17,7 +17,7 @@ var HIGH_PRIORITY = 1500;
  *
  * The fix implemented in this component ensure that we
  *
- * 1) have a hover state after a successive drag.move event
+ * 1) have a hover state after a successful drag.move event
  * 2) have an out event when dragging leaves an element
  *
  * @param {EventBus} eventBus
@@ -35,17 +35,14 @@ export default function HoverFix(eventBus, dragging, elementRegistry) {
    * Event Sequence:
    *
    * drag.start
-   * drag.move
    * drag.move >> ensure we are hovering
    */
   eventBus.on('drag.start', function(event) {
 
-    eventBus.once('drag.move', function() {
+    eventBus.once('drag.move', function(event) {
 
-      eventBus.once('drag.move', function(event) {
+      self.ensureHover(event);
 
-        self.ensureHover(event);
-      });
     });
 
   });

--- a/test/spec/features/create/CreateSpec.js
+++ b/test/spec/features/create/CreateSpec.js
@@ -59,7 +59,7 @@ describe('features/create - Create', function() {
     canvas.setRootElement(rootShape);
 
     parentShape = elementFactory.createShape({
-      id: 'parent',
+      id: 'parentShape',
       x: 100, y: 100, width: 300, height: 200
     });
 

--- a/test/spec/features/create/CreateSpec.js
+++ b/test/spec/features/create/CreateSpec.js
@@ -840,4 +840,31 @@ describe('features/create - Create', function() {
 
   });
 
+
+  describe('integration', function() {
+
+    it('should create on hover after dragging is initialized', inject(
+      function(create, dragging, elementRegistry, hoverFix) {
+
+        // given
+        hoverFix.findTargetGfx = function(event) {
+          return elementRegistry.getGraphics(parentShape);
+        };
+
+        // when
+        create.start(canvasEvent(getMid(parentShape)), newShape);
+
+        dragging.end();
+
+        // then
+        var createdShape = elementRegistry.get('newShape');
+
+        expect(createdShape).to.exist;
+        expect(createdShape).to.equal(newShape);
+        expect(createdShape.parent).to.equal(parentShape);
+      }
+    ));
+
+  });
+
 });

--- a/test/spec/features/dragging/HoverFixSpec.js
+++ b/test/spec/features/dragging/HoverFixSpec.js
@@ -63,7 +63,6 @@ describe('features/dragging - HoverFix', function() {
       // when
       dragging.init(canvasEvent({ x: 10, y: 10 }), 'foo');
       dragging.move(canvasEvent({ x: 30, y: 20 }));
-      dragging.move(canvasEvent({ x: 5, y: 10 }));
 
       // then
       expect(fixed).to.be.true;

--- a/test/spec/features/dragging/HoverFixSpec.js
+++ b/test/spec/features/dragging/HoverFixSpec.js
@@ -51,22 +51,31 @@ describe('features/dragging - HoverFix', function() {
     }));
 
 
-    it('should ensure hover', inject(function(dragging, hoverFix) {
+    it('should ensure hover', inject(
+      function(eventBus, dragging, hoverFix, elementRegistry) {
 
-      // given
-      var fixed = false;
+        // given
+        var gfx = elementRegistry.getGraphics(shape1);
 
-      hoverFix.ensureHover = function(event) {
-        fixed = true;
-      };
+        var listener = sinon.spy(function(event) {
+          expect(event.hover).to.eql(shape1);
+          expect(event.hoverGfx).to.eql(gfx);
+        });
 
-      // when
-      dragging.init(canvasEvent({ x: 10, y: 10 }), 'foo');
-      dragging.move(canvasEvent({ x: 30, y: 20 }));
+        eventBus.on('drag.hover', listener);
 
-      // then
-      expect(fixed).to.be.true;
-    }));
+        hoverFix.findTargetGfx = function(event) {
+          return gfx;
+        };
+
+        // when
+        dragging.init(canvasEvent({ x: 10, y: 10 }), 'foo');
+        dragging.move(canvasEvent({ x: 30, y: 20 }));
+
+        // then
+        expect(listener).to.have.been.calledOnce;
+      }
+    ));
 
   });
 


### PR DESCRIPTION
This sets the create target on every hover. We ensure via `HoverFix` that we always have a target to create on.

It also cleans up the existing `HoverFix` to ensure it
* executes after one  `drag.move` (as it worked before with the current use of the `eventBus`)
* offers a better test case to actually test the hovering, cf. [Hour Of Code](https://github.com/bpmn-io/hour-of-code/commit/cacaf6808213da7286db3e8322eb8f4a31f7e2c4)

![Kapture 2019-08-19 at 15 38 48](https://user-images.githubusercontent.com/9433996/63270150-dc193300-c297-11e9-80cf-c9a9c707d8ac.gif)

Related to camunda/camunda-modeler#1467