### PR TITLE
feat(util/Text): support soft breaks

### DIFF
--- a/lib/util/Text.js
+++ b/lib/util/Text.js
@@ -275,7 +275,9 @@ Text.prototype.layoutText = function(text, options) {
 
   var lineHeight = getLineHeight(style);
 
-  var lines = text.split(/\r?\n/g),
+  // we split text by lines and normalize
+  // {soft break} + {line break} => { line break }
+  var lines = text.split(/\u00AD?\r?\n/),
       layouted = [];
 
   var maxWidth = box.width - padding.left - padding.right;

--- a/lib/util/Text.js
+++ b/lib/util/Text.js
@@ -123,6 +123,8 @@ function fit(lines, fitLine, originalLine, textBBox) {
   };
 }
 
+var SOFT_BREAK = '\u00AD';
+
 
 /**
  * Shortens a line based on spacing and hyphens.
@@ -133,13 +135,15 @@ function fit(lines, fitLine, originalLine, textBBox) {
  * @return {string} the shortened string
  */
 function semanticShorten(line, maxLength) {
-  var parts = line.split(/(\s|-)/g),
+
+  var parts = line.split(/(\s|-|\u00AD)/g),
       part,
       shortenedParts = [],
       length = 0;
 
-  // try to shorten via spaces + hyphens
+  // try to shorten via break chars
   if (parts.length > 1) {
+
     while ((part = parts.shift())) {
       if (part.length + length < maxLength) {
         shortenedParts.push(part);
@@ -147,13 +151,20 @@ function semanticShorten(line, maxLength) {
       } else {
 
         // remove previous part, too if hyphen does not fit anymore
-        if (part === '-') {
+        if (part === '-' || part === SOFT_BREAK) {
           shortenedParts.pop();
         }
 
         break;
       }
     }
+  }
+
+  var last = shortenedParts[shortenedParts.length - 1];
+
+  // translate trailing soft break to actual hyphen
+  if (last && last === SOFT_BREAK) {
+    shortenedParts[shortenedParts.length - 1] = '-';
   }
 
   return shortenedParts.join('');

--- a/test/spec/util/TextSpec.js
+++ b/test/spec/util/TextSpec.js
@@ -124,7 +124,6 @@ describe('util - Text', function() {
 
   describe('#createText', function() {
 
-
     it('should create simple label', function() {
 
       // given
@@ -252,6 +251,63 @@ describe('util - Text', function() {
 
         expect(text).to.exist;
         expect(toFitBBox(text, { x: 0, y: -40, width: 100, height: 190 })).to.be.true;
+      });
+
+
+      it('preformated / soft breaks', function() {
+
+        // given
+        // string contains invisible "soft break characters" => |
+        // Fight Hippopoto­|monstro­|sesquippe­|daliophobia
+        var label = 'Fight Hippopoto­monstro­sesquippe­daliophobia';
+
+        // when
+        var text = createText(container, label, {
+          box: { width: 100, height: 100 },
+          align: 'center-middle',
+          padding: 5
+        });
+
+        expect(text).to.exist;
+        expect(toFitBBox(text, { x: 0, y: 0, width: 100, height: 100 })).to.be.true;
+      });
+
+
+      it('preformated / soft breaks / no break', function() {
+
+        // given
+        // string contains invisible "soft break characters" => |
+        // Fight A|B|C
+        var label = 'Fight A­B­C';
+
+        // when
+        var text = createText(container, label, {
+          box: { width: 100, height: 100 },
+          align: 'center-middle',
+          padding: 5
+        });
+
+        expect(text).to.exist;
+        expect(toFitBBox(text, { x: 0, y: 35, width: 100, height: 30 })).to.be.true;
+      });
+
+
+      it('preformated / soft breaks / some breaks', function() {
+
+        // given
+        // string contains invisible "soft break characters" => |
+        // Fight A|B|C|D|E|F|G|H|I|J|K
+        var label = 'Fight A­B­C­D­E­FG­H­I­J­K';
+
+        // when
+        var text = createText(container, label, {
+          box: { width: 100, height: 100 },
+          align: 'center-middle',
+          padding: 5
+        });
+
+        expect(text).to.exist;
+        expect(toFitBBox(text, { x: 0, y: 25, width: 100, height: 50 })).to.be.true;
       });
 
 

--- a/test/spec/util/TextSpec.js
+++ b/test/spec/util/TextSpec.js
@@ -10,35 +10,6 @@ import {
 } from 'tiny-svg';
 
 
-function toFitBBox(actual, expected) {
-
-  var actualBBox = actual.getBBox ? actual.getBBox() : actual;
-
-  var pass = actualBBox.width <= expected.width &&
-             (expected.height ? actualBBox.height <= expected.height : true);
-
-
-  if (actualBBox.x) {
-    pass = actualBBox.x >= expected.x &&
-           actualBBox.y >= expected.y &&
-           actualBBox.x + actualBBox.width <= expected.x + expected.width &&
-           (expected.height ? actualBBox.y + actualBBox.height <= expected.y + expected.height : true);
-  }
-
-  if (!pass) {
-    var bbox = pick(actualBBox, ['x', 'y', 'width', 'height']);
-
-    var message =
-      'Expected Element#' + actual.id + ' with bbox ' +
-       JSON.stringify(bbox) + ' to fit ' +
-       JSON.stringify(expected);
-
-    console.error(message);
-  }
-
-  return !!pass;
-}
-
 import TextUtil from 'lib/util/Text';
 
 import TestContainer from 'mocha-test-container-support';
@@ -78,6 +49,40 @@ describe('util - Text', function() {
 
     svgAppend(svg, container);
   });
+
+  function toFitBBox(actual, expected) {
+
+    var parent = actual.parentNode;
+
+    if (parent) {
+      drawRect(expected, { strokeWidth: '1px', stroke: 'orange' });
+    }
+
+    var actualBBox = actual.getBBox ? actual.getBBox() : actual;
+
+    var pass = actualBBox.width <= expected.width &&
+               (expected.height ? actualBBox.height <= expected.height : true);
+
+    if (actualBBox.x) {
+      pass = actualBBox.x >= expected.x &&
+             actualBBox.y >= expected.y &&
+             actualBBox.x + actualBBox.width <= expected.x + expected.width &&
+             (expected.height ? actualBBox.y + actualBBox.height <= expected.y + expected.height : true);
+    }
+
+    if (!pass) {
+      var bbox = pick(actualBBox, ['x', 'y', 'width', 'height']);
+
+      var message =
+        'Expected Element#' + actual.id + ' with bbox ' +
+         JSON.stringify(bbox) + ' to fit ' +
+         JSON.stringify(expected);
+
+      console.error(message);
+    }
+
+    return !!pass;
+  }
 
   function drawRect(bounds, style) {
 
@@ -280,6 +285,25 @@ describe('util - Text', function() {
       });
 
 
+      it('preformated / soft breaks / forced breaks', function() {
+
+        // given
+        // string contains invisible "soft break characters" => |
+        // Hippopoto­|monstro­\n\nsesquippe­|daliophobia
+        var label = 'Hippopoto­monstro\n\nsesquippe­daliophobia';
+
+        // when
+        var text = createText(container, label, {
+          box: { width: 100, height: 100 },
+          align: 'center-middle',
+          padding: 5
+        });
+
+        expect(text).to.exist;
+        expect(toFitBBox(text, { x: 0, y: 0, width: 100, height: 100 })).to.be.true;
+      });
+
+
       it('preformated / soft breaks / no break', function() {
 
         // given
@@ -296,6 +320,25 @@ describe('util - Text', function() {
 
         expect(text).to.exist;
         expect(toFitBBox(text, { x: 0, y: 35, width: 100, height: 30 })).to.be.true;
+      });
+
+
+      it('preformated / soft breaks / CR_LF', function() {
+
+        // given
+        // string contains invisible "soft break characters" => |
+        // Fight Hippopoto­|monstro­|\r\nsesquippe­|daliophobia
+        var label = 'Fight Hippopoto­monstro­\r\nsesquippe­daliophobia';
+
+        // when
+        var text = createText(container, label, {
+          box: { width: 100, height: 100 },
+          align: 'center-middle',
+          padding: 5
+        });
+
+        expect(text).to.exist;
+        expect(toFitBBox(text, { x: 0, y: 0, width: 100, height: 100 })).to.be.true;
       });
 
 

--- a/test/spec/util/TextSpec.js
+++ b/test/spec/util/TextSpec.js
@@ -114,9 +114,16 @@ describe('util - Text', function() {
     var element = textAndBoundingBox.element,
         dimensions = textAndBoundingBox.dimensions;
 
-    drawRect(dimensions, { strokeWidth: '1px', stroke: 'fuchsia' });
-
     svgAppend(container, element);
+
+    var bbox = element.getBBox();
+
+    drawRect({
+      x: bbox.x,
+      y: bbox.y,
+      width: dimensions.width,
+      height: dimensions.height
+    }, { strokeWidth: '1px', stroke: 'fuchsia' });
 
     return element;
   }


### PR DESCRIPTION
This adds handling for discretionary hyphens / soft breaks in our renderer.

If a discretionary hyphen is rendered as a break point it becomes a `-`.

Related to https://github.com/bpmn-io/bpmn-js/issues/1383

---

![capture KCFgUj_optimized](https://user-images.githubusercontent.com/58601/101823702-77888400-3b2b-11eb-8501-094f4fa02244.gif)
