### PR TITLE
Replace whitelist/blacklist with allowlist/blocklist

### DIFF
--- a/test/spec/features/rules/priority-rules/PriorityRules.js
+++ b/test/spec/features/rules/priority-rules/PriorityRules.js
@@ -17,13 +17,13 @@ inherits(PriorityRules, RuleProvider);
 
 PriorityRules.prototype.init = function() {
 
-  // a white+black list containing
+  // a allow+block list containing
   // element ids
-  var whiteList = [
+  var allowList = [
     'always-resizable'
   ];
 
-  var blackList = [
+  var blockList = [
     'never-resizable'
   ];
 
@@ -36,11 +36,11 @@ PriorityRules.prototype.init = function() {
   this.addRule('shape.resize', HIGH_PRIORITY, function(context) {
     var shape = context.shape;
 
-    if (whiteList.indexOf(shape.id) !== -1) {
+    if (allowList.indexOf(shape.id) !== -1) {
       return true;
     }
 
-    if (blackList.indexOf(shape.id) !== -1) {
+    if (blockList.indexOf(shape.id) !== -1) {
       return false;
     }
   });


### PR DESCRIPTION
Related to https://go-review.googlesource.com/c/go/+/236857/

> There's been plenty of discussion on the usage of these terms in tech.
> I'm not trying to have yet another debate. It's clear that there are
> people who are hurt by them and who are made to feel unwelcome by their
> use due not to technical reasons but to their historical and social
> context. That's simply enough reason to replace them.
> 
> Anyway, allowlist and blocklist are more self-explanatory than whitelist
> and blacklist, so this change has negative cost.
> 
> Didn't change vendored, bundled, and minified files. Nearly all changes
> are tests or comments, with a couple renames in cmd/link and cmd/oldlink
> which are extremely safe. This should be fine to land during the freeze
> without even asking for an exception.

I agree completely with the statement above. This PR does not contain any API changes.