### PR TITLE
fix dblclick event

### DIFF
--- a/lib/features/interaction-events/InteractionEvents.js
+++ b/lib/features/interaction-events/InteractionEvents.js
@@ -166,11 +166,33 @@ export default function InteractionEvents(eventBus, elementRegistry, styles) {
   var ELEMENT_SELECTOR = 'svg, .djs-element';
 
   // event handling ///////
-
+  
+  var isClicking = false,
+      delay = 300, 
+      timeout = null;
+  
   function registerEvent(node, event, localEvent, ignoredFilter) {
 
     var handler = handlers[localEvent] = function(event) {
-      fire(localEvent, event);
+      
+      if(localEvent === 'element.click') {
+
+        isClicking = true;
+        timeout && clearTimeout(timeout);
+        timeout = setTimeout(function() {
+          isClicking = false;
+          fire(localEvent, event);
+        }, delay)
+        
+      } else if(localEvent === 'element.dblclick') {
+        
+        isClicking && timeout && clearTimeout(timeout);
+        fire(localEvent, event);
+        isClicking = false;
+        
+      } else {
+        fire(localEvent, event);
+      }
     };
 
     if (ignoredFilter) {


### PR DESCRIPTION
fire dblclick event should not fire click handler.

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
