### PR TITLE
Correct stroke colors

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -146,12 +146,12 @@ svg.new-parent {
 
 .drop-not-ok,
 .connect-not-ok {
-  stroke: var(--shape-attach-allowed-stroke-color) !important;
   cursor: not-allowed;
 }
 
 .djs-element.attach-ok .djs-visual > :nth-child(1) {
   stroke-width: 5px !important;
+  stroke: var(--shape-attach-allowed-stroke-color) !important;
 }
 
 .djs-frame.connect-not-ok .djs-visual > :nth-child(1),


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

We accidentally placed the stroke color in the wrong place while we updated the color palette (cf. https://github.com/bpmn-io/diagram-js/issues/476, [these lines of code](https://github.com/bpmn-io/diagram-js/commit/c206608bcef920e0770393fb3b3641fe52322072#diff-682322eea3bdf2a0256e2e37fb5a12ac5c9744f340488edcb053b4dbe8f57137R149-R155)).

**Before**
![Kapture 2021-01-20 at 10 40 11](https://user-images.githubusercontent.com/9433996/105156509-3ad98080-5b0c-11eb-88c1-4a433383fe8a.gif)

**After**

![Kapture 2021-01-20 at 10 40 51](https://user-images.githubusercontent.com/9433996/105156519-3f9e3480-5b0c-11eb-96da-fb4c0354e277.gif)


Related to https://github.com/bpmn-io/bpmn-js/issues/1380

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/diagram-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
