### PR TITLE
test(palette): add test cases for tool highlighting

### DIFF
--- a/test/spec/features/palette/PaletteSpec.js
+++ b/test/spec/features/palette/PaletteSpec.js
@@ -524,6 +524,67 @@ describe('features/palette', function() {
 
   });
 
+
+  describe('tools highlighting', function() {
+
+    var entries = {
+      'entryA': {
+        group: 'tools',
+        action: function() {}
+      },
+      'entryB': {
+        group: 'tools',
+        action: function() {}
+      },
+      'entryC': {
+        action: function() {}
+      }
+    };
+
+    beforeEach(bootstrapDiagram({
+      modules: [ paletteModule ]
+    }));
+
+    beforeEach(inject(function(palette) {
+
+      palette.registerProvider(new Provider(entries));
+    }));
+
+
+    (isPhantomJS() ? it.skip : it)('should update tool highlight', inject(function(eventBus, palette) {
+
+      // given
+      var toolName = 'entryA';
+
+      // when
+      eventBus.fire('tool-manager.update', { tool: toolName });
+
+      var entryNode = getEntryNode(toolName, palette._container);
+
+      // then
+      expect(is(entryNode, 'highlighted-entry')).to.be.true;
+
+    }));
+
+
+    (isPhantomJS() ? it.skip : it)('should unset tool highlight', inject(function(eventBus, palette) {
+
+      // given
+      var toolName = 'entryA';
+
+      // when
+      eventBus.fire('tool-manager.update', { tool: toolName });
+      eventBus.fire('tool-manager.update', { tool: 'other' });
+
+      var entryNode = getEntryNode(toolName, palette._container);
+
+      // then
+      expect(is(entryNode, 'highlighted-entry')).to.be.false;
+
+    }));
+
+  });
+
 });
 
 
@@ -547,4 +608,12 @@ function expectPaletteCls(marker, expectedActive) {
 
     expect(isActive).to.eql(expectedActive);
   });
+}
+
+function getEntryNode(action, container) {
+  return domQuery('.entry[data-action="' + action + '"]', container);
+}
+
+function isPhantomJS() {
+  return /PhantomJS/.test(window.navigator.userAgent);
 }


### PR DESCRIPTION
Adds test cases for the tool highlighting on the palette. Skips the tests for phantom-js.

Rationale (cf. https://github.com/bpmn-io/diagram-js/pull/515#issue-550333421)


> * min-dash#forEach will handle HTMLCollection as objects
> * in phantom-js, it also iterates over the length property of the children collection
> --> crashes on the next line when trying to access HTML attributes from a non-DOM element