### PR TITLE
ZoomScroll - Ability to enable to use mouse wheel directly without ctrl key

### DIFF
--- a/lib/navigation/zoomscroll/ZoomScroll.js
+++ b/lib/navigation/zoomscroll/ZoomScroll.js
@@ -27,6 +27,8 @@ var DELTA_THRESHOLD = 0.1;
 
 var DEFAULT_SCALE = 0.75;
 
+var DEFAULT_DIRECT_ZOOM_WITH_MOUSE_WHEEL = false;
+
 /**
  * An implementation of zooming and scrolling within the
  * {@link Canvas} via the mouse wheel.
@@ -37,6 +39,7 @@ var DEFAULT_SCALE = 0.75;
  * @param {Object} [config]
  * @param {Boolean} [config.enabled=true] default enabled state
  * @param {Number} [config.scale=.75] scroll sensivity
+ * @param {Boolean} [config.isDirectZoomWithMouseWheel=false] Uses direct mouse wheel without ctrl key for zooming
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
  */
@@ -53,6 +56,7 @@ export default function ZoomScroll(config, eventBus, canvas) {
 
   this._totalDelta = 0;
   this._scale = config.scale || DEFAULT_SCALE;
+  this._isDirectZoomWithMouseWheel = typeof config.isDirectZoomWithMouseWheel === 'undefined' ? DEFAULT_DIRECT_ZOOM_WITH_MOUSE_WHEEL : config.isDirectZoomWithMouseWheel;
 
   var self = this;
 
@@ -100,7 +104,6 @@ ZoomScroll.prototype.zoom = function zoom(delta, position) {
 
 
 ZoomScroll.prototype._handleWheel = function handleWheel(event) {
-
   // event is already handled by '.djs-scrollable'
   if (domClosest(event.target, '.djs-scrollable', true)) {
     return;
@@ -113,8 +116,7 @@ ZoomScroll.prototype._handleWheel = function handleWheel(event) {
   // pinch to zoom is mapped to wheel + ctrlKey = true
   // in modern browsers (!)
 
-  var isZoom = event.ctrlKey;
-
+  var isZoom = this._isDirectZoomWithMouseWheel ? !event.ctrlKey && !event.shiftKey : event.ctrlKey;
   var isHorizontalScroll = event.shiftKey;
 
   var factor = -1 * this._scale,
@@ -172,6 +174,21 @@ ZoomScroll.prototype.stepZoom = function stepZoom(delta, position) {
   var stepSize = getStepSize(RANGE, NUM_STEPS);
 
   this._zoom(delta, position, stepSize);
+};
+
+
+/**
+ * Zoom depending on delta.
+ *
+ * @param {number} delta
+ * @param {Object} position
+ */
+ZoomScroll.prototype.isDirectZoomWithMouseWheel = function isDirectZoomWithMouseWheel(value) {
+  if (typeof value === 'undefined') {
+    return this._isDirectZoomWithMouseWheel;
+  } else {
+    this._isDirectZoomWithMouseWheel = value;
+  }
 };
 
 

--- a/lib/navigation/zoomscroll/ZoomScroll.js
+++ b/lib/navigation/zoomscroll/ZoomScroll.js
@@ -178,10 +178,9 @@ ZoomScroll.prototype.stepZoom = function stepZoom(delta, position) {
 
 
 /**
- * Zoom depending on delta.
+ * Uses direct mouse wheel without ctrl key for zooming.
  *
- * @param {number} delta
- * @param {Object} position
+ * @param {boolean} value
  */
 ZoomScroll.prototype.isDirectZoomWithMouseWheel = function isDirectZoomWithMouseWheel(value) {
   if (typeof value === 'undefined') {

--- a/lib/navigation/zoomscroll/ZoomScroll.js
+++ b/lib/navigation/zoomscroll/ZoomScroll.js
@@ -104,6 +104,7 @@ ZoomScroll.prototype.zoom = function zoom(delta, position) {
 
 
 ZoomScroll.prototype._handleWheel = function handleWheel(event) {
+
   // event is already handled by '.djs-scrollable'
   if (domClosest(event.target, '.djs-scrollable', true)) {
     return;


### PR DESCRIPTION
I would like to provide some code for the ability to use the mouse wheel directly without the use of the ctrl key. This code does not change any current behavior but provides a flag to enable / disable the ability with default false. 

The variable names are all yours to change. It would be nice if you could take the code or provide similar ability. 


__Which issue does this PR address?_
Found in:
https://forum.bpmn.io/t/zooming-or-vertical-scrolling-what-should-be-the-default-mouse-wheel-action/131
