### PR TITLE
Restore selection correctly

### DIFF
--- a/lib/features/create/Create.js
+++ b/lib/features/create/Create.js
@@ -239,14 +239,12 @@ export default function Create(
   }
 
   // cancel on <elements.changed> that is not result of <drag.end>
-  eventBus.on('elements.changed', cancel);
-
-  eventBus.on('create.end', HIGH_PRIORITY, function() {
-    eventBus.off('elements.changed', cancel);
-  });
-
-  eventBus.on('create.ended', function() {
+  eventBus.on('create.init', function() {
     eventBus.on('elements.changed', cancel);
+
+    eventBus.once([ 'create.cancel', 'create.end' ], HIGH_PRIORITY, function() {
+      eventBus.off('elements.changed', cancel);
+    });
   });
 
   // API //////////

--- a/lib/features/dragging/Dragging.js
+++ b/lib/features/dragging/Dragging.js
@@ -56,7 +56,7 @@ function getLength(point) {
  *   * emits life cycle events, namespaced with a prefix assigned
  *     during dragging activation
  *   * sets and restores the cursor
- *   * sets and restores the selection
+ *   * sets and restores the selection if elements still exist
  *   * ensures there can be only one drag operation active at a time
  *
  * Dragging may be canceled manually by calling {@link Dragging#cancel}
@@ -123,7 +123,7 @@ function getLength(point) {
  *   });
  * }
  */
-export default function Dragging(eventBus, canvas, selection) {
+export default function Dragging(eventBus, canvas, selection, elementRegistry) {
 
   var defaultOptions = {
     threshold: 5,
@@ -169,6 +169,14 @@ export default function Dragging(eventBus, canvas, selection) {
     }
 
     return eventBus.fire(dragContext.prefix + '.' + type, event);
+  }
+
+  function restoreSelection(previousSelection) {
+    var existingSelection = previousSelection.filter(function(element) {
+      return elementRegistry.get(element.id);
+    });
+
+    existingSelection.length && selection.select(existingSelection);
   }
 
   // event listeners
@@ -401,7 +409,7 @@ export default function Dragging(eventBus, canvas, selection) {
     var previousSelection = context.payload.previousSelection;
 
     if (restore !== false && previousSelection && !selection.get().length) {
-      selection.select(previousSelection);
+      restoreSelection(previousSelection);
     }
 
     previousContext = context;
@@ -548,5 +556,6 @@ export default function Dragging(eventBus, canvas, selection) {
 Dragging.$inject = [
   'eventBus',
   'canvas',
-  'selection'
+  'selection',
+  'elementRegistry'
 ];

--- a/test/spec/features/dragging/DraggingSpec.js
+++ b/test/spec/features/dragging/DraggingSpec.js
@@ -239,6 +239,95 @@ describe('features/dragging - Dragging', function() {
     }));
 
 
+    describe('cleanup', function() {
+
+      var shape1, shape2;
+
+      beforeEach(inject(function(elementFactory, canvas) {
+        shape1 = elementFactory.createShape({
+          id: 'shape1',
+          x: 100, y: 0,
+          width: 50, height: 50
+        });
+
+        canvas.addShape(shape1);
+
+        shape2 = elementFactory.createShape({
+          id: 'shape2',
+          x: 200, y: 0,
+          width: 50, height: 50
+        });
+
+        canvas.addShape(shape2);
+      }));
+
+
+      it('should restore selection when dragging cancelled', inject(function(dragging, selection) {
+
+        // given
+        var preselected = [ shape1, shape2 ];
+        selection.select(preselected);
+
+        // when
+        dragging.init(canvasEvent({ x: 10, y: 10 }), 'foo');
+        dragging.move(canvasEvent({ x: 30, y: 20 }));
+        dragging.cancel();
+
+        // then
+        var selected = selection.get();
+
+        expect(selected).to.eql(preselected);
+      }));
+
+
+      it('should select again only the existing elements', inject(
+        function(canvas, dragging, selection) {
+
+          // given
+          var preselected = [ shape1, shape2 ];
+          selection.select(preselected);
+
+          // when
+          dragging.init(canvasEvent({ x: 10, y: 10 }), 'foo');
+          dragging.move(canvasEvent({ x: 30, y: 20 }));
+
+          canvas.removeShape(shape1);
+
+          dragging.cancel();
+
+          // then
+          var selected = selection.get();
+
+          expect(selected).to.eql([ shape2 ]);
+        })
+      );
+
+
+      it('should not restore the selection if none of the elements exists', inject(
+        function(canvas, dragging, selection) {
+
+          // given
+          var preselected = [ shape1, shape2 ];
+          selection.select(preselected);
+
+          // when
+          dragging.init(canvasEvent({ x: 10, y: 10 }), 'foo');
+          dragging.move(canvasEvent({ x: 30, y: 20 }));
+
+          canvas.removeShape(shape1);
+          canvas.removeShape(shape2);
+
+          dragging.cancel();
+
+          // then
+          var selected = selection.get();
+
+          expect(selected).to.eql([]);
+        })
+      );
+    });
+
+
     describe('djs-drag-active marker', function() {
 
       it('should not add to root on drag start', inject(function(dragging, canvas, elementRegistry) {


### PR DESCRIPTION
This PR filters out the non-existing elements when restoring selection on dragging cancelation.

Related to https://github.com/bpmn-io/bpmn-js/issues/1225