### PR TITLE
Correctly unsubscribe auto-close handler

### DIFF
--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -16,6 +16,11 @@ import {
 
 var DATA_REF = 'data-id';
 
+var CLOSE_EVENTS = [
+  'contextPad.close',
+  'canvas.viewbox.changing',
+  'commandStack.changed'
+];
 
 /**
  * A popup menu that can be used to display a list of actions anywhere in the canvas.
@@ -169,6 +174,7 @@ PopupMenu.prototype.open = function(element, id, position) {
       parent = canvas.getContainer();
 
   this._attachContainer(current.container, parent, position.cursor);
+  this._bindAutoClose();
 };
 
 
@@ -183,7 +189,7 @@ PopupMenu.prototype.close = function() {
 
   this._emit('close');
 
-  this._unbindHandlers();
+  this._unbindAutoClose();
   domRemove(this._current.container);
   this._current.container = null;
 };
@@ -269,7 +275,7 @@ PopupMenu.prototype._createContainer = function() {
 
 
 /**
- * Attaches the container to the DOM and binds the event handlers.
+ * Attaches the container to the DOM.
  *
  * @param {Object} container
  * @param {Object} parent
@@ -290,9 +296,6 @@ PopupMenu.prototype._attachContainer = function(container, parent, cursor) {
   if (cursor) {
     this._assureIsInbounds(container, cursor);
   }
-
-  // Add Handler
-  this._bindHandlers();
 };
 
 
@@ -462,38 +465,18 @@ PopupMenu.prototype._createEntry = function(entry) {
 
 
 /**
- * Binds the `close` method to 'contextPad.close' & 'canvas.viewbox.changed'.
+ * Set up listener to close popup automatically on certain events.
  */
-PopupMenu.prototype._bindHandlers = function() {
-
-  var eventBus = this._eventBus,
-      self = this;
-
-  function close() {
-    self.close();
-  }
-
-  eventBus.once('contextPad.close', close);
-  eventBus.once('canvas.viewbox.changing', close);
-  eventBus.once('commandStack.changed', close);
+PopupMenu.prototype._bindAutoClose = function() {
+  this._eventBus.once(CLOSE_EVENTS, this.close, this);
 };
 
 
 /**
- * Unbinds the `close` method to 'contextPad.close' & 'canvas.viewbox.changing'.
+ * Remove the auto-closing listener.
  */
-PopupMenu.prototype._unbindHandlers = function() {
-
-  var eventBus = this._eventBus,
-      self = this;
-
-  function close() {
-    self.close();
-  }
-
-  eventBus.off('contextPad.close', close);
-  eventBus.off('canvas.viewbox.changed', close);
-  eventBus.off('commandStack.changed', close);
+PopupMenu.prototype._unbindAutoClose = function() {
+  this._eventBus.off(CLOSE_EVENTS, this.close, this);
 };
 
 

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -473,6 +473,8 @@ describe('features/popup', function() {
 
     describe('events', function() {
 
+      afterEach(sinon.restore);
+
       it('should close menu (contextPad.close)', inject(function(popupMenu, eventBus) {
 
         // given
@@ -505,6 +507,26 @@ describe('features/popup', function() {
 
         expect(open).to.be.false;
       }));
+
+
+      it('should correctly unsubscribe when closed via #close', inject(
+        function(popupMenu, eventBus) {
+
+          // given
+          popupMenu.registerProvider('menu', menuProvider);
+
+          popupMenu.open({}, 'menu' ,{ x: 100, y: 100 });
+          popupMenu.close();
+
+          var spy = sinon.spy(popupMenu, 'close');
+
+          // when
+          eventBus.fire('canvas.viewbox.changing');
+
+          // then
+          expect(spy).to.not.have.been.called;
+        }
+      ));
 
     });
 


### PR DESCRIPTION
This fixes a wrong listener being unsubscribed from events. Not sure though, if we should actually listen for context pad events in that place.