### PR TITLE
test(project): remove legacy CI hack

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,31 +1,17 @@
-'use strict';
-
-var coverage = process.env.COVERAGE;
+/* global process */
 
 var path = require('path');
 
-var absoluteBasePath = path.resolve(__dirname);
-
-/* global process */
+var coverage = process.env.COVERAGE;
 
 // configures browsers to run test against
 // any of [ 'ChromeHeadless', 'Chrome', 'Firefox', 'IE', 'PhantomJS' ]
-var browsers =
-  (process.env.TEST_BROWSERS || 'PhantomJS')
-    .replace(/^\s+|\s+$/, '')
-    .split(/\s*,\s*/g)
-    .map(function(browser) {
-      if (browser === 'ChromeHeadless') {
-        process.env.CHROME_BIN = require('puppeteer').executablePath();
+var browsers = (process.env.TEST_BROWSERS || 'PhantomJS').split(',');
 
-        // workaround https://github.com/GoogleChrome/puppeteer/issues/290
-        if (process.platform === 'linux') {
-          return 'ChromeHeadless_Linux';
-        }
-      }
+// use puppeteer provided Chrome for testing
+process.env.CHROME_BIN = require('puppeteer').executablePath();
 
-      return browser;
-    });
+var absoluteBasePath = path.resolve(__dirname);
 
 var suite = coverage ? 'test/coverageBundle.js' : 'test/testBundle.js';
 
@@ -48,20 +34,9 @@ module.exports = function(karma) {
 
     reporters: [ 'progress' ].concat(coverage ? 'coverage' : []),
 
-    browsers: browsers,
+    browsers,
 
     browserNoActivityTimeout: 30000,
-
-    customLaunchers: {
-      ChromeHeadless_Linux: {
-        base: 'ChromeHeadless',
-        flags: [
-          '--no-sandbox',
-          '--disable-setuid-sandbox'
-        ],
-        debug: true
-      }
-    },
 
     coverageReporter: {
       reporters: [


### PR DESCRIPTION
Custom Chrome launcher on Linux is not needed anymore (as of 2020).