### PR TITLE
fix(canvas): remove all planes on `diagram.clear`

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -239,6 +239,10 @@ Canvas.prototype._clear = function() {
     }
   });
 
+  // remove all planes
+  this._activePlane = null;
+  this._planes = {};
+
   // force recomputation of view box
   delete this._cachedViewbox;
 };

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -135,6 +135,23 @@ describe('Canvas', function() {
       expect(canvas._cachedViewbox).not.to.exist;
     }));
 
+
+    it('should remove planes', inject(function(canvas, elementRegistry) {
+
+      // given
+      canvas.createPlane('a');
+      canvas.createPlane('b');
+      canvas.setActivePlane('b');
+
+      // when
+      canvas._clear();
+
+      // then
+      expect(canvas.getPlane('a')).to.be.undefined;
+      expect(canvas.getPlane('b')).to.be.undefined;
+      expect(canvas.getActivePlane().name).to.eql('base');
+    }));
+
   });
 
 
@@ -2108,6 +2125,19 @@ describe('Canvas', function() {
 
         // then
         expect(plane).to.eq(originalPlane);
+      }));
+
+
+      it('should not return a non-existent plane', inject(function(canvas) {
+
+        // given
+        canvas.createPlane('a');
+
+        // when
+        var plane = canvas.getPlane('b');
+
+        // then
+        expect(plane).to.be.undefined;
       }));
 
     });

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -147,8 +147,8 @@ describe('Canvas', function() {
       canvas._clear();
 
       // then
-      expect(canvas.getPlane('a')).to.be.undefined;
-      expect(canvas.getPlane('b')).to.be.undefined;
+      expect(canvas.getPlane('a')).not.to.exist;
+      expect(canvas.getPlane('b')).not.to.exist;
       expect(canvas.getActivePlane().name).to.eql('base');
     }));
 
@@ -2137,7 +2137,7 @@ describe('Canvas', function() {
         var plane = canvas.getPlane('b');
 
         // then
-        expect(plane).to.be.undefined;
+        expect(plane).not.to.exist;
       }));
 
     });


### PR DESCRIPTION
**What is the problem?**
- on `diagram.clear` the planes are not cleared
- Therefore, re-import of the same diagram is not possible if it tries to create the same plane again (related to [BPMNImporter PR](https://github.com/bpmn-io/bpmn-js/blob/fe1005bea417c3fb4a9ea235cffc995ffa7fdc90/lib/import/BpmnImporter.js#L115-L120))
- Root elements are set to `null` on existing diagrams, but not populated with an implicit root by default (related to https://github.com/bpmn-io/dmn-js-properties-panel/issues/23)

**Fix**
on `diagram.clear`:
- Remove all planes 
- Reset active Plane