### PR TITLE
fix(command): return latest changed elements

### DIFF
--- a/lib/command/CommandStack.js
+++ b/lib/command/CommandStack.js
@@ -452,7 +452,7 @@ CommandStack.prototype._popAction = function() {
   actions.pop();
 
   if (!actions.length) {
-    this._eventBus.fire('elements.changed', { elements: uniqueBy('id', dirty) });
+    this._eventBus.fire('elements.changed', { elements: uniqueBy('id', dirty.reverse()) });
 
     dirty.length = 0;
 

--- a/test/spec/command/CommandStackSpec.js
+++ b/test/spec/command/CommandStackSpec.js
@@ -660,7 +660,7 @@ describe('command/CommandStack', function() {
     };
 
 
-    it('should update dirty shapes after change', inject(function(commandStack, eventBus) {
+    it('should update dirty elements after change', inject(function(commandStack, eventBus) {
 
       // given
       commandStack.registerHandler('outer-command', OuterHandler);
@@ -681,6 +681,31 @@ describe('command/CommandStack', function() {
 
       // then
       expect(events).to.eql([ [ s1, s2 ] ]);
+    }));
+
+
+    it('should return latest dirty elements after change', inject(function(commandStack, eventBus) {
+
+      // given
+      commandStack.registerHandler('outer-command', OuterHandler);
+      commandStack.registerHandler('inner-command', InnerHandler);
+
+      var s1 = { id: 1 }, s2 = { id: 1 }, context = { s1: s1, s2: s2 };
+
+      var events = [];
+
+      function logEvent(e) {
+        events.push(e.elements);
+      }
+
+      eventBus.on('elements.changed', logEvent);
+
+      // when
+      commandStack.execute('outer-command', context);
+
+      // then
+      expect(events[0]).to.have.length(1);
+      expect(events[0][0]).to.equal(s2);
     }));
 
   });


### PR DESCRIPTION
# Scenario

1. Command handler A returns dirty shape A with ID `foo`
2. Command handler B returns dirty shape B with ID `foo`
3. `elements.changed` will be fired with shape A even though the latest changed element with ID `foo` was shape B

Replacement (while keeping the ID) is one of the cases where this becomes a problem.

Related to bpmn-io/bpmn-js#1207.