### PR TITLE
Fixup create

### DIFF
--- a/lib/features/create/Create.js
+++ b/lib/features/create/Create.js
@@ -167,11 +167,10 @@ export default function Create(
   });
 
   eventBus.on([ 'create.end', 'create.out', 'create.cleanup' ], function(event) {
-    var context = event.context,
-        target = context.target;
+    var hover = event.hover;
 
-    if (target) {
-      setMarker(target, null);
+    if (hover) {
+      setMarker(hover, null);
     }
   });
 

--- a/lib/features/dragging/HoverFix.js
+++ b/lib/features/dragging/HoverFix.js
@@ -39,12 +39,21 @@ export default function HoverFix(eventBus, dragging, elementRegistry) {
       return;
     }
 
-    var gfx = self._findTargetGfx(event);
+    var originalEvent = event.originalEvent;
+
+    var gfx = self._findTargetGfx(originalEvent);
 
     if (gfx) {
       var element = elementRegistry.get(gfx);
 
+      // 1) cancel current mousemove
+      event.stopPropagation();
+
+      // 2) emit fake hover for new target
       dragging.hover({ element: element, gfx: gfx });
+
+      // 3) re-trigger move event
+      dragging.move(originalEvent);
     }
   }
 
@@ -59,7 +68,7 @@ export default function HoverFix(eventBus, dragging, elementRegistry) {
    */
   eventBus.on('drag.start', function(event) {
 
-    eventBus.once('drag.move', function(event) {
+    eventBus.once('drag.move', HIGH_PRIORITY, function(event) {
 
       ensureHover(event);
 
@@ -124,15 +133,14 @@ export default function HoverFix(eventBus, dragging, elementRegistry) {
   });
 
   this._findTargetGfx = function(event) {
-    var originalEvent = event.originalEvent,
-        position,
+    var position,
         target;
 
-    if (!(originalEvent instanceof MouseEvent)) {
+    if (!(event instanceof MouseEvent)) {
       return;
     }
 
-    position = toPoint(originalEvent);
+    position = toPoint(event);
 
     // damn expensive operation, ouch!
     target = document.elementFromPoint(position.x, position.y);

--- a/test/spec/features/dragging/HoverFixSpec.js
+++ b/test/spec/features/dragging/HoverFixSpec.js
@@ -77,6 +77,41 @@ describe('features/dragging - HoverFix', function() {
       }
     ));
 
+
+    it('should trigger hover and then move', inject(
+      function(eventBus, dragging, hoverFix, elementRegistry) {
+
+        // given
+        var gfx = elementRegistry.getGraphics(shape1);
+
+        var listener = sinon.spy();
+
+        eventBus.on('foo.hover', function() {
+          listener('hover');
+        });
+
+        eventBus.on('foo.move', function() {
+          listener('move');
+        });
+
+        hoverFix._findTargetGfx = function(event) {
+          return gfx;
+        };
+
+        // when
+        dragging.init(canvasEvent({ x: 10, y: 10 }), 'foo');
+        dragging.move(canvasEvent({ x: 30, y: 20 }));
+
+        // then
+        // first hover and then fake move
+        expect(listener).to.have.been.calledTwice;
+        expect(listener.args).to.eql([
+          [ 'hover' ],
+          [ 'move' ]
+        ]);
+      }
+    ));
+
   });
 
 


### PR DESCRIPTION
After merging the fixes from https://github.com/bpmn-io/diagram-js/pull/400 and https://github.com/bpmn-io/diagram-js/pull/399 pasting-without-moving was not possible inside the `rootElement` since the `target` got removed [via the next `create.move`](https://github.com/bpmn-io/diagram-js/blob/develop/lib/features/create/Create.js#L144). This got fired [without the updated dragContext](https://github.com/bpmn-io/diagram-js/blob/develop/lib/features/dragging/Dragging.js#L171) (it is using the old event context without the updated hover, therefore hover is still undefined in this case).

It is working fine inside container elements since the browser fires an additional `hover` event due to the `pointer-event` changes by setting and unsetting the `.djs-drag-active` class.

This pull request adds changes to fire another fake `hover` after the misleading `create.move`, to ensure the hover did not get lost. _Additionaly_ it ensures we remove markers despite the fact the target got removed in the `create.move` handler. 

This fixes the [broken test case](https://travis-ci.org/bpmn-io/diagram-js/builds/574734365#L828) on current master. Paste-without-moving should work perfectly fine now.

![Kapture 2019-08-21 at 11 18 52](https://user-images.githubusercontent.com/9433996/63419680-819de500-c405-11e9-8084-5b938642ea67.gif)