### PR TITLE
Correctly handle stopPropagation for iphone and ipad devices

### DIFF
--- a/lib/features/touch/TouchInteractionEvents.js
+++ b/lib/features/touch/TouchInteractionEvents.js
@@ -37,7 +37,14 @@ function get(service, injector) {
 function stopEvent(event) {
 
   event.preventDefault();
-  event.stopPropagation();
+
+  if (typeof event.stopPropagation === 'function') {
+    event.stopPropagation();
+  } else if (event.srcEvent && typeof event.srcEvent.stopPropagation === 'function') {
+
+    // iPhone & iPad
+    event.srcEvent.stopPropagation();
+  }
 
   if (typeof event.stopImmediatePropagation === 'function') {
     event.stopImmediatePropagation();
@@ -72,7 +79,8 @@ function createTouchRecognizer(node) {
 
   var recognizer = new Hammer.Manager(node, {
     inputClass: Hammer.TouchInput,
-    recognizers: []
+    recognizers: [],
+    domEvents: true
   });
 
 


### PR DESCRIPTION
Fixes touch bugs that occur frequently in Sentry (https://sentry.io/organizations/camunda-modeling/issues/1640119817/?project=5218065&query=is%3Aunresolved&statsPeriod=24h)

For the solution, see: https://stackoverflow.com/questions/26027362/how-to-stoppropagation-w-hammer-js-2-0

I tested this with my iPhone and can confirm it works. One can also test this with XCode iPhone simulator & remote debugging via Safari on MacOS devices.

__Definition of Done__

* [x] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [x] corresponds to [the code standards](https://github.com/bpmn-io/diagram-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [x] passes Continuous Integration checks
* [x] available as feature branch on GitHub
  * [x] contains the cleaned up commit history
  * [x] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
