### PR TITLE
fix(preview): fix preview for reversed flows

### DIFF
--- a/lib/features/connect/ConnectPreview.js
+++ b/lib/features/connect/ConnectPreview.js
@@ -23,29 +23,25 @@ export default function ConnectPreview(injector, eventBus, canvas) {
         source = context.source,
         start = context.start,
         startPosition = context.startPosition,
-        connectionStart = context.connectionStart,
-        connectionEnd = context.connectionEnd,
-        target = context.target;
+        target = context.target,
+        connectionStart = context.connectionStart || startPosition,
+        connectionEnd = context.connectionEnd || {
+          x: event.x,
+          y: event.y
+        },
+        previewStart = connectionStart,
+        previewEnd = connectionEnd;
 
-    if (!connectionStart) {
-      connectionStart = isReverse(context) ? {
-        x: event.x,
-        y: event.y
-      } : startPosition;
-    }
-
-    if (!connectionEnd) {
-      connectionEnd = isReverse(context) ? startPosition : {
-        x: event.x,
-        y: event.y
-      };
+    if (isReverse(context)) {
+      previewStart = connectionEnd;
+      previewEnd = connectionStart;
     }
 
     connectionPreview.drawPreview(context, canConnect, {
       source: source || start,
       target: target || hover,
-      connectionStart: connectionStart,
-      connectionEnd: connectionEnd
+      connectionStart: previewStart,
+      connectionEnd: previewEnd
     });
   });
 

--- a/test/spec/features/connect/ConnectSpec.js
+++ b/test/spec/features/connect/ConnectSpec.js
@@ -353,6 +353,34 @@ describe('features/connect', function() {
       expect(ctx.data.context.connectionPreviewGfx.parentNode).to.exist;
     }));
 
+
+    it('should display preview if connection is reversed', inject(function(connect, dragging, eventBus, connectionPreview) {
+
+      // given
+      var connectionPreviewSpy = sinon.spy(connectionPreview, 'drawPreview');
+
+      eventBus.on('commandStack.connection.create.canExecute', 9999, function(event) {
+        return event.context.source.id !== 's1';
+      });
+
+      // when
+      connect.start(canvasEvent({ x: 250, y: 250 }), shape1);
+      dragging.move(canvasEvent({ x: 250, y: 250 }));
+
+      dragging.hover(canvasEvent({ x: 500, y: 100 }, { element: shape2 }));
+      dragging.move(canvasEvent({ x: 500, y: 100 }));
+
+      var ctx = dragging.context();
+
+      // then
+      expect(ctx.data.context.connectionPreviewGfx.parentNode).to.exist;
+      expect(connectionPreviewSpy.lastCall.args[2].connectionStart.x).to.equal(500);
+      expect(connectionPreviewSpy.lastCall.args[2].connectionStart.y).to.equal(100);
+
+      expect(connectionPreviewSpy.lastCall.args[2].connectionEnd.x).to.equal(250);
+      expect(connectionPreviewSpy.lastCall.args[2].connectionEnd.y).to.equal(250);
+    }));
+
   });
 
 });


### PR DESCRIPTION
Fixes preview when connecting the start event with a message flow. Example of broken behavior:
![114861724-f2b9b980-9ded-11eb-9d7c-4e25e5613a99](https://user-images.githubusercontent.com/21984219/116527835-645c3200-a8db-11eb-84a7-28c8863ccfc1.gif)

fixed:
![recording (9)](https://user-images.githubusercontent.com/21984219/116527853-6920e600-a8db-11eb-874a-f08fa5090823.gif)


related to https://github.com/bpmn-io/bpmn-js/issues/1431

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
