### PR TITLE
chore: fully migrate to GitHub actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
-name: ci
+name: CI
 on: [ push, pull_request ]
 jobs:
-  build:
+  Build:
     runs-on: ubuntu-latest
 
     steps:
@@ -23,6 +23,6 @@ jobs:
     - name: Install dependencies
       run: npm ci
     - name: Build
-      run: COVERAGE=1 npm run all
+      run: TEST_BROWSERS=ChromeHeadless,PhantomJS COVERAGE=1 npm run all
     - name: Upload coverage
       run: npx codecov

--- a/.npmignore
+++ b/.npmignore
@@ -6,5 +6,4 @@ test/*
 !test/matchers
 .eslintignore
 .eslintrc
-.travis.yml
 karma.conf.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js: '10'
-
-script:
-  - TEST_BROWSERS=ChromeHeadless,PhantomJS COVERAGE=1 npm run all
-  - npx codecov

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # diagram-js
 
-[![Build Status](https://travis-ci.com/bpmn-io/diagram-js.svg?branch=develop)](https://travis-ci.com/bpmn-io/diagram-js)
+[![Build Status](https://img.shields.io/github/workflow/status/bpmn-io/diagram-js/CI)](https://github.com/bpmn-io/diagram-js/actions?query=workflow%3ACI)
 
 A toolbox for displaying and modifying diagrams on the web.
 


### PR DESCRIPTION
Run test suite against all browsers on GitHub actions.

Rename ci -> CI to match upper case build action naming conventions.

Remove Travis CI :skull: 