### PR TITLE
fix(create): cancel create on <elements.changed>

### DIFF
--- a/lib/features/create/Create.js
+++ b/lib/features/create/Create.js
@@ -15,6 +15,10 @@ import {
 
 import { getBBox } from '../../util/Elements';
 
+var PREFIX = 'create';
+
+var HIGH_PRIORITY = 2000;
+
 
 /**
  * Create new elements through drag and drop.
@@ -224,6 +228,25 @@ export default function Create(
     });
   });
 
+  function cancel() {
+    var context = dragging.context();
+
+    if (context && context.prefix === PREFIX) {
+      dragging.cancel();
+    }
+  }
+
+  // cancel on <elements.changed> that is not result of <drag.end>
+  eventBus.on('elements.changed', cancel);
+
+  eventBus.on('create.end', HIGH_PRIORITY, function() {
+    eventBus.off('elements.changed', cancel);
+  });
+
+  eventBus.on('create.ended', function() {
+    eventBus.on('elements.changed', cancel);
+  });
+
   // API //////////
 
   this.start = function(event, elements, context) {
@@ -277,7 +300,7 @@ export default function Create(
       });
     });
 
-    dragging.init(event, 'create', {
+    dragging.init(event, PREFIX, {
       cursor: 'grabbing',
       autoActivate: true,
       data: {

--- a/test/spec/features/create/CreateSpec.js
+++ b/test/spec/features/create/CreateSpec.js
@@ -323,6 +323,21 @@ describe('features/create - Create', function() {
       expect(context.shape).to.equal(newShape2);
     }));
 
+
+    it('should cancel on <elements.changed>', inject(
+      function(create, dragging, elementRegistry, eventBus) {
+
+        // given
+        create.start(canvasEvent({ x: 0, y: 0 }), newShape);
+
+        // when
+        eventBus.fire('elements.changed', { elements: [] });
+
+        // then
+        expect(dragging.context()).not.to.exist;
+      }
+    ));
+
   });
 
 


### PR DESCRIPTION
* cancel create on `elements.changed`

Related to camunda/camunda-modeler#1466