### PR TITLE
Middle mouse button canvas move

### DIFF
--- a/lib/features/bendpoints/Bendpoints.js
+++ b/lib/features/bendpoints/Bendpoints.js
@@ -25,6 +25,10 @@ import {
 } from '../../util/Geometry';
 
 import {
+  isPrimaryButton
+} from '../../util/Mouse';
+
+import {
   append as svgAppend,
   attr as svgAttr,
   classes as svgClasses,
@@ -333,6 +337,10 @@ export default function Bendpoints(
   });
 
   eventBus.on('element.mousedown', function(event) {
+
+    if (!isPrimaryButton(event)) {
+      return;
+    }
 
     var originalEvent = event.originalEvent,
         element = event.element;

--- a/lib/features/hand-tool/HandTool.js
+++ b/lib/features/hand-tool/HandTool.js
@@ -1,4 +1,6 @@
-import { hasPrimaryModifier } from '../../util/Mouse';
+import {
+  hasPrimaryModifier
+} from '../../util/Mouse';
 
 import { isKey } from '../../features/keyboard/KeyboardUtil';
 
@@ -22,11 +24,14 @@ export default function HandTool(
   });
 
   eventBus.on('element.mousedown', HIGH_PRIORITY, function(event) {
-    if (hasPrimaryModifier(event)) {
-      self.activateMove(event.originalEvent, true);
 
-      return false;
+    if (!hasPrimaryModifier(event)) {
+      return;
     }
+
+    self.activateMove(event.originalEvent, true);
+
+    return false;
   });
 
   keyboard && keyboard.addListener(HIGH_PRIORITY, function(e) {

--- a/lib/features/interaction-events/InteractionEvents.js
+++ b/lib/features/interaction-events/InteractionEvents.js
@@ -9,7 +9,10 @@ import {
   queryAll as domQueryAll
 } from 'min-dom';
 
-import { isPrimaryButton } from '../../util/Mouse';
+import {
+  isPrimaryButton,
+  isAuxiliaryButton
+} from '../../util/Mouse';
 
 import {
   append as svgAppend,
@@ -23,7 +26,11 @@ import {
   updateLine
 } from '../../util/RenderUtil';
 
-function allowAll(e) { return true; }
+function allowAll(event) { return true; }
+
+function allowPrimaryAndAuxiliary(event) {
+  return isPrimaryButton(event) || isAuxiliaryButton(event);
+}
 
 var LOW_PRIORITY = 500;
 
@@ -125,7 +132,11 @@ export default function InteractionEvents(eventBus, elementRegistry, styles) {
   };
 
   var ignoredFilters = {
-    'element.contextmenu': allowAll
+    'element.contextmenu': allowAll,
+    'element.mousedown': allowPrimaryAndAuxiliary,
+    'element.mouseup': allowPrimaryAndAuxiliary,
+    'element.click': allowPrimaryAndAuxiliary,
+    'element.dblclick': allowPrimaryAndAuxiliary
   };
 
 

--- a/lib/features/lasso-tool/LassoTool.js
+++ b/lib/features/lasso-tool/LassoTool.js
@@ -2,7 +2,9 @@ import { values } from 'min-dash';
 
 import { getEnclosedElements } from '../../util/Elements';
 
-import { hasSecondaryModifier } from '../../util/Mouse';
+import {
+  hasSecondaryModifier
+} from '../../util/Mouse';
 
 import {
   append as svgAppend,
@@ -128,12 +130,14 @@ export default function LassoTool(
 
   eventBus.on('element.mousedown', 1500, function(event) {
 
-    if (hasSecondaryModifier(event)) {
-      self.activateLasso(event.originalEvent);
-
-      // we've handled the event
-      return true;
+    if (!hasSecondaryModifier(event)) {
+      return;
     }
+
+    self.activateLasso(event.originalEvent);
+
+    // we've handled the event
+    return true;
   });
 }
 

--- a/lib/features/move/Move.js
+++ b/lib/features/move/Move.js
@@ -11,6 +11,10 @@ var LOW_PRIORITY = 500,
 
 import { getOriginal as getOriginalEvent } from '../../util/Event';
 
+import {
+  isPrimaryButton
+} from '../../util/Mouse';
+
 var round = Math.round;
 
 function mid(element) {
@@ -165,6 +169,10 @@ export default function MoveEvents(
   // move activation
 
   eventBus.on('element.mousedown', function(event) {
+
+    if (!isPrimaryButton(event)) {
+      return;
+    }
 
     var originalEvent = getOriginalEvent(event);
 

--- a/lib/features/selection/SelectionBehavior.js
+++ b/lib/features/selection/SelectionBehavior.js
@@ -1,6 +1,7 @@
 import {
   hasPrimaryModifier,
-  hasSecondaryModifier
+  hasSecondaryModifier,
+  isPrimaryButton
 } from '../../util/Mouse';
 
 import {
@@ -65,6 +66,11 @@ export default function SelectionBehavior(eventBus, selection, canvas, elementRe
 
   // Select elements on click
   eventBus.on('element.click', function(event) {
+
+    if (!isPrimaryButton(event)) {
+      return;
+    }
+
     var element = event.element;
 
     if (element === canvas.getRootElement()) {

--- a/lib/navigation/movecanvas/MoveCanvas.js
+++ b/lib/navigation/movecanvas/MoveCanvas.js
@@ -46,13 +46,16 @@ export default function MoveCanvas(eventBus, canvas) {
   function handleMove(event) {
 
     var start = context.start,
+        button = context.button,
         position = toPoint(event),
         delta = deltaPos(position, start);
 
     if (!context.dragging && length(delta) > THRESHOLD) {
       context.dragging = true;
 
-      installClickTrap(eventBus);
+      if (button === 0) {
+        installClickTrap(eventBus);
+      }
 
       cursorSet('grab');
     }
@@ -92,12 +95,15 @@ export default function MoveCanvas(eventBus, canvas) {
       return;
     }
 
+    var button = event.button;
+
     // reject right mouse button or modifier key
-    if (event.button >= 2 || event.ctrlKey || event.shiftKey || event.altKey) {
+    if (button >= 2 || event.ctrlKey || event.shiftKey || event.altKey) {
       return;
     }
 
     context = {
+      button: button,
       start: toPoint(event)
     };
 

--- a/lib/navigation/movecanvas/MoveCanvas.js
+++ b/lib/navigation/movecanvas/MoveCanvas.js
@@ -92,9 +92,8 @@ export default function MoveCanvas(eventBus, canvas) {
       return;
     }
 
-
-    // reject non-left left mouse button or modifier key
-    if (event.button || event.ctrlKey || event.shiftKey || event.altKey) {
+    // reject right mouse button or modifier key
+    if (event.button >= 2 || event.ctrlKey || event.shiftKey || event.altKey) {
       return;
     }
 

--- a/lib/navigation/movecanvas/MoveCanvas.js
+++ b/lib/navigation/movecanvas/MoveCanvas.js
@@ -113,6 +113,11 @@ export default function MoveCanvas(eventBus, canvas) {
     // we've handled the event
     return true;
   }
+
+  this.isActive = function() {
+    return !!context;
+  };
+
 }
 
 

--- a/lib/util/Mouse.js
+++ b/lib/util/Mouse.js
@@ -10,11 +10,26 @@ export {
   isMac
 } from './Platform';
 
+export function isButton(event, button) {
+  return (getOriginalEvent(event) || event).button === button;
+}
 
 export function isPrimaryButton(event) {
 
   // button === 0 -> left áka primary mouse button
-  return !(getOriginalEvent(event) || event).button;
+  return isButton(event, 0);
+}
+
+export function isAuxiliaryButton(event) {
+
+  // button === 1 -> auxiliary áka wheel button
+  return isButton(event, 1);
+}
+
+export function isSecondaryButton(event) {
+
+  // button === 2 -> right áka secondary button
+  return isButton(event, 2);
 }
 
 export function hasPrimaryModifier(event) {

--- a/test/spec/features/bendpoints/BendpointsSpec.js
+++ b/test/spec/features/bendpoints/BendpointsSpec.js
@@ -128,6 +128,31 @@ describe('features/bendpoints', function() {
     }));
 
 
+    it('should NOT activate on AUXILIARY mouse button', inject(
+      function(dragging, eventBus, elementRegistry) {
+
+        // when
+        eventBus.fire('element.hover', {
+          element: connection,
+          gfx: elementRegistry.getGraphics(connection)
+        });
+        eventBus.fire('element.mousemove', {
+          element: connection,
+          originalEvent: canvasEvent({ x: 250, y: 250 })
+        });
+        eventBus.fire('element.mousedown', {
+          element: connection,
+          originalEvent: canvasEvent({ x: 250, y: 250 }, { button: 1 })
+        });
+
+        var draggingContext = dragging.context();
+
+        // then
+        expect(draggingContext).not.to.exist;
+      }
+    ));
+
+
     it('should activate bendpoint move on starting waypoint', inject(
       function(dragging, eventBus, elementRegistry) {
 

--- a/test/spec/features/hand-tool/HandToolSpec.js
+++ b/test/spec/features/hand-tool/HandToolSpec.js
@@ -105,6 +105,16 @@ describe('features/hand-tool', function() {
       expect(handTool.isActive()).to.be.true;
     }));
 
+
+    it('should NOT start on AUXILIARY mousedown', inject(function(handTool, eventBus) {
+
+      // when
+      eventBus.fire(mouseDownEvent(rootShape, { button: 1, ctrlKey: false }));
+
+      // then
+      expect(handTool.isActive()).to.be.false;
+    }));
+
   });
 
 

--- a/test/spec/features/interaction-events/InteractionEventsSpec.js
+++ b/test/spec/features/interaction-events/InteractionEventsSpec.js
@@ -5,6 +5,15 @@ import {
 
 import interactionEventsModule from 'lib/features/interaction-events';
 
+import {
+  queryAll as domQueryAll
+} from 'min-dom';
+
+import {
+  filter
+} from 'min-dash';
+
+
 var bindings = {
   mouseover: 'element.hover',
   mouseout: 'element.out',
@@ -15,13 +24,12 @@ var bindings = {
   contextmenu: 'element.contextmenu'
 };
 
-import {
-  queryAll as domQueryAll
-} from 'min-dom';
-
-import {
-  filter
-} from 'min-dash';
+var auxiliaryBindings = {
+  click: 'element.click',
+  dblclick: 'element.dblclick',
+  mousedown: 'element.mousedown',
+  mouseup: 'element.mouseup'
+};
 
 
 describe('features/interaction-events', function() {
@@ -150,6 +158,11 @@ describe('features/interaction-events', function() {
         verifyEvent(event);
       });
 
+      // auxiliary-clicks
+      Object.keys(auxiliaryBindings).forEach(function(event) {
+        verifyEvent(event, 1);
+      });
+
       // <contextmenu> right-click
       verifyEvent('contextmenu', 2);
 
@@ -159,12 +172,7 @@ describe('features/interaction-events', function() {
     describe('should suppress', function() {
 
       // right-clicks
-      [
-        'click',
-        'mousedown',
-        'mouseup',
-        'dblclick'
-      ].forEach(function(event) {
+      Object.keys(auxiliaryBindings).forEach(function(event) {
         verifyNoEvent(event, 2);
       });
 

--- a/test/spec/features/lasso-tool/LassoToolSpec.js
+++ b/test/spec/features/lasso-tool/LassoToolSpec.js
@@ -1,11 +1,16 @@
 import {
   bootstrapDiagram,
+  getDiagramJS,
   inject
 } from 'test/TestHelper';
 
 import {
   createCanvasEvent as canvasEvent
 } from '../../../util/MockEvents';
+
+import {
+  assign
+} from 'min-dash';
 
 import modelingModule from 'lib/features/modeling';
 import lassoToolModule from 'lib/features/lasso-tool';
@@ -15,7 +20,13 @@ import draggingModule from 'lib/features/dragging';
 describe('features/lasso-tool', function() {
 
 
-  beforeEach(bootstrapDiagram({ modules: [ modelingModule, lassoToolModule, draggingModule ] }));
+  beforeEach(bootstrapDiagram({
+    modules: [
+      modelingModule,
+      lassoToolModule,
+      draggingModule
+    ]
+  }));
 
 
   var rootShape, childShape, childShape2, childShape3, childShape4;
@@ -136,4 +147,42 @@ describe('features/lasso-tool', function() {
 
   });
 
+
+  describe('activate on mouse', function() {
+
+    it('should start on PRIMARY mousedown', inject(function(lassoTool, eventBus) {
+
+      // when
+      eventBus.fire(mouseDownEvent(rootShape, { shiftKey: true }));
+
+      // then
+      expect(lassoTool.isActive()).to.be.true;
+    }));
+
+
+    it('should NOT start on AUXILIARY mousedown', inject(function(lassoTool, eventBus) {
+
+      // when
+      eventBus.fire(mouseDownEvent(rootShape, { button: 1, shiftKey: true }));
+
+      // then
+      expect(lassoTool.isActive()).to.be.falsy;
+    }));
+
+  });
+
 });
+
+
+// helpers ////////////////
+
+function mouseDownEvent(element, data) {
+
+  return getDiagramJS().invoke(function(eventBus) {
+    return eventBus.createEvent({
+      type: 'element.mousedown',
+      element: element,
+      originalEvent: assign({ button: 0 }, data || {})
+    });
+  });
+}

--- a/test/spec/features/move/MoveSpec.js
+++ b/test/spec/features/move/MoveSpec.js
@@ -1,5 +1,6 @@
 import {
   bootstrapDiagram,
+  getDiagramJS,
   inject
 } from 'test/TestHelper';
 
@@ -18,7 +19,12 @@ import moveModule from 'lib/features/move';
 
 describe('features/move - Move', function() {
 
-  beforeEach(bootstrapDiagram({ modules: [ moveModule, modelingModule ] }));
+  beforeEach(bootstrapDiagram({
+    modules: [
+      moveModule,
+      modelingModule
+    ]
+  }));
 
   beforeEach(inject(function(canvas, dragging) {
     dragging.setOptions({ manual: true });
@@ -176,4 +182,44 @@ describe('features/move - Move', function() {
 
   });
 
+
+  describe('activate on mouse', function() {
+
+    it('should start on PRIMARY mousedown', inject(function(dragging, eventBus) {
+
+      // when
+      eventBus.fire(mouseDownEvent(parentShape));
+
+      // then
+      var context = dragging.context();
+
+      expect(context && context.prefix).to.match(/^shape.move/);
+    }));
+
+
+    it('should NOT start on AUXILIARY mousedown', inject(function(dragging, eventBus) {
+
+      // when
+      eventBus.fire(mouseDownEvent(parentShape, { button: 1 }));
+
+      // then
+      expect(dragging.context()).not.to.exist;
+    }));
+
+  });
+
 });
+
+
+// helpers ////////////////
+
+function mouseDownEvent(element, data) {
+
+  return getDiagramJS().invoke(function(eventBus) {
+    return eventBus.createEvent({
+      type: 'element.mousedown',
+      element: element,
+      originalEvent: assign({ button: 0 }, data || {})
+    });
+  });
+}

--- a/test/spec/features/selection/SelectionBehaviorSpec.js
+++ b/test/spec/features/selection/SelectionBehaviorSpec.js
@@ -305,7 +305,7 @@ describe('features/selection/Selection', function() {
 
   describe('element.click', function() {
 
-    it('should select element on click', inject(function(eventBus, selection) {
+    it('should select element on PRIMARY click', inject(function(eventBus, selection) {
 
       // when
       eventBus.fire(clickEvent(shape1));
@@ -313,6 +313,16 @@ describe('features/selection/Selection', function() {
       // then
       expect(selection.get()).to.have.length(1);
       expect(selection.isSelected(shape1)).to.be.true;
+    }));
+
+
+    it('should NOT select element on AUXILIARY click', inject(function(eventBus, selection) {
+
+      // when
+      eventBus.fire(clickEvent(shape1, { button: 1 }));
+
+      // then
+      expect(selection.get()).to.be.empty;
     }));
 
 

--- a/test/spec/features/selection/SelectionBehaviorSpec.js
+++ b/test/spec/features/selection/SelectionBehaviorSpec.js
@@ -1,7 +1,12 @@
 import {
   bootstrapDiagram,
+  getDiagramJS,
   inject
 } from 'test/TestHelper';
+
+import {
+  assign
+} from 'min-dash';
 
 import coreModule from 'lib/core';
 import createModule from 'lib/features/create';
@@ -303,10 +308,7 @@ describe('features/selection/Selection', function() {
     it('should select element on click', inject(function(eventBus, selection) {
 
       // when
-      eventBus.fire(eventBus.createEvent({
-        type: 'element.click',
-        element: shape1
-      }));
+      eventBus.fire(clickEvent(shape1));
 
       // then
       expect(selection.get()).to.have.length(1);
@@ -320,10 +322,7 @@ describe('features/selection/Selection', function() {
       selection.select(shape1);
 
       // when
-      eventBus.fire(eventBus.createEvent({
-        type: 'element.click',
-        element: shape1
-      }));
+      eventBus.fire(clickEvent(shape1));
 
       // then
       expect(selection.get()).to.have.length(0);
@@ -337,10 +336,7 @@ describe('features/selection/Selection', function() {
       selection.select(shape1);
 
       // when
-      eventBus.fire(eventBus.createEvent({
-        type: 'element.click',
-        element: shape2
-      }));
+      eventBus.fire(clickEvent(shape2));
 
       // then
       expect(selection.get()).to.have.length(1);
@@ -356,11 +352,7 @@ describe('features/selection/Selection', function() {
         selection.select(shape1);
 
         // when
-        eventBus.fire(eventBus.createEvent({
-          type: 'element.click',
-          element: shape2,
-          ctrlKey: true
-        }));
+        eventBus.fire(clickEvent(shape2, { ctrlKey: true }));
 
         // then
         expect(selection.get()).to.have.length(2);
@@ -377,11 +369,7 @@ describe('features/selection/Selection', function() {
         selection.select(shape1);
 
         // when
-        eventBus.fire(eventBus.createEvent({
-          type: 'element.click',
-          element: shape2,
-          shiftKey: true
-        }));
+        eventBus.fire(clickEvent(shape2, { shiftKey: true }));
 
         // then
         expect(selection.get()).to.have.length(2);
@@ -398,11 +386,7 @@ describe('features/selection/Selection', function() {
         selection.select([ shape1, shape2 ]);
 
         // when
-        eventBus.fire(eventBus.createEvent({
-          type: 'element.click',
-          element: shape1,
-          ctrlKey: true
-        }));
+        eventBus.fire(clickEvent(shape1, { ctrlKey: true }));
 
         // then
         expect(selection.get()).to.have.length(1);
@@ -419,11 +403,7 @@ describe('features/selection/Selection', function() {
         selection.select([ shape1, shape2 ]);
 
         // when
-        eventBus.fire(eventBus.createEvent({
-          type: 'element.click',
-          element: shape1,
-          shiftKey: true
-        }));
+        eventBus.fire(clickEvent(shape1, { shiftKey: true }));
 
         // then
         expect(selection.get()).to.have.length(1);
@@ -435,3 +415,17 @@ describe('features/selection/Selection', function() {
   });
 
 });
+
+
+// helpers ////////////////
+
+function clickEvent(element, data) {
+
+  return getDiagramJS().invoke(function(eventBus) {
+    return eventBus.createEvent({
+      type: 'element.click',
+      element: element,
+      originalEvent: assign({ button: 0 }, data || {})
+    });
+  });
+}

--- a/test/spec/navigation/movecanvas/MoveCanvasSpec.js
+++ b/test/spec/navigation/movecanvas/MoveCanvasSpec.js
@@ -1,7 +1,12 @@
 import {
   bootstrapDiagram,
+  getDiagramJS,
   inject
 } from 'test/TestHelper';
+
+import {
+  assign
+} from 'min-dash';
 
 import moveCanvasModule from 'lib/navigation/movecanvas';
 import interactionEventsModule from 'lib/features/interaction-events';
@@ -11,7 +16,11 @@ describe('navigation/movecanvas', function() {
 
   describe('bootstrap', function() {
 
-    beforeEach(bootstrapDiagram({ modules: [ moveCanvasModule ] }));
+    beforeEach(bootstrapDiagram({
+      modules: [
+        moveCanvasModule
+      ]
+    }));
 
 
     it('should bootstrap', inject(function(moveCanvas, canvas) {
@@ -30,9 +39,61 @@ describe('navigation/movecanvas', function() {
   });
 
 
+  describe('activate on mouse', function() {
+
+    var rootElement;
+
+    beforeEach(bootstrapDiagram({
+      modules: [
+        moveCanvasModule
+      ]
+    }));
+
+    beforeEach(inject(function(canvas) {
+      rootElement = canvas.getRootElement();
+    }));
+
+
+    it('should start on PRIMARY mousedown', inject(function(eventBus) {
+
+      // when
+      var started = eventBus.fire(mouseDownEvent(rootElement));
+
+      // then
+      expect(started).to.be.true;
+    }));
+
+
+    it('should start on AUXILIARY mousedown', inject(function(eventBus) {
+
+      // when
+      var started = eventBus.fire(mouseDownEvent(rootElement, { button: 1 }));
+
+      // then
+      expect(started).to.be.true;
+    }));
+
+
+    it('should NOT start on mousedown with modifier key', inject(function(eventBus) {
+
+      // when
+      var started = eventBus.fire(mouseDownEvent(rootElement, { ctrlKey: true }));
+
+      // then
+      expect(started).to.be.undefined;
+    }));
+
+  });
+
+
   describe('integration', function() {
 
-    beforeEach(bootstrapDiagram({ modules: [ moveCanvasModule, interactionEventsModule ] }));
+    beforeEach(bootstrapDiagram({
+      modules: [
+        moveCanvasModule,
+        interactionEventsModule
+      ]
+    }));
 
 
     it('should silence click', inject(function(eventBus, moveCanvas, canvas) {
@@ -55,3 +116,20 @@ describe('navigation/movecanvas', function() {
   });
 
 });
+
+
+// helpers ////////////////
+
+function mouseDownEvent(element, data) {
+
+  return getDiagramJS().invoke(function(eventBus, elementRegistry) {
+    return eventBus.createEvent({
+      type: 'element.mousedown',
+      element: element,
+      originalEvent: assign({
+        button: 0,
+        target: elementRegistry.getGraphics(element)
+      }, data || {})
+    });
+  });
+}

--- a/test/spec/navigation/movecanvas/MoveCanvasSpec.js
+++ b/test/spec/navigation/movecanvas/MoveCanvasSpec.js
@@ -54,33 +54,71 @@ describe('navigation/movecanvas', function() {
     }));
 
 
-    it('should start on PRIMARY mousedown', inject(function(eventBus) {
+    it('should start on PRIMARY mousedown', inject(function(eventBus, moveCanvas) {
 
       // when
-      var started = eventBus.fire(mouseDownEvent(rootElement));
+      eventBus.fire(mouseDownEvent(rootElement));
 
       // then
-      expect(started).to.be.true;
+      expect(moveCanvas.isActive()).to.be.true;
     }));
 
 
-    it('should start on AUXILIARY mousedown', inject(function(eventBus) {
+    it('should start on AUXILIARY mousedown', inject(function(eventBus, moveCanvas) {
 
       // when
-      var started = eventBus.fire(mouseDownEvent(rootElement, { button: 1 }));
+      eventBus.fire(mouseDownEvent(rootElement, { button: 1 }));
 
       // then
-      expect(started).to.be.true;
+      expect(moveCanvas.isActive()).to.be.true;
     }));
 
 
-    it('should NOT start on mousedown with modifier key', inject(function(eventBus) {
+    it('should NOT start on mousedown with modifier key', inject(function(eventBus, moveCanvas) {
 
       // when
-      var started = eventBus.fire(mouseDownEvent(rootElement, { ctrlKey: true }));
+      eventBus.fire(mouseDownEvent(rootElement, { ctrlKey: true }));
 
       // then
-      expect(started).to.be.undefined;
+      expect(moveCanvas.isActive()).to.be.false;
+    }));
+
+  });
+
+
+  describe('behavior', function() {
+
+    var rootElement;
+
+    beforeEach(bootstrapDiagram({
+      modules: [
+        moveCanvasModule
+      ]
+    }));
+
+    beforeEach(inject(function(canvas) {
+      rootElement = canvas.getRootElement();
+    }));
+
+
+    it('should move', inject(function(eventBus, canvas, moveCanvas) {
+
+      // given
+      var viewbox = canvas.viewbox();
+
+      eventBus.fire(mouseDownEvent(rootElement, { clientX: 0, clientY: 0 }));
+
+      // when
+      document.dispatchEvent(createMouseEvent(200, 100, 'mousemove'));
+      document.dispatchEvent(createMouseEvent(200, 100, 'mouseup'));
+
+      // then
+      var updatedViewbox = canvas.viewbox();
+
+      expect(moveCanvas.isActive()).to.be.false;
+
+      expect(viewbox.x - updatedViewbox.x).to.eql(200);
+      expect(viewbox.y - updatedViewbox.y).to.eql(100);
     }));
 
   });
@@ -132,4 +170,36 @@ function mouseDownEvent(element, data) {
       }, data || {})
     });
   });
+}
+
+
+function createMouseEvent(x, y, type) {
+  var event = document.createEvent('MouseEvent');
+
+  var screenX = x,
+      screenY = y,
+      clientX = x,
+      clientY = y;
+
+  if (event.initMouseEvent) {
+    event.initMouseEvent(
+      type,
+      true,
+      true,
+      window,
+      0,
+      screenX,
+      screenY,
+      clientX,
+      clientY,
+      false,
+      false,
+      false,
+      false,
+      0,
+      null
+    );
+  }
+
+  return event;
 }

--- a/test/util/MockEvents.js
+++ b/test/util/MockEvents.js
@@ -41,7 +41,8 @@ export function createEvent(target, position, data) {
       clientX: position.x,
       clientY: position.y,
       offsetX: position.x,
-      offsetY: position.y
+      offsetY: position.y,
+      button: 0
     }, data || {});
 
     return eventBus.createEvent(data);


### PR DESCRIPTION
Support middle mouse button canvas move like other state of the art drawing tools support it.

* Introduces ability for interaction events to forward middle mouse button mouse events
* updates behaviors to handle that case accordingly
* increases test coverage around mouse activation in the tools that use `element.*` events
* make `MoveCanvas` react to middle mouse button

Interestingly our existing behavior to "prevent clicks" is not needed when dragging and dropping using the middle mouse button (tested in Firefox and Chromium). I had to make the existing fix somewhat more specific to only catch left mouse button interactions (https://github.com/bpmn-io/diagram-js/commit/0d1c964eebd4c8ffdc090ce3d472605b35396a43).

This introduces a _breaking change_: Previously we'd only pipe left mouse button clicks to components, now we pipe both left (and middle) mouse buttons to interested parties. Components must themselves distinguish the two, see: https://github.com/bpmn-io/diagram-js/pull/509/commits/752adf5848f6aa0ba6edeed1957b02014bfdc80a.

----

_A screen cast showing the feature in action in bpmn-js._

![capture gMAk8t_optimized](https://user-images.githubusercontent.com/58601/101943442-5be4b280-3beb-11eb-91a3-a6d554c3f81c.gif)
