### PR TITLE
feat(copy-paste): allow host attachment using copyPaste.paste API

### DIFF
--- a/lib/features/copy-paste/CopyPaste.js
+++ b/lib/features/copy-paste/CopyPaste.js
@@ -213,7 +213,7 @@ CopyPaste.prototype.paste = function(context) {
     return;
   }
 
-  var hints = {};
+  var hints = context ? (context.hints || {}) : {};
 
   this._eventBus.fire('copyPaste.pasteElements', {
     hints: hints

--- a/test/spec/features/copy-paste/CopyPasteSpec.js
+++ b/test/spec/features/copy-paste/CopyPasteSpec.js
@@ -12,6 +12,7 @@ import {
   some
 } from 'min-dash';
 
+import attachSupportModule from 'lib/features/attach-support';
 import copyPasteModule from 'lib/features/copy-paste';
 import modelingModule from 'lib/features/modeling';
 import rulesModule from './rules';
@@ -24,6 +25,7 @@ describe('features/copy-paste', function() {
 
   beforeEach(bootstrapDiagram({
     modules: [
+      attachSupportModule,
       copyPasteModule,
       modelingModule,
       rulesModule,
@@ -338,7 +340,7 @@ describe('features/copy-paste', function() {
         var tree = copyPaste.copy(attacher);
 
         // then
-        expect(tree).to.be.empty;
+        expect(findElementInTree(attacher, tree, 0)).to.be.ok;
       }));
 
     });
@@ -410,7 +412,42 @@ describe('features/copy-paste', function() {
         });
 
         // then
-        expect(parentShape.children).to.have.length(2);
+        expect(parentShape.children).to.have.length(3);
+      }));
+
+
+      it('should paste and attach', inject(function(copyPaste) {
+
+        // given
+        copyPaste.copy(attacher);
+
+        // when
+        var nonAttachedElement = copyPaste.paste({
+          element: parentShape,
+          point: {
+            x: 1000,
+            y: 1000
+          }
+        })[0];
+
+        copyPaste.copy(nonAttachedElement);
+
+        var attachedElement = copyPaste.paste({
+          element: host,
+          point: {
+            x: host.x,
+            y: host.y
+          },
+          hints: {
+            attach: 'attach'
+          }
+        })[0];
+
+        // then
+        expect(nonAttachedElement.host).to.be.undefined;
+
+        expect(attachedElement.host).to.eql(host);
+
       }));
 
     });

--- a/test/spec/features/copy-paste/rules/CopyPasteRules.js
+++ b/test/spec/features/copy-paste/rules/CopyPasteRules.js
@@ -15,11 +15,6 @@ inherits(CopyPasteRules, RuleProvider);
 CopyPasteRules.prototype.init = function() {
 
   this.addRule('element.copy', function(context) {
-    var element = context.element;
-
-    if (element.host) {
-      return false;
-    }
 
     return true;
   });


### PR DESCRIPTION
Linked to: https://github.com/bpmn-io/bpmn-js/pull/1192

This PR helps creating host attachments using copyPaste module, especially useful for tests.

A **hints** object can be provided to context parameter:

![Screenshot 2019-09-24 at 15 51 29](https://user-images.githubusercontent.com/15003836/65517547-30d94a80-dee3-11e9-95ec-f816edc9e7bc.png)

The same feature exists already for modeling.createShape API.