### PR TITLE
feat(command): attach command to previous undo/redo context

### DIFF
--- a/lib/command/CommandStack.js
+++ b/lib/command/CommandStack.js
@@ -139,15 +139,20 @@ CommandStack.$inject = [ 'eventBus', 'injector' ];
  *
  * @param {string} command the command to execute
  * @param {Object} context the environment to execute the command in
+ * @param {boolean} [append=false] if true, append this execution to the existing undo step
  */
-CommandStack.prototype.execute = function(command, context) {
+CommandStack.prototype.execute = function(command, context, compact) {
   if (!command) {
     throw new Error('command required');
   }
 
   this._currentExecution.trigger = 'execute';
 
-  var action = { command: command, context: context };
+  var action = {
+    id: compact && this.canUndo() ? this._getUndoAction().id : null,
+    command: command,
+    context: context,
+  };
 
   this._pushAction(action);
   this._internalExecute(action);

--- a/test/spec/command/CommandStackSpec.js
+++ b/test/spec/command/CommandStackSpec.js
@@ -362,6 +362,49 @@ describe('command/CommandStack', function() {
   });
 
 
+  describe('#execute compact', function() {
+
+    it('should undo in single step', inject(function(commandStack) {
+
+      // given
+      commandStack.registerHandler('simple-command', SimpleCommand);
+
+      var context = { element: { trace: [] } };
+
+      commandStack.execute('simple-command', context, true);
+      commandStack.execute('simple-command', context, true);
+
+      // when
+      commandStack.undo();
+
+      // then
+      expect(commandStack._stack.length).to.equal(2);
+      expect(commandStack._stackIdx).to.equal(-1);
+    }));
+
+
+    it('should redo in single step', inject(function(commandStack) {
+
+      // given
+      commandStack.registerHandler('simple-command', SimpleCommand);
+
+      var context = { element: { trace: [] } };
+
+      commandStack.execute('simple-command', context, true);
+      commandStack.execute('simple-command', context, true);
+
+      // when
+      commandStack.undo();
+      commandStack.redo();
+
+      // then
+      expect(commandStack._stack.length).to.equal(2);
+      expect(commandStack._stackIdx).to.equal(1);
+    }));
+
+  });
+
+
   describe('command context', function() {
 
     it('should pass command context to handler', inject(function(commandStack) {


### PR DESCRIPTION
This adds the ability to attach commands to the previous undo/redo context.

By doing so I can execute things invisible to the user (from the undo/redo) perspective.

```javascript
// given
commandStack.registerHandler('simple-command', SimpleCommand);

var context = { element: { trace: [] } };

commandStack.execute('simple-command', context, true);
commandStack.execute('simple-command', context, true);

// when
commandStack.undo();

// then
// both commands are undone
```