### PR TITLE
fix(keyboard): bind zoom in to `=` key

### DIFF
--- a/lib/features/keyboard/KeyboardBindings.js
+++ b/lib/features/keyboard/KeyboardBindings.js
@@ -126,7 +126,9 @@ KeyboardBindings.prototype.registerBindings = function(keyboard, editorActions) 
 
     var event = context.keyEvent;
 
-    if (isKey([ '+', 'Add' ], event) && isCmd(event)) {
+    // quirk: it has to be triggered by `=` as well to work on international keyboard layout
+    // cf: https://github.com/bpmn-io/bpmn-js/issues/1362#issuecomment-722989754
+    if (isKey([ '+', 'Add', '=' ], event) && isCmd(event)) {
       editorActions.trigger('stepZoom', { value: 1 });
 
       return true;

--- a/test/spec/features/keyboard/ZoomSpec.js
+++ b/test/spec/features/keyboard/ZoomSpec.js
@@ -14,7 +14,7 @@ import keyboardModule from 'lib/features/keyboard';
 import { createKeyEvent } from 'test/util/KeyEvents';
 
 var KEYS = {
-  ZOOM_IN: [ '+', 'Add' ],
+  ZOOM_IN: [ '+', 'Add', '=' ],
   ZOOM_OUT: [ '-', 'Subtract' ],
   ZOOM_DEFAULT: [ '0' ],
 };


### PR DESCRIPTION
This is required for the feature to work on international
keyboard layout.

Related to https://github.com/bpmn-io/bpmn-js/issues/1362

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/diagram-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
