### PR TITLE
chore(project): use source maps in tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -107,7 +107,8 @@ module.exports = function(karma) {
           'node_modules',
           absoluteBasePath
         ]
-      }
+      },
+      devtool: 'eval-source-map'
     }
   });
 };


### PR DESCRIPTION
Source maps are really helpful when debugging and don't significantly change the bundle time.