### PR TITLE
Prevent error if element does not exist

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -322,7 +322,9 @@ Canvas.prototype._updateMarker = function(element, marker, add) {
   if (!element.id) {
     element = this._elementRegistry.get(element);
   }
-
+  if (!element) {
+    return;
+  }
   // we need to access all
   container = this._elementRegistry._elements[element.id];
 


### PR DESCRIPTION
In order to prevent an error while setting a marker, element is checked again
