### PR TITLE
Prevent error if element does not exist

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -323,6 +323,11 @@ Canvas.prototype._updateMarker = function(element, marker, add) {
     element = this._elementRegistry.get(element);
   }
 
+  // Check if element is existing
+  if (!element) {
+    return;
+  }
+
   // we need to access all
   container = this._elementRegistry._elements[element.id];
 


### PR DESCRIPTION
In order to prevent an error while setting a marker, element is checked again

Error, if check is not available:

TypeError: "element is undefined"
    _updateMarker Canvas.js:330
    addMarker Canvas.js:379
    componentDidUpdate bpmn.modeler.component.tsx:254

No error after checking for element