### PR TITLE
chore: make ChromeHeadless our default test browser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: node_js
 node_js: '10'
 
 script:
-  - COVERAGE=1 npm run all
+  - TEST_BROWSERS=ChromeHeadless,PhantomJS COVERAGE=1 npm run all
   - npx codecov

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,7 +4,7 @@ var coverage = process.env.COVERAGE;
 
 // configures browsers to run test against
 // any of [ 'ChromeHeadless', 'Chrome', 'Firefox', 'IE', 'PhantomJS' ]
-var browsers = (process.env.TEST_BROWSERS || 'PhantomJS').split(',');
+var browsers = (process.env.TEST_BROWSERS || 'ChromeHeadless').split(',');
 
 // use puppeteer provided Chrome for testing
 process.env.CHROME_BIN = require('puppeteer').executablePath();

--- a/test/spec/features/global-connect/GlobalConnectSpec.js
+++ b/test/spec/features/global-connect/GlobalConnectSpec.js
@@ -61,7 +61,7 @@ describe('features/global-connect-tool', function() {
       globalConnect.toggle();
 
       // then
-      expect(globalConnect.isActive()).to.be.falsy;
+      expect(globalConnect.isActive()).not.to.be.ok;
     }));
 
   });

--- a/test/spec/features/hand-tool/HandToolSpec.js
+++ b/test/spec/features/hand-tool/HandToolSpec.js
@@ -63,7 +63,7 @@ describe('features/hand-tool', function() {
       handTool.toggle();
 
       // then
-      expect(handTool.isActive()).to.be.falsy;
+      expect(handTool.isActive()).not.to.be.ok;
     }));
 
   });
@@ -140,7 +140,7 @@ describe('features/hand-tool', function() {
       });
 
       // then
-      expect(handTool.isActive()).to.be.falsy;
+      expect(handTool.isActive()).not.to.be.ok;
     }));
 
 
@@ -157,7 +157,7 @@ describe('features/hand-tool', function() {
       });
 
       // then
-      expect(handTool.isActive()).to.be.falsy;
+      expect(handTool.isActive()).not.to.be.ok;
     }));
 
 

--- a/test/spec/features/lasso-tool/LassoToolSpec.js
+++ b/test/spec/features/lasso-tool/LassoToolSpec.js
@@ -83,7 +83,7 @@ describe('features/lasso-tool', function() {
       lassoTool.toggle();
 
       // then
-      expect(lassoTool.isActive()).to.be.falsy;
+      expect(lassoTool.isActive()).not.to.be.ok;
     }));
 
   });
@@ -166,7 +166,7 @@ describe('features/lasso-tool', function() {
       eventBus.fire(mouseDownEvent(rootShape, { button: 1, shiftKey: true }));
 
       // then
-      expect(lassoTool.isActive()).to.be.falsy;
+      expect(lassoTool.isActive()).not.to.be.ok;
     }));
 
   });

--- a/test/spec/features/space-tool/SpaceToolSpec.js
+++ b/test/spec/features/space-tool/SpaceToolSpec.js
@@ -50,7 +50,7 @@ describe('features/space-tool', function() {
       spaceTool.toggle();
 
       // then
-      expect(spaceTool.isActive()).to.be.falsy;
+      expect(spaceTool.isActive()).not.to.be.ok;
     }));
 
   });


### PR DESCRIPTION
Run against both, ChromeHeadless and PhantomJS in CI to have each one covered.