### PR TITLE
chore(project): update to path-intersection@2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5296,9 +5296,9 @@
       }
     },
     "path-intersection": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-1.1.1.tgz",
-      "integrity": "sha512-EdeUuXCm0+tb/2gv8PmRhd9fYYOtbDeTYkwCnzkBuAEjevEZi2mWUi1DVFF5nqSObYsxKcchvKUhnRULWOFreQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.1.0.tgz",
+      "integrity": "sha512-QUhfkGUIEv0v+1P6yGbUh+UjeMtiko2AT6hbzbbUUi9vC3uYeBPiwguW6AjOT/d7vwYs6+jZrbqCkuRECb+Odw=="
     },
     "path-is-absolute": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "min-dash": "^3.5.0",
     "min-dom": "^3.0.0",
     "object-refs": "^0.3.0",
-    "path-intersection": "^1.0.2",
+    "path-intersection": "^2.1.0",
     "tiny-svg": "^2.2.1"
   }
 }


### PR DESCRIPTION
This updates the [path-intersection](https://github.com/bpmn-io/path-intersection) library we use for clipping to the latest version (v2.0.1). Features: 

* smaller bundle size
* numerous intersection detection improvements

---

Using the `MoveStressSpec` in bpmn-js I was able to verify that the new version of path-intersection leads to a significant reduction in _intersection cannot be found errors_: 

```
## path-intersection@1

#2404 rate=0.389351081530782, no-intersections=936

## path-intersection@2

#2413 rate=0.009117281392457521, no-intersections=22
```

![capture 3lMqJc_optimized](https://user-images.githubusercontent.com/58601/70754459-8c271600-1d37-11ea-891b-5db071f72f64.gif)

---

Here is a screenshot of the impossible: Newer version, even smaller bundle sizes!

![image](https://user-images.githubusercontent.com/58601/70754750-46b71880-1d38-11ea-94c5-c5a61a9246fd.png)
