### PR TITLE
style: adjust search input

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -751,6 +751,7 @@ marker.djs-dragger tspan {
   width: 100%;
   padding: 6px 10px;
   border: 1px solid var(--search-input-border-color);
+  box-sizing: border-box;
 }
 
 .djs-search-input input:focus {


### PR DESCRIPTION
This ensures the `.djs-search-input` always uses the full width of the border box.

_before_
![image](https://user-images.githubusercontent.com/9433996/139864333-f3973c10-d008-40c0-b953-cbd16752dfca.png)

_after_
![image](https://user-images.githubusercontent.com/9433996/139864275-627e3b0b-cd5f-4f91-aa95-4f27f86b3888.png)

