### PR TITLE
test: do not double add test-container class

### DIFF
--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -9,7 +9,8 @@ import diagramCSS from '../assets/diagram-js.css';
 insertCSS('diagram-js.css', diagramCSS);
 
 insertCSS('diagram-js-testing.css',
-  '.test-container .test-content-container { height: 500px; max-height: 100%; }'
+  'body .test-container { height: auto }' +
+  'body .test-content-container { height: 90vh; }'
 );
 
 

--- a/test/helper/index.js
+++ b/test/helper/index.js
@@ -40,7 +40,6 @@ export function bootstrapDiagram(options, locals) {
 
     var testContainer;
 
-
     // Make sure the test container is an optional dependency and we fall back
     // to an empty <div> if it does not exist.
     //
@@ -50,11 +49,10 @@ export function bootstrapDiagram(options, locals) {
       testContainer = TestContainer.get(this);
     } catch (e) {
       testContainer = document.createElement('div');
+      testContainer.classList.add('test-content-container');
+
       document.body.appendChild(testContainer);
     }
-
-    testContainer.classList.add('test-container');
-
 
     var _options = options,
         _locals = locals;

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -942,8 +942,8 @@ describe('Canvas', function() {
         var newScroll = canvas.scroll();
 
         // then
-        expect(newScroll.x).to.equal(viewbox.x + 50);
-        expect(newScroll.y).to.equal(viewbox.y + 100);
+        expect(newScroll.x).to.be.closeTo(viewbox.x + 50, .001);
+        expect(newScroll.y).to.be.closeTo(viewbox.y + 100, .001);
 
       }));
 

--- a/test/spec/features/bendpoints/BendpointsSpec.js
+++ b/test/spec/features/bendpoints/BendpointsSpec.js
@@ -535,7 +535,7 @@ describe('features/bendpoints', function() {
 
         // then
         expect(newBounds).to.not.eql(oldBounds);
-        expect(newBounds.left).to.equal(525);
+        expect(newBounds.left).to.be.closeTo(525, 2);
       }
     ));
 
@@ -571,7 +571,7 @@ describe('features/bendpoints', function() {
 
         // then
         expect(newBounds).to.not.eql(oldBounds);
-        expect(newBounds.left).to.equal(453);
+        expect(newBounds.left).to.be.closeTo(453, 2);
       }
     ));
 

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -1066,7 +1066,7 @@ describe('features/popup', function() {
         height: menu.scrollHeight
       };
 
-      expect(menu.offsetLeft).to.equal(2000 - menuDimensions.width);
+      expect(menu.offsetLeft).to.be.closeTo(2000 - menuDimensions.width, 2);
     }));
 
   });


### PR DESCRIPTION
This improves the test container markup we generate (and expose) via our helpers https://github.com/bpmn-io/diagram-js/commit/36983303bb6ea10fd76f4a5e4d05c37be35090cf.

Also, https://github.com/bpmn-io/diagram-js/commit/9b3d28166f0f6ba7be9a10a2fd6ea3c6e7558de3 our tests run stable against all target browsers currently tested headless.