### PR TITLE
Consistent mark as changed

### DIFF
--- a/lib/core/GraphicsFactory.js
+++ b/lib/core/GraphicsFactory.js
@@ -38,7 +38,7 @@ export default function GraphicsFactory(eventBus, elementRegistry) {
 GraphicsFactory.$inject = [ 'eventBus' , 'elementRegistry' ];
 
 
-GraphicsFactory.prototype._getChildren = function(element) {
+GraphicsFactory.prototype._getChildrenContainer = function(element) {
 
   var gfx = this._elementRegistry.getGraphics(element);
 
@@ -132,7 +132,7 @@ GraphicsFactory.prototype._createContainer = function(
 };
 
 GraphicsFactory.prototype.create = function(type, element, parentIndex) {
-  var childrenGfx = this._getChildren(element.parent);
+  var childrenGfx = this._getChildrenContainer(element.parent);
   return this._createContainer(type, childrenGfx, parentIndex, isFrameElement(element));
 };
 
@@ -161,12 +161,12 @@ GraphicsFactory.prototype.updateContainments = function(elements) {
       return;
     }
 
-    var childGfx = self._getChildren(parent);
+    var childrenGfx = self._getChildrenContainer(parent);
 
-    forEach(children.slice().reverse(), function(c) {
-      var gfx = elementRegistry.getGraphics(c);
+    forEach(children.slice().reverse(), function(child) {
+      var childGfx = elementRegistry.getGraphics(child);
 
-      prependTo(gfx.parentNode, childGfx);
+      prependTo(childGfx.parentNode, childrenGfx);
     });
   });
 };

--- a/lib/features/modeling/cmd/CreateConnectionHandler.js
+++ b/lib/features/modeling/cmd/CreateConnectionHandler.js
@@ -54,4 +54,6 @@ CreateConnectionHandler.prototype.revert = function(context) {
 
   connection.source = null;
   connection.target = null;
+
+  return connection;
 };

--- a/lib/features/modeling/cmd/CreateShapeHandler.js
+++ b/lib/features/modeling/cmd/CreateShapeHandler.js
@@ -62,6 +62,10 @@ CreateShapeHandler.prototype.execute = function(context) {
  */
 CreateShapeHandler.prototype.revert = function(context) {
 
+  var shape = context.shape;
+
   // (3) remove form canvas
-  this._canvas.removeShape(context.shape);
+  this._canvas.removeShape(shape);
+
+  return shape;
 };

--- a/test/spec/.eslintrc
+++ b/test/spec/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "globals": {
+    "sinon": true
+  }
+}

--- a/test/spec/command/CommandStackSpec.js
+++ b/test/spec/command/CommandStackSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   getDiagramJS,

--- a/test/spec/core/EventBusSpec.js
+++ b/test/spec/core/EventBusSpec.js
@@ -1,8 +1,6 @@
 import EventBus from 'lib/core/EventBus';
 
 
-/* global sinon */
-
 describe('core/EventBus', function() {
 
   var eventBus;

--- a/test/spec/features/attach-support/AttachSupportSpec.js
+++ b/test/spec/features/attach-support/AttachSupportSpec.js
@@ -29,8 +29,6 @@ import { classes as svgClasses } from 'tiny-svg';
 var ATTACH = { attach: true };
 var NO_ATTACH = { attach: false };
 
-/* global sinon */
-
 
 describe('features/attach-support', function() {
 

--- a/test/spec/features/auto-resize/AutoResizeSpec.js
+++ b/test/spec/features/auto-resize/AutoResizeSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject
@@ -16,8 +14,6 @@ import replaceModule from 'lib/features/replace';
 
 import AutoResizeProvider from 'lib/features/auto-resize/AutoResizeProvider';
 import AutoResize from 'lib/features/auto-resize/AutoResize';
-
-var spy = sinon.spy;
 
 import inherits from 'inherits';
 
@@ -168,7 +164,7 @@ describe('features/auto-resize', function() {
     it('should only resize on actual size change', inject(function(autoResize, modeling) {
 
       // given
-      var resizeSpy = spy(autoResize, 'resize');
+      var resizeSpy = sinon.spy(autoResize, 'resize');
 
       // when
       modeling.moveElements([ topLevelShape ], { x: -300, y: 0 }, parentShape);
@@ -295,7 +291,7 @@ describe('features/auto-resize', function() {
       it('on move <ne>', inject(function(autoResize, modeling) {
 
         // given
-        var resizeSpy = spy(autoResize, 'resize');
+        var resizeSpy = sinon.spy(autoResize, 'resize');
 
         // when
         modeling.moveElements([ childShape1 ], { x: -100, y: -100 }, parentShape);
@@ -742,7 +738,7 @@ describe('features/auto-resize', function() {
       it('on resize child shape <nwse>', inject(function(autoResize, modeling) {
 
         // given
-        var resizeSpy = spy(autoResize, 'resize');
+        var resizeSpy = sinon.spy(autoResize, 'resize');
 
         var newBounds = { x: 0, y: 0, width: 500, height: 500 };
 

--- a/test/spec/features/auto-scroll/AutoScrollSpec.js
+++ b/test/spec/features/auto-scroll/AutoScrollSpec.js
@@ -1,7 +1,5 @@
 import { createCanvasEvent as canvasEvent } from '../../../util/MockEvents';
 
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject

--- a/test/spec/features/bendpoints/BendpointsMoveSpec.js
+++ b/test/spec/features/bendpoints/BendpointsMoveSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   getDiagramJS,
@@ -32,8 +30,6 @@ var testModules = [
   modelingModule,
   selectModule
 ];
-
-var spy = sinon.spy;
 
 
 describe('features/bendpoints - move', function() {
@@ -534,7 +530,7 @@ describe('features/bendpoints - move', function() {
     beforeEach(inject(setupDiagram));
 
     beforeEach(inject(function(connectionPreview) {
-      drawPreviewSpy = spy(connectionPreview, 'drawPreview');
+      drawPreviewSpy = sinon.spy(connectionPreview, 'drawPreview');
     }));
 
     afterEach(sinon.restore);

--- a/test/spec/features/bendpoints/BendpointsSpec.js
+++ b/test/spec/features/bendpoints/BendpointsSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject
@@ -21,7 +19,8 @@ import {
 
 import {
   getVisual
-} from '../../../../lib/util/GraphicsUtil';
+} from 'lib/util/GraphicsUtil';
+
 
 describe('features/bendpoints', function() {
 

--- a/test/spec/features/bendpoints/ConnectionSegmentMoveSpec.js
+++ b/test/spec/features/bendpoints/ConnectionSegmentMoveSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   getDiagramJS,

--- a/test/spec/features/connect/ConnectSpec.js
+++ b/test/spec/features/connect/ConnectSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   createEvent as globalEvent
 } from '../../../util/MockEvents';

--- a/test/spec/features/create/CreateSpec.js
+++ b/test/spec/features/create/CreateSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject

--- a/test/spec/features/dragging/HoverFixSpec.js
+++ b/test/spec/features/dragging/HoverFixSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject

--- a/test/spec/features/editor-actions/EditorActionsSpec.js
+++ b/test/spec/features/editor-actions/EditorActionsSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject

--- a/test/spec/features/global-connect/GlobalConnectSpec.js
+++ b/test/spec/features/global-connect/GlobalConnectSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject

--- a/test/spec/features/hand-tool/HandToolSpec.js
+++ b/test/spec/features/hand-tool/HandToolSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject
@@ -12,8 +10,6 @@ import draggingModule from 'lib/features/dragging';
 import keyboardModule from 'lib/features/keyboard';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
-
-var spy = sinon.spy;
 
 
 describe('features/hand-tool', function() {
@@ -81,7 +77,7 @@ describe('features/hand-tool', function() {
         keyEvent: createKeyEvent(' ')
       });
 
-      removeEventListenerSpy = spy(window, 'removeEventListener');
+      removeEventListenerSpy = sinon.spy(window, 'removeEventListener');
     }));
 
     afterEach(function() {

--- a/test/spec/features/interaction-events/InteractionEventsSpec.js
+++ b/test/spec/features/interaction-events/InteractionEventsSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject

--- a/test/spec/features/keyboard/CopySpec.js
+++ b/test/spec/features/keyboard/CopySpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject
@@ -15,8 +13,6 @@ import keyboardModule from 'lib/features/keyboard';
 import editorActionsModule from 'lib/features/editor-actions';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
-
-var spy = sinon.spy;
 
 var KEYS = [ 'c', 'C' ];
 
@@ -60,7 +56,7 @@ describe('features/keyboard - copy', function() {
       it(testCase.desc, inject(function(keyboard, editorActions) {
 
         // given
-        var copySpy = spy(editorActions, 'trigger');
+        var copySpy = sinon.spy(editorActions, 'trigger');
 
         var event = createKeyEvent(key, { ctrlKey: testCase.ctrlKey });
 

--- a/test/spec/features/keyboard/KeyboardSpec.js
+++ b/test/spec/features/keyboard/KeyboardSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import TestContainer from 'mocha-test-container-support';
 
 import {
@@ -15,9 +13,6 @@ import {
 } from 'test/TestHelper';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
-
-var spy = sinon.spy,
-    stub = sinon.stub;
 
 
 describe('features/keyboard', function() {
@@ -91,7 +86,7 @@ describe('features/keyboard', function() {
     it('should bind keyboard events to node', inject(function(keyboard) {
 
       // given
-      var keyHandlerSpy = spy(keyboard, '_keyHandler');
+      var keyHandlerSpy = sinon.spy(keyboard, '_keyHandler');
 
       // when
       keyboard.bind(testDiv);
@@ -106,7 +101,7 @@ describe('features/keyboard', function() {
     it('should unbind keyboard events to node', inject(function(keyboard) {
 
       // given
-      var keyHandlerSpy = spy(keyboard, '_keyHandler');
+      var keyHandlerSpy = sinon.spy(keyboard, '_keyHandler');
 
       keyboard.bind(testDiv);
 
@@ -144,7 +139,7 @@ describe('features/keyboard', function() {
       function(keyboard, eventBus) {
 
         // given
-        var eventBusSpy = spy(eventBus, 'fire');
+        var eventBusSpy = sinon.spy(eventBus, 'fire');
 
         var inputField = document.createElement('input');
         testDiv.appendChild(inputField);
@@ -165,7 +160,7 @@ describe('features/keyboard', function() {
     it('should add keydown listener by default', inject(function(keyboard) {
 
       // given
-      var keydownSpy = spy();
+      var keydownSpy = sinon.spy();
 
       // when
       keyboard.addListener(keydownSpy);
@@ -182,7 +177,7 @@ describe('features/keyboard', function() {
     it('should add keyup listener', inject(function(keyboard) {
 
       // given
-      var keyupSpy = spy();
+      var keyupSpy = sinon.spy();
 
       // when
       keyboard.addListener(keyupSpy, 'keyboard.keyup');
@@ -199,8 +194,8 @@ describe('features/keyboard', function() {
     it('should handle listeners by priority', inject(function(keyboard) {
 
       // given
-      var lowerPrioritySpy = spy();
-      var higherPrioritySpy = stub().returns(true);
+      var lowerPrioritySpy = sinon.spy();
+      var higherPrioritySpy = sinon.stub().returns(true);
 
       keyboard.addListener(500, lowerPrioritySpy);
       keyboard.addListener(1000, higherPrioritySpy);
@@ -220,8 +215,8 @@ describe('features/keyboard', function() {
       function(keyboard) {
 
         // given
-        var lowerPrioritySpy = spy();
-        var higherPrioritySpy = spy();
+        var lowerPrioritySpy = sinon.spy();
+        var higherPrioritySpy = sinon.spy();
 
         keyboard.addListener(500, lowerPrioritySpy);
         keyboard.addListener(1000, higherPrioritySpy);
@@ -242,7 +237,7 @@ describe('features/keyboard', function() {
       function(keyboard) {
 
         // given
-        var keyboardEventSpy = spy();
+        var keyboardEventSpy = sinon.spy();
 
         keyboard.addListener(keyboardEventSpy);
 
@@ -285,7 +280,7 @@ describe('features/keyboard', function() {
     it('should remove keydown listener by default', inject(function(keyboard) {
 
       // given
-      var keydownSpy = spy();
+      var keydownSpy = sinon.spy();
 
       keyboard.addListener(keydownSpy);
 
@@ -305,7 +300,7 @@ describe('features/keyboard', function() {
     it('should remove keyup listener', inject(function(keyboard) {
 
       // given
-      var keyupSpy = spy();
+      var keyupSpy = sinon.spy();
 
       keyboard.addListener(keyupSpy, 'keyboard.keyup');
 

--- a/test/spec/features/keyboard/PasteSpec.js
+++ b/test/spec/features/keyboard/PasteSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject
@@ -15,8 +13,6 @@ import keyboardModule from 'lib/features/keyboard';
 import editorActionsModule from 'lib/features/editor-actions';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
-
-var spy = sinon.spy;
 
 var KEYS = [ 'v', 'V' ];
 
@@ -58,7 +54,7 @@ describe('features/keyboard - paste', function() {
       it(testCase.desc, inject(function(keyboard, editorActions) {
 
         // given
-        var pasteSpy = spy(editorActions, 'trigger');
+        var pasteSpy = sinon.spy(editorActions, 'trigger');
 
         var event = createKeyEvent(key, { ctrlKey: testCase.ctrlKey });
 

--- a/test/spec/features/keyboard/RedoSpec.js
+++ b/test/spec/features/keyboard/RedoSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject
@@ -14,8 +12,6 @@ import editorActionsModule from 'lib/features/editor-actions';
 import keyboardModule from 'lib/features/keyboard';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
-
-var spy = sinon.spy;
 
 var KEYS = {
   Z: [ 'z', 'Z' ],
@@ -90,7 +86,7 @@ describe('features/keyboard - redo', function() {
       it(testCase.desc, inject(function(keyboard, editorActions) {
 
         // given
-        var redoSpy = spy(editorActions, 'trigger');
+        var redoSpy = sinon.spy(editorActions, 'trigger');
 
         var event = createKeyEvent(key, {
           ctrlKey: testCase.ctrlKey,

--- a/test/spec/features/keyboard/RemoveSelectionSpec.js
+++ b/test/spec/features/keyboard/RemoveSelectionSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject
@@ -14,8 +12,6 @@ import editorActionsModule from 'lib/features/editor-actions';
 import keyboardModule from 'lib/features/keyboard';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
-
-var spy = sinon.spy;
 
 var KEYS = [
   'Delete',
@@ -45,7 +41,7 @@ describe('features/keyboard - remove selection', function() {
       inject(function(keyboard, editorActions) {
 
         // given
-        var removeSelectionSpy = spy(editorActions, 'trigger');
+        var removeSelectionSpy = sinon.spy(editorActions, 'trigger');
 
         var event = createKeyEvent(key);
 

--- a/test/spec/features/keyboard/UndoSpec.js
+++ b/test/spec/features/keyboard/UndoSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject
@@ -14,8 +12,6 @@ import editorActionsModule from 'lib/features/editor-actions';
 import keyboardModule from 'lib/features/keyboard';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
-
-var spy = sinon.spy;
 
 var KEYS = [ 'z', 'Z' ];
 
@@ -69,7 +65,7 @@ describe('features/keyboard - undo', function() {
       it(testCase.desc, inject(function(keyboard, editorActions) {
 
         // given
-        var undoSpy = spy(editorActions, 'trigger');
+        var undoSpy = sinon.spy(editorActions, 'trigger');
 
         var event = createKeyEvent(key, {
           ctrlKey: testCase.ctrlKey,

--- a/test/spec/features/label-support/LabelSupportSpec.js
+++ b/test/spec/features/label-support/LabelSupportSpec.js
@@ -17,8 +17,6 @@ import {
   classes as svgClasses
 } from 'tiny-svg';
 
-/* global sinon */
-
 
 describe('features/label-support', function() {
 

--- a/test/spec/features/modeling/CreateConnectionSpec.js
+++ b/test/spec/features/modeling/CreateConnectionSpec.js
@@ -63,11 +63,13 @@ describe('features/modeling - create connection', function() {
       it('execute', inject(function(modeling, elementRegistry) {
 
         // when
-        modeling.connect(sourceShape, targetShape, newConnection);
+        var createdConnection = modeling.connect(sourceShape, targetShape, newConnection);
 
         var connection = elementRegistry.get('newConnection');
 
         // then
+        expect(createdConnection).to.eql(connection);
+
         expect(connection.id).to.eql('newConnection');
 
         expect(connection.waypoints).to.eql([

--- a/test/spec/features/modeling/CreateConnectionSpec.js
+++ b/test/spec/features/modeling/CreateConnectionSpec.js
@@ -92,7 +92,48 @@ describe('features/modeling - create connection', function() {
         expect(elementRegistry.get('newConnection')).not.to.exist;
       }));
 
+
+      it('redo', inject(function(modeling, commandStack, elementRegistry) {
+
+        // given
+        modeling.connect(sourceShape, targetShape, newConnection);
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        var connection = elementRegistry.get('newConnection');
+
+        expect(connection.id).to.eql('newConnection');
+
+        expect(connection.waypoints).to.eql([
+          { x: 130, y: 130 },
+          { x: 230, y: 130 }
+        ]);
+      }));
+
     });
+
+
+    it('should mark as changed', inject(function(eventBus, modeling, commandStack) {
+
+      // given
+      var changedSpy = sinon.spy(function(event) {
+        expect(event.elements).to.have.length(1);
+      });
+
+      eventBus.on('elements.changed', changedSpy);
+
+      // when
+      modeling.connect(sourceShape, targetShape, newConnection);
+
+      commandStack.undo();
+      commandStack.redo();
+
+      // then
+      expect(changedSpy).to.have.been.calledThrice;
+    }));
 
 
     it('should have a parent', inject(function(modeling) {

--- a/test/spec/features/modeling/CreateShapeSpec.js
+++ b/test/spec/features/modeling/CreateShapeSpec.js
@@ -8,7 +8,6 @@ import modelingModule from 'lib/features/modeling';
 
 describe('features/modeling - create shape', function() {
 
-
   beforeEach(bootstrapDiagram({ modules: [ modelingModule ] }));
 
 
@@ -80,7 +79,48 @@ describe('features/modeling - create shape', function() {
         expect(parentShape.children).not.to.contain(newShape);
       }));
 
+
+      it('redo', inject(function(modeling, commandStack, elementRegistry) {
+
+        // given
+        modeling.createShape(newShape, position, parentShape);
+
+        commandStack.undo();
+
+        // when
+        commandStack.redo();
+
+        var shape = elementRegistry.get('newShape');
+
+        // then
+        expect(shape).to.include({
+          id: 'newShape',
+          x: 125, y: 125,
+          width: 100, height: 100
+        });
+      }));
+
     });
+
+
+    it('should mark as changed', inject(function(eventBus, modeling, commandStack) {
+
+      // given
+      var changedSpy = sinon.spy(function(event) {
+        expect(event.elements).to.have.length(1);
+      });
+
+      eventBus.on('elements.changed', changedSpy);
+
+      // when
+      modeling.createShape(newShape, position, parentShape);
+
+      commandStack.undo();
+      commandStack.redo();
+
+      // then
+      expect(changedSpy).to.have.been.calledThrice;
+    }));
 
 
     it('should have a parent', inject(function(modeling) {

--- a/test/spec/features/modeling/LayoutConnectionSpec.js
+++ b/test/spec/features/modeling/LayoutConnectionSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject

--- a/test/spec/features/modeling/MoveShapeSpec.js
+++ b/test/spec/features/modeling/MoveShapeSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject

--- a/test/spec/features/modeling/ReconnectConnectionSpec.js
+++ b/test/spec/features/modeling/ReconnectConnectionSpec.js
@@ -5,8 +5,6 @@ import {
 
 import modelingModule from 'lib/features/modeling';
 
-/* global sinon */
-
 
 describe('features/modeling - reconnect connection', function() {
 

--- a/test/spec/features/modeling/ReplaceShapeSpec.js
+++ b/test/spec/features/modeling/ReplaceShapeSpec.js
@@ -1,13 +1,9 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject
 } from 'test/TestHelper';
 
 import modelingModule from 'lib/features/modeling';
-
-var spy = sinon.spy;
 
 
 describe('features/modeling - replace shape', function() {
@@ -127,8 +123,8 @@ describe('features/modeling - replace shape', function() {
       var newShapeData = { x: 50, y: 50, width: 100, height: 100 },
           hints = { foo: 'foo' };
 
-      var moveElementsSpy = spy(modeling, 'moveElements'),
-          reconnectStartSpy = spy(modeling, 'reconnectStart');
+      var moveElementsSpy = sinon.spy(modeling, 'moveElements'),
+          reconnectStartSpy = sinon.spy(modeling, 'reconnectStart');
 
       // when
       modeling.replaceShape(shape1, newShapeData, hints);

--- a/test/spec/features/move/MoveSpec.js
+++ b/test/spec/features/move/MoveSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject
@@ -16,8 +14,6 @@ import {
 
 import modelingModule from 'lib/features/modeling';
 import moveModule from 'lib/features/move';
-
-var spy = sinon.spy;
 
 
 describe('features/move - Move', function() {
@@ -154,7 +150,7 @@ describe('features/move - Move', function() {
       function(dragging, elementRegistry, modeling, move) {
 
         // given
-        var moveElementsSpy = spy(modeling, 'moveElements');
+        var moveElementsSpy = sinon.spy(modeling, 'moveElements');
 
         move.start(canvasEvent({ x: 0, y: 0 }), childShape);
 

--- a/test/spec/features/palette/PaletteSpec.js
+++ b/test/spec/features/palette/PaletteSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   getDiagramJS,
@@ -16,8 +14,6 @@ import {
 import {
   assign
 } from 'min-dash';
-
-var spy = sinon.spy;
 
 
 describe('features/palette', function() {
@@ -44,7 +40,7 @@ describe('features/palette', function() {
     it('should create + attach with provider', inject(function(eventBus, canvas, palette) {
 
       // given
-      var createSpy = spy(function(event) {
+      var createSpy = sinon.spy(function(event) {
         expect(event.container).to.equal(palette._container);
       });
 
@@ -126,7 +122,7 @@ describe('features/palette', function() {
 
       palette.registerProvider(provider);
 
-      var getSpy = spy(provider, 'getPaletteEntries');
+      var getSpy = sinon.spy(provider, 'getPaletteEntries');
 
       // when
       var entries = palette.getEntries();
@@ -372,7 +368,7 @@ describe('features/palette', function() {
     it('should close', inject(function(eventBus, palette) {
 
       // given
-      var changedSpy = spy(function(event) {
+      var changedSpy = sinon.spy(function(event) {
         expect(event.open).to.be.false;
         expect(event.twoColumn).to.be.false;
       });
@@ -397,7 +393,7 @@ describe('features/palette', function() {
       // given
       palette.close();
 
-      var changedSpy = spy(function(event) {
+      var changedSpy = sinon.spy(function(event) {
         expect(event.open).to.be.true;
         expect(event.twoColumn).to.be.false;
       });
@@ -457,7 +453,7 @@ describe('features/palette', function() {
 
         parent.style.height = '300px';
 
-        var changedSpy = spy(function(event) {
+        var changedSpy = sinon.spy(function(event) {
           expect(event.open).to.be.true;
           expect(event.twoColumn).to.be.false;
         });
@@ -483,7 +479,7 @@ describe('features/palette', function() {
 
         parent.style.height = '270px';
 
-        var changedSpy = spy(function(event) {
+        var changedSpy = sinon.spy(function(event) {
           expect(event.open).to.be.true;
           expect(event.twoColumn).to.be.true;
         });
@@ -508,7 +504,7 @@ describe('features/palette', function() {
         parent.style.height = '270px';
         canvas.resized();
 
-        var changedSpy = spy(function(event) {
+        var changedSpy = sinon.spy(function(event) {
           expect(event.open).to.be.true;
           expect(event.twoColumn).to.be.false;
         });

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   getDiagramJS,
@@ -23,7 +21,6 @@ import { createEvent as globalEvent } from '../../../util/MockEvents';
 
 import popupMenuModule from 'lib/features/popup-menu';
 import modelingModule from 'lib/features/modeling';
-
 
 
 describe('features/popup', function() {

--- a/test/spec/features/resize/ResizeSpec.js
+++ b/test/spec/features/resize/ResizeSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject
@@ -27,7 +25,6 @@ function bounds(b) {
   return pick(b, [ 'x', 'y', 'width', 'height' ]);
 }
 
-var spy = sinon.spy;
 
 describe('features/resize - Resize', function() {
 
@@ -212,7 +209,7 @@ describe('features/resize - Resize', function() {
       function(canvas, dragging, elementFactory, modeling, resize) {
 
         // given
-        var resizeShapeSpy = spy(modeling, 'resizeShape');
+        var resizeShapeSpy = sinon.spy(modeling, 'resizeShape');
 
         var shape = elementFactory.createShape({
           id: 'shapeA',

--- a/test/spec/features/search-pad/SearchPadSpec.js
+++ b/test/spec/features/search-pad/SearchPadSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject

--- a/test/spec/features/selection/SelectionSpec.js
+++ b/test/spec/features/selection/SelectionSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject

--- a/test/spec/i18n/I18NSpec.js
+++ b/test/spec/i18n/I18NSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   inject
@@ -7,8 +5,6 @@ import {
 
 import paletteModule from 'lib/features/palette';
 import i18nModule from 'lib/i18n';
-
-var spy = sinon.spy;
 
 
 describe('i18n', function() {
@@ -21,7 +17,7 @@ describe('i18n', function() {
     it('should emit i18n.changed event', inject(function(i18n, eventBus) {
 
       // given
-      var listener = spy(function() {});
+      var listener = sinon.spy();
 
       eventBus.on('i18n.changed', listener);
 
@@ -43,7 +39,7 @@ describe('i18n', function() {
     it('should update palette', inject(function(palette, i18n) {
 
       // given
-      var paletteUpdate = spy(palette, '_update');
+      var paletteUpdate = sinon.spy(palette, '_update');
       palette._init();
 
       // when

--- a/test/spec/navigation/zoomscoll/ZoomScrollSpec.js
+++ b/test/spec/navigation/zoomscoll/ZoomScrollSpec.js
@@ -1,5 +1,3 @@
-/* global sinon */
-
 import {
   bootstrapDiagram,
   getDiagramJS,


### PR DESCRIPTION
https://github.com/bpmn-io/diagram-js/commit/784ac08f07305612ea5f350b442d1a4ba4590804 and https://github.com/bpmn-io/diagram-js/commit/ed8c0736d180802bd9b2ea9302cec2aa9203828c fix the dirty change handling on `shape.create` and `connection.create` to match the behavior of `shape.delete` and `connection.delete`.  

Previously when reverting the `shape.create` and `connection.create` command the element was not marked as changed on the stack.

With both fixes in place `elements.changed` will contain the removed elements. Interested parties may listen to the event to figure out the elements that got changed, including now removed elements (these have no parents).

This should be merged to `develop`, as I regard this as too dangerous to bug fix.