### PR TITLE
Added new external example object diagram modeler to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Some libraries / applications built on top of diagram-js:
 * [Node Sequencer](https://github.com/philippfromme/node-sequencer) - A Node-Based Sequencer for the Web ([Demo](https://philippfromme.github.io/node-sequencer-demo/))
 * [chor-js](https://github.com/bptlab/chor-js) - A BPMN 2.0 Choreography diagram viewer and editor
 * [postit-js](https://github.com/pinussilvestrus/postit-js) - Create Post-it boards on a canvas editor ([Demo](https://postit-js-demo.netlify.app/))
+* [Object Diagram Modeler](https://github.com/timKraeuter/object-diagram-modeler) - An object diagram viewer and editor ([Demo](https://timkraeuter.com/object-diagram-modeler/))
 
 ## Resources
 


### PR DESCRIPTION
I implemented an object diagram viewer and editor based on diagram-js.
I would like it to be included in the external examples.