### PR TITLE
Make Modeler Fully Visible by Default

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -45,7 +45,11 @@ function ensurePx(number) {
  */
 function createContainer(options) {
 
-  options = assign({}, { width: '100%', height: '100%' }, options);
+  options = assign({}, {
+    width: '100%',
+    height: '100%',
+    position: 'absolute'
+  }, options);
 
   var container = options.container || document.body;
 


### PR DESCRIPTION
__Which issue does this PR address?__

Users of bpmn-js and dmn-js keep running into an issue where the modeler is not fully visible.

![image](https://user-images.githubusercontent.com/7633572/105684444-42769c00-5ef5-11eb-9a0a-2273e13e62d5.png)

This issue can be fixed by adding `position: absolute` to the container. This PR adds this position by default.

Related to bpmn-io/bpmn-js#1412