### PR TITLE
Add trigger to commandStack.changed event

### DIFF
--- a/lib/command/CommandStack.js
+++ b/lib/command/CommandStack.js
@@ -107,11 +107,14 @@ export default function CommandStack(eventBus, injector) {
    * Current active commandStack execution
    *
    * @type {Object}
-   * @property {string|undefined} trigger Indicates whether this was an execution, undo, redo, or clear
+   * @property {Object[]} actions
+   * @property {Object[]} dirty
+   * @property { 'undo' | 'redo' | 'clear' | 'execute' | null } trigger the cause of the current excecution
    */
   this._currentExecution = {
     actions: [],
-    dirty: []
+    dirty: [],
+    trigger: null
   };
 
 
@@ -142,8 +145,8 @@ CommandStack.prototype.execute = function(command, context) {
     throw new Error('command required');
   }
 
-  var execution = this._currentExecution;
-  execution.trigger || (execution.trigger = 'execute');
+  this._currentExecution.trigger = 'execute';
+
   var action = { command: command, context: context };
 
   this._pushAction(action);
@@ -202,7 +205,6 @@ CommandStack.prototype.canExecute = function(command, context) {
 CommandStack.prototype.clear = function(emit) {
   this._stack.length = 0;
   this._stackIdx = -1;
-  delete this._currentExecution.trigger;
 
   if (emit !== false) {
     this._fire('changed', { trigger: 'clear' });
@@ -215,11 +217,11 @@ CommandStack.prototype.clear = function(emit) {
  */
 CommandStack.prototype.undo = function() {
   var action = this._getUndoAction(),
-      execution = this._currentExecution,
       next;
 
-  execution.trigger = 'undo';
   if (action) {
+    this._currentExecution.trigger = 'undo';
+
     this._pushAction(action);
 
     while (action) {
@@ -243,13 +245,12 @@ CommandStack.prototype.undo = function() {
  */
 CommandStack.prototype.redo = function() {
   var action = this._getRedoAction(),
-      execution = this._currentExecution,
       next;
 
   if (action) {
-    this._pushAction(action);
+    this._currentExecution.trigger = 'redo';
 
-    execution.trigger = 'redo';
+    this._pushAction(action);
 
     while (action) {
       this._internalExecute(action, true);
@@ -467,7 +468,8 @@ CommandStack.prototype._popAction = function() {
     dirty.length = 0;
 
     this._fire('changed', { trigger: trigger });
-    delete execution.trigger;
+
+    execution.trigger = null;
   }
 };
 

--- a/lib/command/CommandStack.js
+++ b/lib/command/CommandStack.js
@@ -107,6 +107,7 @@ export default function CommandStack(eventBus, injector) {
    * Current active commandStack execution
    *
    * @type {Object}
+   * @property {string|undefined} trigger Indicates whether this was an execution, undo, redo, or clear
    */
   this._currentExecution = {
     actions: [],
@@ -141,6 +142,8 @@ CommandStack.prototype.execute = function(command, context) {
     throw new Error('command required');
   }
 
+  var execution = this._currentExecution;
+  execution.trigger || (execution.trigger = 'execute');
   var action = { command: command, context: context };
 
   this._pushAction(action);
@@ -199,9 +202,10 @@ CommandStack.prototype.canExecute = function(command, context) {
 CommandStack.prototype.clear = function(emit) {
   this._stack.length = 0;
   this._stackIdx = -1;
+  delete this._currentExecution.trigger;
 
   if (emit !== false) {
-    this._fire('changed');
+    this._fire('changed', { trigger: 'clear' });
   }
 };
 
@@ -211,8 +215,10 @@ CommandStack.prototype.clear = function(emit) {
  */
 CommandStack.prototype.undo = function() {
   var action = this._getUndoAction(),
+      execution = this._currentExecution,
       next;
 
+  execution.trigger = 'undo';
   if (action) {
     this._pushAction(action);
 
@@ -237,10 +243,13 @@ CommandStack.prototype.undo = function() {
  */
 CommandStack.prototype.redo = function() {
   var action = this._getRedoAction(),
+      execution = this._currentExecution,
       next;
 
   if (action) {
     this._pushAction(action);
+
+    execution.trigger = 'redo';
 
     while (action) {
       this._internalExecute(action, true);
@@ -446,6 +455,7 @@ CommandStack.prototype._pushAction = function(action) {
 
 CommandStack.prototype._popAction = function() {
   var execution = this._currentExecution,
+      trigger = execution.trigger,
       actions = execution.actions,
       dirty = execution.dirty;
 
@@ -456,7 +466,8 @@ CommandStack.prototype._popAction = function() {
 
     dirty.length = 0;
 
-    this._fire('changed');
+    this._fire('changed', { trigger: trigger });
+    delete execution.trigger;
   }
 };
 

--- a/test/spec/command/CommandStackSpec.js
+++ b/test/spec/command/CommandStackSpec.js
@@ -876,87 +876,86 @@ describe('command/CommandStack', function() {
 
   });
 
-  describe('change-event', function() {
 
-    var testSetup = function(eventBus, commandStack) {
-      var eventData = {};
+  describe('trigger', function() {
 
+    beforeEach(inject(function(commandStack) {
       commandStack.registerHandler('complex-command', ComplexCommand);
       commandStack.registerHandler('pre-command', PreCommand);
       commandStack.registerHandler('post-command', PostCommand);
-      eventBus.on('commandStack.changed', function(event) {
-        eventData.changeEvent = event.trigger;
+    }));
+
+
+    it('should indicate <execute>', inject(function(eventBus, commandStack) {
+
+      // given
+      var changedSpy = sinon.spy(function(event) {
+        expect(event.trigger).to.eql('execute');
       });
 
-      return eventData;
-    };
+      // when
+      eventBus.on('commandStack.changed', changedSpy);
 
-    describe('should indicate details about a change', function() {
+      commandStack.execute('complex-command', { element: { trace: [] } });
 
-      it('with trigger <execute>', inject(function(eventBus, commandStack) {
+      // then
+      expect(changedSpy).to.have.been.calledOnce;
+    }));
 
-        // given
-        var eventData = testSetup(eventBus, commandStack);
 
-        // when
-        commandStack.execute('complex-command', { element: { trace: [] } });
+    it('with trigger <undo>', inject(function(eventBus, commandStack) {
 
-        // then
-        var changeEvent = eventData.changeEvent;
+      // given
+      var changedSpy = sinon.spy(function(event) {
+        expect(event.trigger).to.eql('undo');
+      });
 
-        expect(changeEvent).to.equal('execute');
+      commandStack.execute('complex-command', { element: { trace: [] } });
 
-      }));
+      // when
+      eventBus.on('commandStack.changed', changedSpy);
 
-      it('with trigger <undo>', inject(function(eventBus, commandStack) {
+      commandStack.undo();
 
-        // given
-        var eventData = testSetup(eventBus, commandStack);
+      // then
+      expect(changedSpy).to.have.been.calledOnce;
+    }));
 
-        // when
-        commandStack.execute('complex-command', { element: { trace: [] } });
-        commandStack.undo();
 
-        // then
-        var changeEvent = eventData.changeEvent;
+    it('with trigger <redo>', inject(function(eventBus, commandStack) {
 
-        expect(changeEvent).to.equal('undo');
+      // given
+      var changedSpy = sinon.spy(function(event) {
+        expect(event.trigger).to.eql('redo');
+      });
 
-      }));
+      commandStack.execute('complex-command', { element: { trace: [] } });
+      commandStack.undo();
 
-      it('with trigger <redo>', inject(function(eventBus, commandStack) {
+      // when
+      eventBus.on('commandStack.changed', changedSpy);
+      commandStack.redo();
 
-        // given
-        var eventData = testSetup(eventBus, commandStack);
+      // then
+      expect(changedSpy).to.have.been.calledOnce;
+    }));
 
-        // when
-        commandStack.execute('complex-command', { element: { trace: [] } });
-        commandStack.undo();
-        commandStack.redo();
 
-        // then
-        var changeEvent = eventData.changeEvent;
+    it('with trigger <clear>', inject(function(eventBus, commandStack) {
 
-        expect(changeEvent).to.equal('redo');
+      // given
+      var changedSpy = sinon.spy(function(event) {
+        expect(event.trigger).to.eql('clear');
+      });
 
-      }));
+      // when
+      eventBus.on('commandStack.changed', changedSpy);
 
-      it('with trigger <clear>', inject(function(eventBus, commandStack) {
+      commandStack.clear();
 
-        // given
-        var eventData = testSetup(eventBus, commandStack);
-
-        // when
-        commandStack.clear();
-
-        // then
-        var changeEvent = eventData.changeEvent;
-
-        expect(changeEvent).to.equal('clear');
-
-      }));
-
-    });
+      // then
+      expect(changedSpy).to.have.been.calledOnce;
+    }));
 
   });
 

--- a/test/spec/command/CommandStackSpec.js
+++ b/test/spec/command/CommandStackSpec.js
@@ -876,4 +876,88 @@ describe('command/CommandStack', function() {
 
   });
 
+  describe('change-event', function() {
+
+    var testSetup = function(eventBus, commandStack) {
+      var eventData = {};
+
+      commandStack.registerHandler('complex-command', ComplexCommand);
+      commandStack.registerHandler('pre-command', PreCommand);
+      commandStack.registerHandler('post-command', PostCommand);
+      eventBus.on('commandStack.changed', function(event) {
+        eventData.changeEvent = event.trigger;
+      });
+
+      return eventData;
+    };
+
+    describe('should indicate details about a change', function() {
+
+      it('with trigger <execute>', inject(function(eventBus, commandStack) {
+
+        // given
+        var eventData = testSetup(eventBus, commandStack);
+
+        // when
+        commandStack.execute('complex-command', { element: { trace: [] } });
+
+        // then
+        var changeEvent = eventData.changeEvent;
+
+        expect(changeEvent).to.equal('execute');
+
+      }));
+
+      it('with trigger <undo>', inject(function(eventBus, commandStack) {
+
+        // given
+        var eventData = testSetup(eventBus, commandStack);
+
+        // when
+        commandStack.execute('complex-command', { element: { trace: [] } });
+        commandStack.undo();
+
+        // then
+        var changeEvent = eventData.changeEvent;
+
+        expect(changeEvent).to.equal('undo');
+
+      }));
+
+      it('with trigger <redo>', inject(function(eventBus, commandStack) {
+
+        // given
+        var eventData = testSetup(eventBus, commandStack);
+
+        // when
+        commandStack.execute('complex-command', { element: { trace: [] } });
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        var changeEvent = eventData.changeEvent;
+
+        expect(changeEvent).to.equal('redo');
+
+      }));
+
+      it('with trigger <clear>', inject(function(eventBus, commandStack) {
+
+        // given
+        var eventData = testSetup(eventBus, commandStack);
+
+        // when
+        commandStack.clear();
+
+        // then
+        var changeEvent = eventData.changeEvent;
+
+        expect(changeEvent).to.equal('clear');
+
+      }));
+
+    });
+
+  });
+
 });


### PR DESCRIPTION
This allows consumers to understand the root cause of a command execution, may it be `execute`, `undo`, `redo` or `clear`.