### PR TITLE
Use package json files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-.github
-coverage
-test/*
-!test/util
-!test/helper
-!test/matchers
-.eslintignore
-.eslintrc
-karma.conf.js

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "diagram-js",
   "version": "7.3.0",
   "description": "A toolbox for displaying and modifying diagrams on the web",
+  "main": "index.js",
   "scripts": {
     "all": "run-s lint test",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,15 @@
   "version": "7.3.0",
   "description": "A toolbox for displaying and modifying diagrams on the web",
   "main": "index.js",
+  "files": [
+    ".babelrc",
+    "lib",
+    "assets",
+    "test/util",
+    "test/helper",
+    "test/matchers",
+    "!.eslintrc"
+  ],
   "scripts": {
     "all": "run-s lint test",
     "lint": "eslint .",


### PR DESCRIPTION
This introduces `package.json#files` field as a replacement to `.npmignore`.

Benefits:
* you don't need to update any files when you add random files to repo
* you don't need to exclude coverage
* you don't need to exclude CI configuration

How to test this:
```sh
git checkout develop
npm pack --dry-run 2> before
git checkout use-package-json-files
npm pack --dry-run 2> after
diff -y before after | less
```
