### PR TITLE
fix(palette): use native collection iterator

### DIFF
--- a/lib/features/palette/Palette.js
+++ b/lib/features/palette/Palette.js
@@ -375,7 +375,7 @@ Palette.prototype.updateToolHighlight = function(name) {
 
   toolsContainer = this._toolsContainer;
 
-  forEach(toolsContainer.children, function(tool) {
+  toolsContainer.children.forEach(function(tool) {
     var actionName = tool.getAttribute('data-action');
 
     if (!actionName) {

--- a/test/spec/features/palette/PaletteSpec.js
+++ b/test/spec/features/palette/PaletteSpec.js
@@ -524,6 +524,67 @@ describe('features/palette', function() {
 
   });
 
+
+  describe('tools highlighting', function() {
+
+    var entries = {
+      'entryA': {
+        group: 'tools',
+        action: function() {}
+      },
+      'entryB': {
+        group: 'tools',
+        action: function() {}
+      },
+      'entryC': {
+        action: function() {}
+      }
+    };
+
+    beforeEach(bootstrapDiagram({
+      modules: [ paletteModule ]
+    }));
+
+    beforeEach(inject(function(palette) {
+
+      palette.registerProvider(new Provider(entries));
+    }));
+
+
+    it('should update tool highlight', inject(function(eventBus, palette) {
+
+      // given
+      var toolName = 'entryA';
+
+      // when
+      eventBus.fire('tool-manager.update', { tool: toolName });
+
+      var entryNode = getEntryNode(toolName, palette._container);
+
+      // then
+      expect(is(entryNode, 'highlighted-entry')).to.be.true;
+
+    }));
+
+
+    it('should unset tool highlight', inject(function(eventBus, palette) {
+
+      // given
+      var toolName = 'entryA';
+
+      // when
+      eventBus.fire('tool-manager.update', { tool: toolName });
+      eventBus.fire('tool-manager.update', { tool: 'other' });
+
+      var entryNode = getEntryNode(toolName, palette._container);
+
+      // then
+      expect(is(entryNode, 'highlighted-entry')).to.be.false;
+
+    }));
+
+  });
+
 });
 
 
@@ -547,4 +608,8 @@ function expectPaletteCls(marker, expectedActive) {
 
     expect(isActive).to.eql(expectedActive);
   });
+}
+
+function getEntryNode(action, container) {
+  return domQuery('.entry[data-action="' + action + '"]', container);
 }


### PR DESCRIPTION
* min-dash#forEach will handle `HTMLCollection` as objects
* in phantom-js, it also iterates over the `length` property of the children collection
--> crashes on the next line when trying to access HTML attributes from a non-DOM element

<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

Related to bpmn-io/bpmn-js#1402

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/diagram-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
