### PR TITLE
feat(keyboard): specify which keys are handled

### DIFF
--- a/lib/features/keyboard/Keyboard.js
+++ b/lib/features/keyboard/Keyboard.js
@@ -3,6 +3,7 @@ import {
 } from 'min-dash';
 
 import {
+  closest as domClosest,
   event as domEvent,
   matches as domMatches
 } from 'min-dom';
@@ -16,6 +17,8 @@ import {
 
 var KEYDOWN_EVENT = 'keyboard.keydown',
     KEYUP_EVENT = 'keyboard.keyup';
+
+var HANDLE_MODIFIER_ATTRIBUTE = 'input-handle-modified-keys';
 
 var DEFAULT_PRIORITY = 1000;
 
@@ -106,7 +109,26 @@ Keyboard.prototype._keyHandler = function(event, type) {
 };
 
 Keyboard.prototype._isEventIgnored = function(event) {
-  return isInput(event.target) && !isCmd(event);
+  return isInput(event.target) && this._isModifiedKeyIgnored(event);
+};
+
+Keyboard.prototype._isModifiedKeyIgnored = function(event) {
+  if (!isCmd(event)) {
+    return true;
+  }
+
+  var allowedModifiers = this._getAllowedModifiers(event.target);
+  return !allowedModifiers.includes(event.key);
+};
+
+Keyboard.prototype._getAllowedModifiers = function(element) {
+  var modifierContainer = domClosest(element, '[' + HANDLE_MODIFIER_ATTRIBUTE + ']', true);
+
+  if (!modifierContainer || (this._node && !this._node.contains(modifierContainer))) {
+    return [];
+  }
+
+  return modifierContainer.getAttribute(HANDLE_MODIFIER_ATTRIBUTE).split(',');
 };
 
 Keyboard.prototype.bind = function(node) {


### PR DESCRIPTION
Allow inputs to define which modifier keys should be handled by the application vs. the browser.

This reverts #564 and replaces it with a fine-grained utility to opt-into processing of input-triggered keyboard events.

To react to a `CTRL/CMD+` shortcut the input triggering it must be wrapped in a `[input-handle-modified-keys]` directive like so:

```html
<div input-handle-modified-keys="z,y">
  <input></input>
</div>
```


Check https://github.com/bpmn-io/bpmn-properties-panel/pull/135 for usage in the properties panel.

---

Related to bpmn-io/bpmn-js#1493