### PR TITLE
fix(core): ensure base layer has index 0

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -95,6 +95,10 @@ function createGroup(parent, cls, childIndex) {
 var BASE_LAYER = 'base';
 var HIDDEN_MARKER = 'djs-element-hidden';
 
+// render plane contents behind utility layers
+var PLANE_LAYER_INDEX = 0;
+var UTILITY_LAYER_INDEX = 1;
+
 
 var REQUIRED_MODEL_ATTRS = {
   shape: [ 'x', 'y', 'width', 'height' ],
@@ -255,7 +259,7 @@ Canvas.prototype._clear = function() {
  * @returns {SVGElement}
  */
 Canvas.prototype.getDefaultLayer = function() {
-  return this.getLayer(BASE_LAYER);
+  return this.getLayer(BASE_LAYER, PLANE_LAYER_INDEX);
 };
 
 /**
@@ -304,8 +308,8 @@ Canvas.prototype.getLayer = function(name, index) {
  */
 Canvas.prototype._createLayer = function(name, index) {
 
-  if (!index) {
-    index = 0;
+  if (typeof index === 'undefined') {
+    index = UTILITY_LAYER_INDEX;
   }
 
   var childIndex = reduce(this._layers, function(childIndex, layer) {
@@ -364,7 +368,7 @@ Canvas.prototype.createPlane = function(name, rootElement) {
     };
   }
 
-  var svgLayer = this.getLayer(name);
+  var svgLayer = this.getLayer(name, PLANE_LAYER_INDEX);
   svgClasses(svgLayer).add(HIDDEN_MARKER);
 
   var plane = this._planes[name] = {

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -1990,8 +1990,8 @@ describe('Canvas', function() {
       it('gets default layer', inject(function(canvas) {
 
         // when
+        var defaultLayer = canvas.getDefaultLayer();
         var activeLayer = canvas.getActiveLayer();
-        var baseLayer = canvas.getLayer('base');
 
         // then
         expectLayersOrder(canvas._viewport, [
@@ -1999,7 +1999,7 @@ describe('Canvas', function() {
         ]);
 
         expect(activeLayer).to.exist;
-        expect(activeLayer).to.eql(baseLayer);
+        expect(activeLayer).to.eql(defaultLayer);
 
       }));
 
@@ -2030,7 +2030,7 @@ describe('Canvas', function() {
 
       // when
       canvas.getDefaultLayer();
-      canvas.getLayer('foo', -10);
+      canvas.getLayer('foo', -1);
 
       // then
       expectLayersOrder(canvas._viewport, [
@@ -2044,7 +2044,7 @@ describe('Canvas', function() {
 
       // when
       canvas.getDefaultLayer();
-      canvas.getLayer('foo', 10);
+      canvas.getLayer('foo', 1);
 
       // then
       expectLayersOrder(canvas._viewport, [
@@ -2054,16 +2054,18 @@ describe('Canvas', function() {
     }));
 
 
-    it('layer without specified index gets default index', inject(function(canvas) {
+    it('layer without specified index is above default layer', inject(function(canvas) {
 
       // when
-      canvas.getDefaultLayer();
       canvas.getLayer('foo');
+      canvas.getDefaultLayer();
+      canvas.getLayer('bar');
 
       // then
       expectLayersOrder(canvas._viewport, [
         'base',
-        'foo'
+        'foo',
+        'bar'
       ]);
     }));
 
@@ -2261,6 +2263,54 @@ describe('Canvas', function() {
         // then
         expect(plane.rootElement).to.exist;
         expect(plane.rootElement.isImplicit).to.be.true;
+      }));
+
+
+      it('should create layer below utility planes', inject(function(canvas) {
+
+        // given
+        canvas.getLayer('foo');
+
+        // when
+        canvas.createPlane('A');
+        canvas.createPlane('B');
+
+        canvas.getLayer('bar');
+
+        // then
+        expectLayersOrder(canvas._viewport, [
+          'A',
+          'B',
+          'foo',
+          'bar'
+        ]);
+      }));
+
+
+      it('should create layer with default priority', inject(function(canvas) {
+
+        // when
+        canvas.createPlane('A');
+        canvas.getDefaultLayer();
+        canvas.createPlane('B');
+
+        // then
+        expectLayersOrder(canvas._viewport, [
+          'A',
+          'base',
+          'B'
+        ]);
+      }));
+
+
+      it('should reuse default layer', inject(function(canvas) {
+
+        // when
+        var layer = canvas.getDefaultLayer();
+        var plane = canvas.getActivePlane();
+
+        // then
+        expect(plane.layer).to.eq(layer);
       }));
 
     });


### PR DESCRIPTION
This reverts commit 058731b3ae12f9ae278a6d906b62b8bedd44270f and uses a positive index to place resize layers infront of rendered content

**Why we need to revert:**
- This commit broke the [integration tests](https://github.com/bpmn-io/bpmn-js-integration/actions/runs/1425366500) because we did not consider to set the plane index when only accessing layers (not planes)
- It broke the API that [negative indexes are rendered below](https://github.com/bpmn-io/diagram-js/blob/9b77f3a250b88d712e1056e8a0d738f57143228b/test/spec/core/CanvasSpec.js#L2029) and [positive indexes are rendered above](https://github.com/bpmn-io/diagram-js/blob/9b77f3a250b88d712e1056e8a0d738f57143228b/test/spec/core/CanvasSpec.js#L2043) the base layer

Instead of lowering the index of planes, we should use the existing API to ensure our utility planes are rendered with priority
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
