### PR TITLE
Remove hover class of hovered element on drop

### DIFF
--- a/lib/features/dragging/HoverFix.js
+++ b/lib/features/dragging/HoverFix.js
@@ -24,7 +24,7 @@ var HIGH_PRIORITY = 1500;
  * @param {Dragging} dragging
  * @param {ElementRegistry} elementRegistry
  */
-export default function HoverFix(eventBus, dragging, elementRegistry) {
+export default function HoverFix(canvas, eventBus, dragging, elementRegistry) {
 
   var self = this;
 
@@ -74,6 +74,16 @@ export default function HoverFix(eventBus, dragging, elementRegistry) {
       ensureHover(event);
 
     });
+
+  });
+
+  /**
+   * We make sure that dropping an element forces the element
+   * we're hovering over to lose the hover class.
+   */
+  eventBus.on('drag.end', function(event) {
+
+    canvas.removeMarker(event.hoverGfx, 'hover');
 
   });
 
@@ -152,6 +162,7 @@ export default function HoverFix(eventBus, dragging, elementRegistry) {
 }
 
 HoverFix.$inject = [
+  'canvas',
   'eventBus',
   'dragging',
   'elementRegistry'


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js/issues/1366

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/diagram-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
