### PR TITLE
Activate tools immediately using last good known mouse event

### DIFF
--- a/lib/features/global-connect/GlobalConnect.js
+++ b/lib/features/global-connect/GlobalConnect.js
@@ -11,15 +11,18 @@ var MARKER_OK = 'connect-ok',
  * @param {Canvas} canvas
  * @param {ToolManager} toolManager
  * @param {Rules} rules
+ * @param {Mouse} mouse
  */
 export default function GlobalConnect(
     eventBus, dragging, connect,
-    canvas, toolManager, rules) {
+    canvas, toolManager, rules,
+    mouse) {
 
   var self = this;
 
   this._dragging = dragging;
   this._rules = rules;
+  this._mouse = mouse;
 
   toolManager.registerTool('global-connect', {
     tool: 'global-connect',
@@ -85,14 +88,16 @@ GlobalConnect.$inject = [
   'connect',
   'canvas',
   'toolManager',
-  'rules'
+  'rules',
+  'mouse'
 ];
 
 /**
  * Initiates tool activity.
  */
-GlobalConnect.prototype.start = function(event) {
+GlobalConnect.prototype.start = function(event, autoActivate) {
   this._dragging.init(event, 'global-connect', {
+    autoActivate: autoActivate,
     trapClick: false,
     data: {
       context: {}
@@ -101,11 +106,14 @@ GlobalConnect.prototype.start = function(event) {
 };
 
 GlobalConnect.prototype.toggle = function() {
+
   if (this.isActive()) {
-    this._dragging.cancel();
-  } else {
-    this.start();
+    return this._dragging.cancel();
   }
+
+  var mouseEvent = this._mouse.getLastMoveEvent();
+
+  return this.start(mouseEvent, !!mouseEvent);
 };
 
 GlobalConnect.prototype.isActive = function() {

--- a/lib/features/global-connect/index.js
+++ b/lib/features/global-connect/index.js
@@ -2,6 +2,7 @@ import ConnectModule from '../connect';
 import RulesModule from '../rules';
 import DraggingModule from '../dragging';
 import ToolManagerModule from '../tool-manager';
+import MouseModule from '../mouse';
 
 import GlobalConnect from './GlobalConnect';
 
@@ -10,7 +11,8 @@ export default {
     ConnectModule,
     RulesModule,
     DraggingModule,
-    ToolManagerModule
+    ToolManagerModule,
+    MouseModule
   ],
   globalConnect: [ 'type', GlobalConnect ]
 };

--- a/lib/features/hand-tool/HandTool.js
+++ b/lib/features/hand-tool/HandTool.js
@@ -23,11 +23,11 @@ export default function HandTool(
 
   eventBus.on('element.mousedown', HIGH_PRIORITY, function(event) {
     if (hasPrimaryModifier(event)) {
-      this.activateMove(event.originalEvent, true);
+      self.activateMove(event.originalEvent, true);
 
       return false;
     }
-  }, this);
+  });
 
   keyboard && keyboard.addListener(HIGH_PRIORITY, function(e) {
     if (!isSpace(e.keyEvent) || self.isActive()) {
@@ -57,10 +57,10 @@ export default function HandTool(
     }
 
     eventBus.once('hand.ended', function() {
-      this.activateMove(event.originalEvent, { reactivate: true });
-    }, this);
+      self.activateMove(event.originalEvent, { reactivate: true });
+    });
 
-  }, this);
+  });
 
   eventBus.on('hand.move.move', function(event) {
     var scale = canvas.viewbox().scale;
@@ -79,13 +79,13 @@ export default function HandTool(
     if (!hasPrimaryModifier(event) && reactivate) {
 
       eventBus.once('hand.move.ended', function(event) {
-        this.activateHand(event.originalEvent, true, true);
-      }, this);
+        self.activateHand(event.originalEvent, true, true);
+      });
 
     }
 
     return false;
-  }, this);
+  });
 
 }
 

--- a/lib/features/hand-tool/HandTool.js
+++ b/lib/features/hand-tool/HandTool.js
@@ -6,8 +6,12 @@ var HIGH_PRIORITY = 1500;
 var HAND_CURSOR = 'grab';
 
 
-export default function HandTool(eventBus, canvas, dragging, injector, toolManager) {
+export default function HandTool(
+    eventBus, canvas, dragging,
+    injector, toolManager, mouse) {
+
   this._dragging = dragging;
+  this._mouse = mouse;
 
   var self = this,
       keyboard = injector.get('keyboard', false);
@@ -19,43 +23,29 @@ export default function HandTool(eventBus, canvas, dragging, injector, toolManag
 
   eventBus.on('element.mousedown', HIGH_PRIORITY, function(event) {
     if (hasPrimaryModifier(event)) {
-      this.activateMove(event.originalEvent);
+      this.activateMove(event.originalEvent, true);
 
       return false;
     }
   }, this);
 
   keyboard && keyboard.addListener(HIGH_PRIORITY, function(e) {
-    if (!isSpace(e.keyEvent)) {
+    if (!isSpace(e.keyEvent) || self.isActive()) {
       return;
     }
 
-    if (self.isActive()) {
-      return;
-    }
+    var mouseEvent = self._mouse.getLastMoveEvent();
 
-    function activateMove(event) {
-      self.activateMove(event);
-
-      window.removeEventListener('mousemove', activateMove);
-    }
-
-    window.addEventListener('mousemove', activateMove);
-
-    function deactivateMove(e) {
-      if (!isSpace(e.keyEvent)) {
-        return;
-      }
-
-      window.removeEventListener('mousemove', activateMove);
-
-      keyboard.removeListener(deactivateMove, 'keyboard.keyup');
-
-      dragging.cancel();
-    }
-
-    keyboard.addListener(HIGH_PRIORITY, deactivateMove, 'keyboard.keyup');
+    self.activateMove(mouseEvent, !!mouseEvent);
   }, 'keyboard.keydown');
+
+  keyboard && keyboard.addListener(HIGH_PRIORITY, function(e) {
+    if (!isSpace(e.keyEvent) || !self.isActive()) {
+      return;
+    }
+
+    self.toggle();
+  }, 'keyboard.keyup');
 
   eventBus.on('hand.end', function(event) {
     var target = event.originalEvent.target;
@@ -71,7 +61,6 @@ export default function HandTool(eventBus, canvas, dragging, injector, toolManag
     }, this);
 
   }, this);
-
 
   eventBus.on('hand.move.move', function(event) {
     var scale = canvas.viewbox().scale;
@@ -105,7 +94,8 @@ HandTool.$inject = [
   'canvas',
   'dragging',
   'injector',
-  'toolManager'
+  'toolManager',
+  'mouse'
 ];
 
 
@@ -139,10 +129,12 @@ HandTool.prototype.activateHand = function(event, autoActivate, reactivate) {
 
 HandTool.prototype.toggle = function() {
   if (this.isActive()) {
-    this._dragging.cancel();
-  } else {
-    this.activateHand();
+    return this._dragging.cancel();
   }
+
+  var mouseEvent = this._mouse.getLastMoveEvent();
+
+  this.activateHand(mouseEvent, !!mouseEvent);
 };
 
 HandTool.prototype.isActive = function() {

--- a/lib/features/hand-tool/index.js
+++ b/lib/features/hand-tool/index.js
@@ -1,10 +1,12 @@
 import ToolManagerModule from '../tool-manager';
+import MouseModule from '../mouse';
 
 import HandTool from './HandTool';
 
 export default {
   __depends__: [
-    ToolManagerModule
+    ToolManagerModule,
+    MouseModule
   ],
   __init__: [ 'handTool' ],
   handTool: [ 'type', HandTool ]

--- a/lib/features/lasso-tool/LassoTool.js
+++ b/lib/features/lasso-tool/LassoTool.js
@@ -16,10 +16,12 @@ var LASSO_TOOL_CURSOR = 'crosshair';
 
 export default function LassoTool(
     eventBus, canvas, dragging,
-    elementRegistry, selection, toolManager) {
+    elementRegistry, selection, toolManager,
+    mouse) {
 
   this._selection = selection;
   this._dragging = dragging;
+  this._mouse = mouse;
 
   var self = this;
 
@@ -141,7 +143,8 @@ LassoTool.$inject = [
   'dragging',
   'elementRegistry',
   'selection',
-  'toolManager'
+  'toolManager',
+  'mouse'
 ];
 
 
@@ -156,10 +159,11 @@ LassoTool.prototype.activateLasso = function(event, autoActivate) {
   });
 };
 
-LassoTool.prototype.activateSelection = function(event) {
+LassoTool.prototype.activateSelection = function(event, autoActivate) {
 
   this._dragging.init(event, 'lasso.selection', {
     trapClick: false,
+    autoActivate: autoActivate,
     cursor: LASSO_TOOL_CURSOR,
     data: {
       context: {}
@@ -175,10 +179,12 @@ LassoTool.prototype.select = function(elements, bbox) {
 
 LassoTool.prototype.toggle = function() {
   if (this.isActive()) {
-    this._dragging.cancel();
-  } else {
-    this.activateSelection();
+    return this._dragging.cancel();
   }
+
+  var mouseEvent = this._mouse.getLastMoveEvent();
+
+  this.activateSelection(mouseEvent, !!mouseEvent);
 };
 
 LassoTool.prototype.isActive = function() {

--- a/lib/features/lasso-tool/index.js
+++ b/lib/features/lasso-tool/index.js
@@ -1,10 +1,12 @@
 import ToolManagerModule from '../tool-manager';
+import MouseModule from '../mouse';
 
 import LassoTool from './LassoTool';
 
 export default {
   __depends__: [
-    ToolManagerModule
+    ToolManagerModule,
+    MouseModule
   ],
   __init__: [ 'lassoTool' ],
   lassoTool: [ 'type', LassoTool ]

--- a/lib/features/space-tool/SpaceTool.js
+++ b/lib/features/space-tool/SpaceTool.js
@@ -54,15 +54,21 @@ var PADDING = 20;
  * @param {EventBus} eventBus
  * @param {Modeling} modeling
  * @param {Rules} rules
- * @param {toolManager} toolManager
+ * @param {ToolManager} toolManager
+ * @param {Mouse} mouse
  */
-export default function SpaceTool(canvas, dragging, eventBus, modeling, rules, toolManager) {
+export default function SpaceTool(
+    canvas, dragging, eventBus,
+    modeling, rules, toolManager,
+    mouse) {
+
   this._canvas = canvas;
   this._dragging = dragging;
   this._eventBus = eventBus;
   this._modeling = modeling;
   this._rules = rules;
   this._toolManager = toolManager;
+  this._mouse = mouse;
 
   var self = this;
 
@@ -127,7 +133,8 @@ SpaceTool.$inject = [
   'eventBus',
   'modeling',
   'rules',
-  'toolManager'
+  'toolManager',
+  'mouse'
 ];
 
 /**
@@ -285,11 +292,14 @@ SpaceTool.prototype.calculateAdjustments = function(elements, axis, delta, start
 };
 
 SpaceTool.prototype.toggle = function() {
+
   if (this.isActive()) {
-    this._dragging.cancel();
-  } else {
-    this.activateSelection();
+    return this._dragging.cancel();
   }
+
+  var mouseEvent = this._mouse.getLastMoveEvent();
+
+  this.activateSelection(mouseEvent, !!mouseEvent);
 };
 
 SpaceTool.prototype.isActive = function() {

--- a/lib/features/space-tool/index.js
+++ b/lib/features/space-tool/index.js
@@ -2,6 +2,7 @@ import DraggingModule from '../dragging';
 import RulesModule from '../rules';
 import ToolManagerModule from '../tool-manager';
 import PreviewSupportModule from '../preview-support';
+import MouseModule from '../mouse';
 
 import SpaceTool from './SpaceTool';
 import SpaceToolPreview from './SpaceToolPreview';
@@ -12,7 +13,8 @@ export default {
     DraggingModule,
     RulesModule,
     ToolManagerModule,
-    PreviewSupportModule
+    PreviewSupportModule,
+    MouseModule
   ],
   spaceTool: ['type', SpaceTool ],
   spaceToolPreview: ['type', SpaceToolPreview ]

--- a/lib/features/tool-manager/ToolManager.js
+++ b/lib/features/tool-manager/ToolManager.js
@@ -83,7 +83,6 @@ ToolManager.prototype.bindEvents = function(name, events) {
   });
 
   eventBus.on(eventsToRegister, LOW_PRIORITY, function(event) {
-    var originalEvent = event.originalEvent;
 
     // We defer the de-activation of the tool to the .activate phase,
     // so we're able to check if we want to toggle off the current
@@ -92,10 +91,27 @@ ToolManager.prototype.bindEvents = function(name, events) {
       return;
     }
 
-    if (originalEvent && domClosest(originalEvent.target, '.group[data-group="tools"]')) {
+    if (isPaletteClick(event)) {
       return;
     }
 
     this.setActive(null);
   }, this);
+
 };
+
+
+// helpers ///////////////
+
+/**
+ * Check if a given event is a palette click event.
+ *
+ * @param {EventBus.Event} event
+ *
+ * @return {boolean}
+ */
+function isPaletteClick(event) {
+  var target = event.originalEvent && event.originalEvent.target;
+
+  return target && domClosest(target, '.group[data-group="tools"]');
+}

--- a/test/spec/features/global-connect/GlobalConnectSpec.js
+++ b/test/spec/features/global-connect/GlobalConnectSpec.js
@@ -47,50 +47,74 @@ describe('features/global-connect-tool', function() {
   }));
 
 
-  it('should start connect if allowed', inject(function(eventBus, globalConnect, dragging) {
+  describe('#toggle', function() {
 
-    // given
-    var shape = shapeAbleToStartConnection;
-    var connectSpy = sinon.spy(function(event) {
-      expect(event.context).to.eql({
-        start: shape,
-        connectionStart: { x: 150, y: 130 }
+    it('should activate and deactivate', inject(function(globalConnect) {
+
+      // given
+      globalConnect.toggle();
+
+      // assume
+      expect(globalConnect.isActive()).to.be.true;
+
+      // when
+      globalConnect.toggle();
+
+      // then
+      expect(globalConnect.isActive()).to.be.falsy;
+    }));
+
+  });
+
+
+  describe('behavior', function() {
+
+    it('should start connect if allowed', inject(function(eventBus, globalConnect, dragging) {
+
+      // given
+      var shape = shapeAbleToStartConnection;
+      var connectSpy = sinon.spy(function(event) {
+        expect(event.context).to.eql({
+          start: shape,
+          connectionStart: { x: 150, y: 130 }
+        });
       });
-    });
 
-    eventBus.once('connect.init', connectSpy);
+      eventBus.once('connect.init', connectSpy);
 
-    // when
-    globalConnect.start(canvasEvent({ x: 0, y: 0 }));
+      // when
+      globalConnect.start(canvasEvent({ x: 0, y: 0 }));
 
-    dragging.move(canvasEvent({ x: 150, y: 130 }));
-    dragging.hover(canvasEvent({ x: 150, y: 130 }, { element: shape }));
-    dragging.end(canvasEvent({ x: 0, y: 0 }));
+      dragging.move(canvasEvent({ x: 150, y: 130 }));
+      dragging.hover(canvasEvent({ x: 150, y: 130 }, { element: shape }));
+      dragging.end(canvasEvent({ x: 0, y: 0 }));
 
-    eventBus.fire('element.out', canvasEvent({ x: 99, y: 99 }, { element: shape }));
+      eventBus.fire('element.out', canvasEvent({ x: 99, y: 99 }, { element: shape }));
 
-    // then
-    expect(connectSpy).to.have.been.called;
-  }));
+      // then
+      expect(connectSpy).to.have.been.called;
+    }));
 
 
-  it('should NOT start connect if rejected', inject(function(eventBus, globalConnect, dragging) {
+    it('should NOT start connect if rejected', inject(function(eventBus, globalConnect, dragging) {
 
-    // given
-    var shape = shapeUnableToStartConnection;
-    var connectSpy = sinon.spy();
+      // given
+      var shape = shapeUnableToStartConnection;
+      var connectSpy = sinon.spy();
 
-    eventBus.once('connect.init', connectSpy);
+      eventBus.once('connect.init', connectSpy);
 
-    // when
-    globalConnect.start(canvasEvent({ x: 0, y: 0 }));
-    dragging.hover(canvasEvent({ x: 150, y: 150 }, { element: shape }));
-    dragging.end(canvasEvent({ x: 0, y: 0 }));
+      // when
+      globalConnect.start(canvasEvent({ x: 0, y: 0 }));
+      dragging.hover(canvasEvent({ x: 150, y: 150 }, { element: shape }));
+      dragging.end(canvasEvent({ x: 0, y: 0 }));
 
-    eventBus.fire('element.out', canvasEvent({ x: 99, y: 99 }, { element: shape }));
+      eventBus.fire('element.out', canvasEvent({ x: 99, y: 99 }, { element: shape }));
 
-    // then
-    expect(connectSpy).to.not.have.been.called;
-  }));
+      // then
+      expect(connectSpy).to.not.have.been.called;
+    }));
+
+  });
 
 });

--- a/test/spec/features/hand-tool/HandToolSpec.js
+++ b/test/spec/features/hand-tool/HandToolSpec.js
@@ -49,7 +49,27 @@ describe('features/hand-tool', function() {
   }));
 
 
-  describe('general', function() {
+  describe('#toggle', function() {
+
+    it('should activate and deactivate', inject(function(handTool) {
+
+      // given
+      handTool.toggle();
+
+      // assume
+      expect(handTool.isActive()).to.be.true;
+
+      // when
+      handTool.toggle();
+
+      // then
+      expect(handTool.isActive()).to.be.falsy;
+    }));
+
+  });
+
+
+  describe('behavior', function() {
 
     it('should not move element', inject(function(handTool, dragging) {
 

--- a/test/spec/features/lasso-tool/LassoToolSpec.js
+++ b/test/spec/features/lasso-tool/LassoToolSpec.js
@@ -58,6 +58,26 @@ describe('features/lasso-tool', function() {
   }));
 
 
+  describe('#toggle', function() {
+
+    it('should activate and deactivate', inject(function(lassoTool) {
+
+      // given
+      lassoTool.toggle();
+
+      // assume
+      expect(lassoTool.isActive()).to.be.true;
+
+      // when
+      lassoTool.toggle();
+
+      // then
+      expect(lassoTool.isActive()).to.be.falsy;
+    }));
+
+  });
+
+
   describe('#select', function() {
 
     it('should select elements in bbox', inject(function(lassoTool, selection) {

--- a/test/spec/features/space-tool/SpaceToolSpec.js
+++ b/test/spec/features/space-tool/SpaceToolSpec.js
@@ -28,6 +28,34 @@ var spy = sinon.spy;
 
 describe('features/space-tool', function() {
 
+  describe('#toggle', function() {
+
+    beforeEach(bootstrapDiagram({
+      modules: [
+        modelingModule,
+        spaceToolModule
+      ]
+    }));
+
+
+    it('should activate and deactivate', inject(function(spaceTool) {
+
+      // given
+      spaceTool.toggle();
+
+      // assume
+      expect(spaceTool.isActive()).to.be.true;
+
+      // when
+      spaceTool.toggle();
+
+      // then
+      expect(spaceTool.isActive()).to.be.falsy;
+    }));
+
+  });
+
+
   describe('create/remove space', function() {
 
     beforeEach(bootstrapDiagram({


### PR DESCRIPTION
A long standing UX issue in our toolkit is the fact that tool activation (hand tool, lasso tool, space tool, global connect tool) via keyboard shortcuts is wonky. Due to the fact that a mouse event is missing during keyboard activation actual visual feedback is only displayed after the first mouse move interaction.

A couple of related bugs have been filed in the past regarding this: https://github.com/bpmn-io/diagram-js/issues/136, https://github.com/bpmn-io/bpmn-js/issues/584, https://github.com/camunda/camunda-modeler/issues/664, https://github.com/camunda/camunda-modeler/issues/1229.

Since the rework of copy and paste (and the introduction of two-step copy and paste) we have the means to fix this issue: Automatically activate the tools using the last mouse position recorded by our `mouse` component.

This PR implements the described behavior for all tools.

---

#### Screen cast showing the improved behavior in action in bpmn-js

![capture KDFcD6_optimized](https://user-images.githubusercontent.com/58601/102273216-47bdef80-3f22-11eb-9c6a-d5532b08b158.gif)

---

Closes https://github.com/bpmn-io/diagram-js/issues/136