### PR TITLE
feat(keyboard): use keyCode as fallback

### DIFF
--- a/lib/features/keyboard/KeyboardBindings.js
+++ b/lib/features/keyboard/KeyboardBindings.js
@@ -6,6 +6,16 @@ import {
 
 var LOW_PRIORITY = 500;
 
+export var KEYCODE_C = 67;
+export var KEYCODE_V = 86;
+export var KEYCODE_Y = 89;
+export var KEYCODE_Z = 90;
+
+export var KEYS_COPY = ['c', 'C', KEYCODE_C ];
+export var KEYS_PASTE = [ 'v', 'V', KEYCODE_V ];
+export var KEYS_REDO = [ 'y', 'Y', KEYCODE_Y ];
+export var KEYS_UNDO = [ 'z', 'Z', KEYCODE_Z ];
+
 
 /**
  * Adds default keyboard bindings.
@@ -63,7 +73,7 @@ KeyboardBindings.prototype.registerBindings = function(keyboard, editorActions) 
 
     var event = context.keyEvent;
 
-    if (isCmd(event) && !isShift(event) && isKey(['z', 'Z'], event)) {
+    if (isCmd(event) && !isShift(event) && isKey(KEYS_UNDO, event)) {
       editorActions.trigger('undo');
 
       return true;
@@ -77,7 +87,7 @@ KeyboardBindings.prototype.registerBindings = function(keyboard, editorActions) 
 
     var event = context.keyEvent;
 
-    if (isCmd(event) && (isKey(['y', 'Y'], event) || (isKey(['z', 'Z'], event) && isShift(event)))) {
+    if (isCmd(event) && (isKey(KEYS_REDO, event) || (isKey(KEYS_UNDO, event) && isShift(event)))) {
       editorActions.trigger('redo');
 
       return true;
@@ -90,7 +100,7 @@ KeyboardBindings.prototype.registerBindings = function(keyboard, editorActions) 
 
     var event = context.keyEvent;
 
-    if (isCmd(event) && isKey(['c', 'C'], event)) {
+    if (isCmd(event) && isKey(KEYS_COPY, event)) {
       editorActions.trigger('copy');
 
       return true;
@@ -103,7 +113,7 @@ KeyboardBindings.prototype.registerBindings = function(keyboard, editorActions) 
 
     var event = context.keyEvent;
 
-    if (isCmd(event) && isKey(['v', 'V'], event)) {
+    if (isCmd(event) && isKey(KEYS_PASTE, event)) {
       editorActions.trigger('paste');
 
       return true;

--- a/lib/features/keyboard/KeyboardUtil.js
+++ b/lib/features/keyboard/KeyboardUtil.js
@@ -31,7 +31,7 @@ export function isCmd(event) {
 export function isKey(keys, event) {
   keys = isArray(keys) ? keys : [ keys ];
 
-  return keys.indexOf(event.key) > -1;
+  return keys.indexOf(event.key) !== -1 || keys.indexOf(event.keyCode) !== -1;
 }
 
 /**

--- a/test/spec/features/keyboard/CopySpec.js
+++ b/test/spec/features/keyboard/CopySpec.js
@@ -14,7 +14,7 @@ import editorActionsModule from 'lib/features/editor-actions';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
 
-var KEYS = [ 'c', 'C' ];
+import { KEYS_COPY } from 'lib/features/keyboard/KeyboardBindings';
 
 
 describe('features/keyboard - copy', function() {
@@ -35,12 +35,12 @@ describe('features/keyboard - copy', function() {
   var decisionTable = [
     {
       desc: 'should call copy',
-      keys: KEYS,
+      keys: KEYS_COPY,
       ctrlKey: true,
       called: true
     }, {
       desc: 'should not call copy',
-      keys: KEYS,
+      keys: KEYS_COPY,
       ctrlKey: false,
       called: false
     }

--- a/test/spec/features/keyboard/PasteSpec.js
+++ b/test/spec/features/keyboard/PasteSpec.js
@@ -14,7 +14,7 @@ import editorActionsModule from 'lib/features/editor-actions';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
 
-var KEYS = [ 'v', 'V' ];
+import { KEYS_PASTE } from 'lib/features/keyboard/KeyboardBindings';
 
 
 describe('features/keyboard - paste', function() {
@@ -34,12 +34,12 @@ describe('features/keyboard - paste', function() {
 
   var decisionTable = [{
     desc: 'should call paste',
-    keys: KEYS,
+    keys: KEYS_PASTE,
     ctrlKey: true,
     called: true
   }, {
     desc: 'should not call paste',
-    keys: KEYS,
+    keys: KEYS_PASTE,
     ctrlKey: false,
     called: false
   }];

--- a/test/spec/features/keyboard/RedoSpec.js
+++ b/test/spec/features/keyboard/RedoSpec.js
@@ -13,10 +13,10 @@ import keyboardModule from 'lib/features/keyboard';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
 
-var KEYS = {
-  Z: [ 'z', 'Z' ],
-  Y: [ 'y', 'y' ]
-};
+import {
+  KEYS_REDO,
+  KEYS_UNDO
+} from 'lib/features/keyboard/KeyboardBindings';
 
 
 describe('features/keyboard - redo', function() {
@@ -34,43 +34,43 @@ describe('features/keyboard - redo', function() {
 
   var decisionTable = [{
     desc: 'should call redo',
-    keys: KEYS.Z,
+    keys: KEYS_UNDO,
     ctrlKey: true,
     shiftKey: true,
     called: true
   }, {
     desc: 'should call redo',
-    keys: KEYS.Y,
+    keys: KEYS_REDO,
     ctrlKey: true,
     shiftKey: false,
     called: true
   }, {
     desc: 'should call redo',
-    keys: KEYS.Y,
+    keys: KEYS_REDO,
     ctrlKey: true,
     shiftKey: true,
     called: true
   }, {
     desc: 'should not call redo',
-    keys: KEYS.Z,
+    keys: KEYS_UNDO,
     ctrlKey: false,
     shiftKey: true,
     called: false
   }, {
     desc: 'should not call redo',
-    keys: KEYS.Z,
+    keys: KEYS_UNDO,
     ctrlKey: true,
     shiftKey: false,
     called: false
   }, {
     desc: 'should not call redo',
-    keys: KEYS.Y,
+    keys: KEYS_REDO,
     ctrlKey: false,
     shiftKey: false,
     called: false
   }, {
     desc: 'should not call redo',
-    keys: KEYS.Z,
+    keys: KEYS_UNDO,
     ctrlKey: false,
     shiftKey: false,
     called: false

--- a/test/spec/features/keyboard/UndoSpec.js
+++ b/test/spec/features/keyboard/UndoSpec.js
@@ -13,7 +13,7 @@ import keyboardModule from 'lib/features/keyboard';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
 
-var KEYS = [ 'z', 'Z' ];
+import { KEYS_UNDO } from 'lib/features/keyboard/KeyboardBindings';
 
 
 describe('features/keyboard - undo', function() {
@@ -31,25 +31,25 @@ describe('features/keyboard - undo', function() {
 
   var decisionTable = [{
     desc: 'should call undo',
-    keys: KEYS,
+    keys: KEYS_UNDO,
     ctrlKey: true,
     shiftKey: false,
     called: true
   }, {
     desc: 'should not call undo',
-    keys: KEYS,
+    keys: KEYS_UNDO,
     ctrlKey: true,
     shiftKey: true,
     called: false
   }, {
     desc: 'should not call undo',
-    keys: KEYS,
+    keys: KEYS_UNDO,
     ctrlKey: false,
     shiftKey: true,
     called: false
   }, {
     desc: 'should not call undo',
-    keys: KEYS,
+    keys: KEYS_UNDO,
     ctrlKey: false,
     shiftKey: false,
     called: false


### PR DESCRIPTION
Using `keyCode` as a fallback ensures that the keyboard bindings work on keyboards other than QWERTY. I've successfully tested it using a Russian keyboard layout.

Closes https://github.com/bpmn-io/diagram-js/pull/456