### PR TITLE
Revert bendpoint preview quick fix

### DIFF
--- a/lib/features/bendpoints/BendpointMovePreview.js
+++ b/lib/features/bendpoints/BendpointMovePreview.js
@@ -108,12 +108,6 @@ export default function BendpointMovePreview(bendpointMove, injector, eventBus, 
         hints = context.hints || {},
         drawPreviewHints = {};
 
-    // do nothing when hovering non-diagram
-    // element, i.e. the palette
-    if (!hover) {
-      return;
-    }
-
     if (connectionPreview) {
       if (hints.connectionStart) {
         drawPreviewHints.connectionStart = hints.connectionStart;
@@ -122,6 +116,7 @@ export default function BendpointMovePreview(bendpointMove, injector, eventBus, 
       if (hints.connectionEnd) {
         drawPreviewHints.connectionEnd = hints.connectionEnd;
       }
+
 
       if (type === RECONNECT_START) {
         if (isReverse(context)) {

--- a/test/spec/features/bendpoints/BendpointsMoveSpec.js
+++ b/test/spec/features/bendpoints/BendpointsMoveSpec.js
@@ -745,14 +745,10 @@ describe('features/bendpoints - move', function() {
 
 
     it('should filter out redundant waypoints from preview',
-      inject(function(bendpointMove, dragging, canvas) {
+      inject(function(bendpointMove, dragging) {
 
         // when
         bendpointMove.start(canvasEvent({ x: 500, y: 250 }), connection, 1);
-        dragging.hover({
-          element: shape2,
-          gfx: canvas.getGraphics(shape2)
-        });
         dragging.move(canvasEvent({ x: 550, y: 250 }));
 
         var ctx = dragging.context(),


### PR DESCRIPTION
This reverts https://github.com/bpmn-io/diagram-js/commit/66b77964ba692dc7da5454d7855a9043de88f89b. The fix looked simple enough but actually introduced some [unwanted side-effects](https://travis-ci.com/github/bpmn-io/bpmn-js/builds/208964265).

Specifically we do rely on `connectionPreview` to attach `getConnection` to the bendpoint move context in our tests, both in diagram-js as well as bpmn-js. 

While this is shaky in the first place (relying on an internal just like that) I'd rather revert the fix now and investigate an appropriate solution in an orderly manner.

I'll investigate if I can find a more appropriate solution.