### PR TITLE
fix(keyboard): only ignore non-modifier events on inputs

### DIFF
--- a/lib/features/keyboard/Keyboard.js
+++ b/lib/features/keyboard/Keyboard.js
@@ -19,7 +19,6 @@ var KEYDOWN_EVENT = 'keyboard.keydown',
 
 var DEFAULT_PRIORITY = 1000;
 
-
 /**
  * A keyboard abstraction that may be activated and
  * deactivated by users at will, consuming key events
@@ -89,10 +88,9 @@ Keyboard.prototype._keyupHandler = function(event) {
 };
 
 Keyboard.prototype._keyHandler = function(event, type) {
-  var target = event.target,
-      eventBusResult;
+  var eventBusResult;
 
-  if (isInput(target)) {
+  if (this._isEventIgnored(event)) {
     return;
   }
 
@@ -105,6 +103,10 @@ Keyboard.prototype._keyHandler = function(event, type) {
   if (eventBusResult) {
     event.preventDefault();
   }
+};
+
+Keyboard.prototype._isEventIgnored = function(event) {
+  return isInput(event.target) && !isCmd(event);
 };
 
 Keyboard.prototype.bind = function(node) {

--- a/test/spec/features/keyboard/KeyboardSpec.js
+++ b/test/spec/features/keyboard/KeyboardSpec.js
@@ -135,7 +135,7 @@ describe('features/keyboard', function() {
     }));
 
 
-    it('should not fire event if target is input field', inject(
+    it('should not fire non-modifier event if target is input field', inject(
       function(keyboard, eventBus) {
 
         // given
@@ -146,9 +146,29 @@ describe('features/keyboard', function() {
 
         // when
         keyboard._keyHandler({ key: TEST_KEY, target: inputField });
+        keyboard._keyHandler({ key: TEST_KEY, shiftKey: true, target: inputField });
 
         // then
         expect(eventBusSpy).to.not.be.called;
+      })
+    );
+
+
+    it('should fire modifier event if target is input field', inject(
+      function(keyboard, eventBus) {
+
+        // given
+        var eventBusSpy = sinon.spy(eventBus, 'fire');
+
+        var inputField = document.createElement('input');
+        testDiv.appendChild(inputField);
+
+        // when
+        keyboard._keyHandler({ key: TEST_KEY, metaKey: true, target: inputField });
+        keyboard._keyHandler({ key: TEST_KEY, ctrlKey: true, target: inputField });
+
+        // then
+        expect(eventBusSpy).to.have.been.calledTwice;
       })
     );
 


### PR DESCRIPTION
This allows us to handle undo, redo and other CTRL/CMD guarded events in a way expected by users.

Related to https://github.com/bpmn-io/form-js/pull/153#issuecomment-906737249 and likely the safest, most intuitive default behavior.