### PR TITLE
fix: moving this._emit('open') line to the end of open() method to al…

### DIFF
--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -153,7 +153,6 @@ PopupMenu.prototype.open = function(element, id, position) {
     this.close();
   }
 
-  this._emit('open');
 
   var current = this._current = {
     className: id,
@@ -184,6 +183,7 @@ PopupMenu.prototype.open = function(element, id, position) {
       parent = canvas.getContainer();
 
   this._attachContainer(current.container, parent, position.cursor);
+  this._emit('open');
   this._bindAutoClose();
 };
 


### PR DESCRIPTION
PopupMenu.open() method fires 'popupMenu.open' event before popup menu entries are attached to the DOM. Due to this a custom 'popupMenu.open' event listener is unable to find the custom popupMenu entry using document querySelector because my custom menu entry is not attached to the DOM yet. 
Proposing to move the 'this._emit('open');' line to the end of the PopupMenu.open() method after menu entries have been attached to the DOM.

PR addresses this issue:
https://github.com/bpmn-io/diagram-js/issues/472
