### PR TITLE
Add ability to provide context pads for multiple elements

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -550,7 +550,7 @@ marker.djs-dragger tspan {
 }
 
 .djs-popup-body .entry {
-  padding: 4px 10px 4px 5px;
+  padding: 4px 5px;
 }
 
 .djs-popup-body .entry > span {

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -367,7 +367,7 @@ marker.djs-dragger tspan {
   stroke-linecap: round;
   stroke-width: 1px;
   pointer-events: none;
-  shape-rendering: crispEdges;
+  shape-rendering: geometricPrecision;
   stroke-dasharray: 5, 5;
 }
 
@@ -814,4 +814,11 @@ marker.djs-dragger tspan {
 .djs-element-hidden .djs-outline,
 .djs-label-hidden .djs-label {
   display: none !important;
+}
+
+.djs-selection-outline {
+  shape-rendering: geometricPrecision;
+  stroke: var(--element-selected-outline-stroke-color);
+  stroke-dasharray: 1,1;
+  stroke-width: 1px;
 }

--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -1,9 +1,11 @@
 import {
   assign,
-  isFunction,
-  isArray,
+  every,
   forEach,
-  isDefined
+  isArray,
+  isDefined,
+  isFunction,
+  some
 } from 'min-dash';
 
 import {
@@ -15,15 +17,23 @@ import {
   domify as domify
 } from 'min-dom';
 
+import { getBBox } from '../../util/Elements';
+
 var entrySelector = '.entry';
 
 var DEFAULT_PRIORITY = 1000;
+var CONTEXT_PAD_PADDING = 12;
 
+
+/**
+ * @typedef {djs.model.Base|djs.model.Base[]} ContextPadTarget
+ */
 
 /**
  * A context pad that displays element specific, contextual actions next
  * to a diagram element.
  *
+ * @param {Canvas} canvas
  * @param {Object} config
  * @param {boolean|Object} [config.scale={ min: 1.0, max: 1.5 }]
  * @param {number} [config.scale.min]
@@ -31,8 +41,9 @@ var DEFAULT_PRIORITY = 1000;
  * @param {EventBus} eventBus
  * @param {Overlays} overlays
  */
-export default function ContextPad(config, eventBus, overlays) {
+export default function ContextPad(canvas, config, eventBus, overlays) {
 
+  this._canvas = canvas;
   this._eventBus = eventBus;
   this._overlays = overlays;
 
@@ -42,10 +53,6 @@ export default function ContextPad(config, eventBus, overlays) {
   };
 
   this._overlaysConfig = {
-    position: {
-      right: -9,
-      top: -6
-    },
     scale: scale
   };
 
@@ -55,6 +62,7 @@ export default function ContextPad(config, eventBus, overlays) {
 }
 
 ContextPad.$inject = [
+  'canvas',
   'config.contextPad',
   'eventBus',
   'overlays'
@@ -62,68 +70,78 @@ ContextPad.$inject = [
 
 
 /**
- * Registers events needed for interaction with other components
+ * Registers events needed for interaction with other components.
  */
 ContextPad.prototype._init = function() {
-
-  var eventBus = this._eventBus;
-
   var self = this;
 
-  eventBus.on('selection.changed', function(e) {
+  this._eventBus.on('selection.changed', function(event) {
 
-    var selection = e.newSelection;
+    var selection = event.newSelection;
 
-    if (selection.length === 1) {
-      self.open(selection[0]);
+    var target = selection.length
+      ? selection.length === 1
+        ? selection[0]
+        : selection
+      : null;
+
+    if (target) {
+      self.open(target, true);
     } else {
       self.close();
     }
   });
 
-  eventBus.on('elements.delete', function(event) {
-    var elements = event.elements;
-
-    forEach(elements, function(e) {
-      if (self.isOpen(e)) {
-        self.close();
-      }
-    });
-  });
-
-  eventBus.on('element.changed', function(event) {
-    var element = event.element,
+  this._eventBus.on('elements.changed', function(event) {
+    var elements = event.elements,
         current = self._current;
 
-    // force reopen if element for which we are currently opened changed
-    if (current && current.element === element) {
-      self.open(element, true);
+    if (!current) {
+      return;
+    }
+
+    var currentTarget = current.target;
+
+    var currentChanged = some(
+      isArray(currentTarget) ? currentTarget : [ currentTarget ],
+      function(element) {
+        return includes(elements, element);
+      }
+    );
+
+    // re-open if elements in current selection changed
+    if (currentChanged) {
+      self.open(currentTarget, true);
     }
   });
 };
 
 
 /**
- * Register a provider with the context pad
+ * Register context pad provider.
  *
  * @param  {number} [priority=1000]
  * @param  {ContextPadProvider} provider
  *
  * @example
  * const contextPadProvider = {
-  *   getContextPadEntries: function(element) {
-  *     return function(entries) {
-  *       return {
-  *         ...entries,
-  *         'entry-1': {
-  *           label: 'My Entry',
-  *           action: function() { alert("I have been clicked!"); }
-  *         }
-  *       };
-  *     }
-  *   }
-  * };
-  *
+ *   getContextPadEntries: function(element) {
+ *     return function(entries) {
+ *       return {
+ *         ...entries,
+ *         'entry-1': {
+ *           label: 'My Entry',
+ *           action: function() { alert("I have been clicked!"); }
+ *         }
+ *       };
+ *     }
+ *   },
+ *
+ *   getMultiElementContextPadEntries: function(elements) {
+ *     // ...
+ *   }
+ * };
+ *
  * contextPad.registerProvider(800, contextPadProvider);
  */
 ContextPad.prototype.registerProvider = function(priority, provider) {
@@ -139,21 +157,30 @@ ContextPad.prototype.registerProvider = function(priority, provider) {
 
 
 /**
- * Returns the context pad entries for a given element
+ * Get context pad entries for given elements.
  *
- * @param {djs.element.Base} element
+ * @param {ContextPadTarget} target
  *
- * @return {Array<ContextPadEntryDescriptor>} list of entries
+ * @return {ContextPadEntryDescriptor[]} list of entries
  */
-ContextPad.prototype.getEntries = function(element) {
+ContextPad.prototype.getEntries = function(target) {
   var providers = this._getProviders();
+
+  var provideFn = isArray(target)
+    ? 'getMultiElementContextPadEntries'
+    : 'getContextPadEntries';
 
   var entries = {};
 
   // loop through all providers and their entries.
   // group entries by id so that overriding an entry is possible
   forEach(providers, function(provider) {
-    var entriesOrUpdater = provider.getContextPadEntries(element);
+
+    if (!isFunction(provider[provideFn])) {
+      return;
+    }
+
+    var entriesOrUpdater = provider[provideFn](target);
 
     if (isFunction(entriesOrUpdater)) {
       entries = entriesOrUpdater(entries);
@@ -169,7 +196,7 @@ ContextPad.prototype.getEntries = function(element) {
 
 
 /**
- * Trigger an action available on the opened context pad
+ * Trigger context pad action.
  *
  * @param  {string} action
  * @param  {Event} event
@@ -177,7 +204,7 @@ ContextPad.prototype.getEntries = function(element) {
  */
 ContextPad.prototype.trigger = function(action, event, autoActivate) {
 
-  var element = this._current.element,
+  var target = this._current.target,
       entries = this._current.entries,
       entry,
       handler,
@@ -196,11 +223,11 @@ ContextPad.prototype.trigger = function(action, event, autoActivate) {
   // simple action (via callback function)
   if (isFunction(handler)) {
     if (action === 'click') {
-      return handler(originalEvent, element, autoActivate);
+      return handler(originalEvent, target, autoActivate);
     }
   } else {
     if (handler[action]) {
-      return handler[action](originalEvent, element, autoActivate);
+      return handler[action](originalEvent, target, autoActivate);
     }
   }
 
@@ -210,18 +237,19 @@ ContextPad.prototype.trigger = function(action, event, autoActivate) {
 
 
 /**
- * Open the context pad for the given element
+ * Open the context pad for given elements.
  *
- * @param {djs.model.Base} element
- * @param {boolean} force if true, force reopening the context pad
+ * @param {ContextPadTarget} target
+ * @param {boolean} [force=false] - Force re-opening context pad.
  */
-ContextPad.prototype.open = function(element, force) {
-  if (!force && this.isOpen(element)) {
+ContextPad.prototype.open = function(target, force) {
+  if (!force && this.isOpen(target)) {
     return;
   }
 
   this.close();
-  this._updateAndOpen(element);
+
+  this._updateAndOpen(target);
 };
 
 ContextPad.prototype._getProviders = function() {
@@ -236,10 +264,13 @@ ContextPad.prototype._getProviders = function() {
   return event.providers;
 };
 
-ContextPad.prototype._updateAndOpen = function(element) {
 
-  var entries = this.getEntries(element),
-      pad = this.getPad(element),
+/**
+ * @param {ContextPadTarget} target
+ */
+ContextPad.prototype._updateAndOpen = function(target) {
+  var entries = this.getEntries(target),
+      pad = this.getPad(target),
       html = pad.html;
 
   forEach(entries, function(entry, id) {
@@ -273,16 +304,20 @@ ContextPad.prototype._updateAndOpen = function(element) {
   domClasses(html).add('open');
 
   this._current = {
-    element: element,
-    pad: pad,
-    entries: entries
+    target: target,
+    entries: entries,
+    pad: pad
   };
 
   this._eventBus.fire('contextPad.open', { current: this._current });
 };
 
-
-ContextPad.prototype.getPad = function(element) {
+/**
+ * @param {ContextPadTarget} target
+ *
+ * @return {Overlay}
+ */
+ContextPad.prototype.getPad = function(target) {
   if (this.isOpen()) {
     return this._current.pad;
   }
@@ -293,9 +328,11 @@ ContextPad.prototype.getPad = function(element) {
 
   var html = domify('<div class="djs-context-pad"></div>');
 
+  var position = this._getPosition(target);
+
   var overlaysConfig = assign({
     html: html
-  }, this._overlaysConfig);
+  }, this._overlaysConfig, position);
 
   domDelegate.bind(html, entrySelector, 'click', function(event) {
     self.trigger('click', event);
@@ -310,11 +347,16 @@ ContextPad.prototype.getPad = function(element) {
     event.stopPropagation();
   });
 
-  this._overlayId = overlays.add(element, 'context-pad', overlaysConfig);
+  var activeRootElement = this._canvas.getRootElement();
+
+  this._overlayId = overlays.add(activeRootElement, 'context-pad', overlaysConfig);
 
   var pad = overlays.get(this._overlayId);
 
-  this._eventBus.fire('contextPad.create', { element: element, pad: pad });
+  this._eventBus.fire('contextPad.create', {
+    target: target,
+    pad: pad
+  });
 
   return pad;
 };
@@ -338,27 +380,84 @@ ContextPad.prototype.close = function() {
 };
 
 /**
- * Check if pad is open. If element is given, will check
- * if pad is opened with given element.
+ * Check if pad is open.
  *
- * @param {Element} element
+ * If target is provided, check if it is opened
+ * for the given target (single or multiple elements).
+ *
+ * @param {ContextPadTarget} [target]
  * @return {boolean}
  */
-ContextPad.prototype.isOpen = function(element) {
-  return !!this._current && (!element ? true : this._current.element === element);
+ContextPad.prototype.isOpen = function(target) {
+  var current = this._current;
+
+  if (!current) {
+    return false;
+  }
+
+  // basic no-args is open check
+  if (!target) {
+    return true;
+  }
+
+  var currentTarget = current.target;
+
+  // strict handling of single vs. multi-selection
+  if (isArray(target) !== isArray(currentTarget)) {
+    return false;
+  }
+
+  if (isArray(target)) {
+    return (
+      target.length === currentTarget.length &&
+      every(target, function(element) {
+        return includes(currentTarget, element);
+      })
+    );
+  } else {
+    return currentTarget === target;
+  }
 };
 
 
+/**
+ * Get contex pad position.
+ *
+ * @param {ContextPadTarget} target
+ * @return {Bounds}
+ */
+ContextPad.prototype._getPosition = function(target) {
+
+  var elements = isArray(target) ? target : [ target ];
+  var bBox = getBBox(elements);
+
+  return {
+    position: {
+      left: bBox.x + bBox.width + CONTEXT_PAD_PADDING,
+      top: bBox.y - CONTEXT_PAD_PADDING / 2
+    }
+  };
+};
 
 
-// helpers //////////////////////
+// helpers //////////
 
 function addClasses(element, classNames) {
-
   var classes = domClasses(element);
 
-  var actualClassNames = isArray(classNames) ? classNames : classNames.split(/\s+/g);
-  actualClassNames.forEach(function(cls) {
+  classNames = isArray(classNames) ? classNames : classNames.split(/\s+/g);
+
+  classNames.forEach(function(cls) {
     classes.add(cls);
   });
+}
+
+/**
+ * @param {any[]} array
+ * @param {any} item
+ *
+ * @return {boolean}
+ */
+function includes(array, item) {
+  return array.indexOf(item) !== -1;
 }

--- a/lib/features/overlays/Overlays.js
+++ b/lib/features/overlays/Overlays.js
@@ -655,6 +655,12 @@ function setPosition(el, x, y) {
   assignStyle(el, { left: x + 'px', top: y + 'px' });
 }
 
+/**
+ * Set element visible
+ *
+ * @param {DOMElement} el
+ * @param {boolean} [visible=true]
+ */
 function setVisible(el, visible) {
   el.style.display = visible === false ? 'none' : '';
 }

--- a/lib/features/selection/SelectionVisuals.js
+++ b/lib/features/selection/SelectionVisuals.js
@@ -1,9 +1,22 @@
 import {
+  assign,
   forEach
 } from 'min-dash';
 
+import {
+  append as svgAppend,
+  attr as svgAttr,
+  classes as svgClasses,
+  clear as svgClear,
+  create as svgCreate
+} from 'tiny-svg';
+
+import { getBBox } from '../../util/Elements';
+
 var MARKER_HOVER = 'hover',
     MARKER_SELECTED = 'selected';
+
+var SELECTION_OUTLINE_PADDING = 6;
 
 
 /**
@@ -14,11 +27,13 @@ var MARKER_HOVER = 'hover',
  *
  * Makes elements selectable, too.
  *
- * @param {EventBus} events
- * @param {SelectionService} selection
  * @param {Canvas} canvas
+ * @param {EventBus} eventBus
  */
-export default function SelectionVisuals(events, canvas, selection, styles) {
+export default function SelectionVisuals(canvas, eventBus) {
+  this._canvas = canvas;
+
+  var self = this;
 
   this._multiSelectionBox = null;
 
@@ -30,15 +45,15 @@ export default function SelectionVisuals(events, canvas, selection, styles) {
     canvas.removeMarker(e, cls);
   }
 
-  events.on('element.hover', function(event) {
+  eventBus.on('element.hover', function(event) {
     addMarker(event.element, MARKER_HOVER);
   });
 
-  events.on('element.out', function(event) {
+  eventBus.on('element.out', function(event) {
     removeMarker(event.element, MARKER_HOVER);
   });
 
-  events.on('selection.changed', function(event) {
+  eventBus.on('selection.changed', function(event) {
 
     function deselect(s) {
       removeMarker(s, MARKER_SELECTED);
@@ -62,12 +77,45 @@ export default function SelectionVisuals(events, canvas, selection, styles) {
         select(e);
       }
     });
+
+    self._updateSelectionOutline(newSelection);
   });
 }
 
 SelectionVisuals.$inject = [
-  'eventBus',
   'canvas',
-  'selection',
-  'styles'
+  'eventBus'
 ];
+
+SelectionVisuals.prototype._updateSelectionOutline = function(selection) {
+  var layer = this._canvas.getLayer('selectionOutline');
+
+  svgClear(layer);
+
+  if (selection.length <= 1) {
+    return;
+  }
+
+  var bBox = addSelectionOutlinePadding(getBBox(selection));
+
+  var rect = svgCreate('rect');
+
+  svgAttr(rect, assign({
+    fill: 'none'
+  }, bBox));
+
+  svgClasses(rect).add('djs-selection-outline');
+
+  svgAppend(layer, rect);
+};
+
+// helpers //////////
+
+function addSelectionOutlinePadding(bBox) {
+  return {
+    x: bBox.x - SELECTION_OUTLINE_PADDING,
+    y: bBox.y - SELECTION_OUTLINE_PADDING,
+    width: bBox.width + SELECTION_OUTLINE_PADDING * 2,
+    height: bBox.height + SELECTION_OUTLINE_PADDING * 2
+  };
+}

--- a/lib/features/selection/SelectionVisuals.js
+++ b/lib/features/selection/SelectionVisuals.js
@@ -30,7 +30,7 @@ var SELECTION_OUTLINE_PADDING = 6;
  * @param {Canvas} canvas
  * @param {EventBus} eventBus
  */
-export default function SelectionVisuals(canvas, eventBus) {
+export default function SelectionVisuals(canvas, eventBus, selection) {
   this._canvas = canvas;
 
   var self = this;
@@ -80,11 +80,19 @@ export default function SelectionVisuals(canvas, eventBus) {
 
     self._updateSelectionOutline(newSelection);
   });
+
+
+  eventBus.on('element.changed', function(event) {
+    if (selection.isSelected(event.element)) {
+      self._updateSelectionOutline(selection.get());
+    }
+  });
 }
 
 SelectionVisuals.$inject = [
   'canvas',
-  'eventBus'
+  'eventBus',
+  'selection'
 ];
 
 SelectionVisuals.prototype._updateSelectionOutline = function(selection) {

--- a/lib/util/Elements.js
+++ b/lib/util/Elements.js
@@ -10,6 +10,9 @@ import {
   forEach
 } from 'min-dash';
 
+/**
+ * @typedef { {x:number, y: number, width: number, height: number} } Bounds
+ */
 
 /**
  * Get parent elements.
@@ -238,7 +241,9 @@ export function getClosure(elements, isTopLevel, closure) {
  * the array or the element primitive.
  *
  * @param {Array<djs.model.Shape>|djs.model.Shape} elements
- * @param {boolean} stopRecursion
+ * @param {boolean} [stopRecursion=false]
+ *
+ * @return {Bounds}
  */
 export function getBBox(elements, stopRecursion) {
 

--- a/test/spec/features/context-pad/ContextPadProvider.js
+++ b/test/spec/features/context-pad/ContextPadProvider.js
@@ -2,6 +2,8 @@ import imageA from './resources/a.png';
 import imageB from './resources/b.png';
 import imageC from './resources/c.png';
 
+import { every } from 'min-dash';
+
 
 export default function ContextPadProvider(contextPad) {
   contextPad.registerProvider(this);
@@ -47,6 +49,38 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
         }
       },
       'action.no-image': {
+        action: function(e) {
+          e.__handled = true;
+        }
+      }
+    };
+  }
+};
+
+
+ContextPadProvider.prototype.getMultiElementContextPadEntries = function(elements) {
+
+  function allTyped(elements, type) {
+    return every(elements, function(element) {
+      return element.type === type;
+    });
+  }
+
+  if (allTyped(elements, 'A')) {
+    return {
+      'action.a': {
+        imageUrl: imageA,
+        action: function(e) {
+          e.__handled = true;
+        }
+      }
+    };
+  }
+
+  if (allTyped(elements, 'C')) {
+    return {
+      'action.c': {
+        imageUrl: imageC,
         action: function(e) {
           e.__handled = true;
         }

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -378,7 +378,7 @@ describe('features/context-pad', function() {
       var open = sinon.spy(contextPad, 'open');
 
       // when
-      eventBus.fire('element.changed', { element: shape });
+      eventBus.fire('elements.changed', { elements: [ shape ] });
 
       // then
       expect(open).to.have.been.calledWith(shape, true);
@@ -397,7 +397,7 @@ describe('features/context-pad', function() {
       var open = sinon.spy(contextPad, 'open');
 
       // when
-      eventBus.fire('element.changed', { element: canvas.getRootElement() });
+      eventBus.fire('elements.changed', { elements: [ canvas.getRootElement() ] });
 
       // then
       expect(open).not.to.have.been.called;

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -8,7 +8,7 @@ import {
   inject
 } from 'test/TestHelper';
 
-import { assign } from 'min-dash';
+import { assign, isArray } from 'min-dash';
 
 import {
   query as domQuery,
@@ -17,6 +17,7 @@ import {
 } from 'min-dom';
 
 import contextPadModule from 'lib/features/context-pad';
+import selectionModule from 'lib/features/selection';
 
 import ContextPadProvider from './ContextPadProvider';
 
@@ -54,9 +55,17 @@ describe('features/context-pad', function() {
 
     beforeEach(bootstrapDiagram({ modules: [ contextPadModule, initPadModule ] }));
 
-
+    /**
+     * @constructor
+     *
+     * @param {any} [entriesOrUpdater]
+     */
     function Provider(entriesOrUpdater) {
       this.getContextPadEntries = function(element) {
+        return entriesOrUpdater || {};
+      };
+
+      this.getMultiElementContextPadEntries = function(element) {
         return entriesOrUpdater || {};
       };
     }
@@ -74,24 +83,63 @@ describe('features/context-pad', function() {
     }));
 
 
-    it('should query provider for entries', inject(function(contextPad) {
+    describe('should query provider for entries', function() {
 
-      // given
-      var provider = new Provider();
+      it('single element', inject(function(contextPad) {
 
-      contextPad.registerProvider(provider);
+        // given
+        var provider = {
+          getContextPadEntries: sinon.spy()
+        };
 
-      sinon.spy(provider, 'getContextPadEntries');
+        contextPad.registerProvider(provider);
 
-      // when
-      var entries = contextPad.getEntries('FOO');
+        // when
+        var entries = contextPad.getEntries('FOO');
 
-      // then
-      expect(entries).to.eql({});
+        // then
+        expect(entries).to.eql({});
 
-      // pass over providers
-      expect(provider.getContextPadEntries).to.have.been.calledWith('FOO');
-    }));
+        // pass over providers
+        expect(provider.getContextPadEntries).to.have.been.calledWith('FOO');
+      }));
+
+
+      it('multiple elements', inject(function(contextPad) {
+
+        // given
+        var provider = {
+          getMultiElementContextPadEntries: sinon.spy()
+        };
+
+        contextPad.registerProvider(provider);
+
+        // when
+        var entries = contextPad.getEntries([ 'FOO', 'BAR' ]);
+
+        // then
+        expect(entries).to.eql({});
+
+        // pass over providers
+        expect(provider.getMultiElementContextPadEntries).to.have.been.calledWith([ 'FOO', 'BAR' ]);
+      }));
+
+
+      it('missing provider API', inject(function(contextPad) {
+
+        // given
+        var provider = {};
+
+        contextPad.registerProvider(provider);
+
+        // when
+        var entries = contextPad.getEntries('FOO');
+
+        // then
+        expect(entries).to.eql({});
+      }));
+
+    });
 
 
     describe('with updater', function() {
@@ -110,7 +158,7 @@ describe('features/context-pad', function() {
         contextPad.registerProvider(updatingProvider);
 
         // when
-        var entries = contextPad.getEntries();
+        var entries = contextPad.getEntries([]);
 
         // then
         expect(entries.entryA).to.exist;
@@ -132,7 +180,7 @@ describe('features/context-pad', function() {
         contextPad.registerProvider(updatingProvider);
 
         // when
-        var entries = contextPad.getEntries();
+        var entries = contextPad.getEntries([]);
 
         // then
         expect(entries.entryA).to.exist;
@@ -154,7 +202,7 @@ describe('features/context-pad', function() {
         contextPad.registerProvider(updatingProvider);
 
         // when
-        var entries = contextPad.getEntries();
+        var entries = contextPad.getEntries([]);
 
         // then
         expect(entries.entryA).to.not.exist;
@@ -178,7 +226,7 @@ describe('features/context-pad', function() {
           contextPad.registerProvider(updatingProvider);
 
           // when
-          var entries = contextPad.getEntries();
+          var entries = contextPad.getEntries([]);
 
           // then
           expect(entries.entryA).to.not.exist;
@@ -192,7 +240,7 @@ describe('features/context-pad', function() {
           contextPad.registerProvider(1200, updatingProvider);
 
           // when
-          var entries = contextPad.getEntries();
+          var entries = contextPad.getEntries([]);
 
           // then
           expect(entries.entryA).to.exist;
@@ -263,9 +311,14 @@ describe('features/context-pad', function() {
   });
 
 
-  describe('lifecycle', function() {
+  describe('life-cycle', function() {
 
-    beforeEach(bootstrapDiagram({ modules: [ contextPadModule, providerModule ] }));
+    beforeEach(bootstrapDiagram({
+      modules: [
+        contextPadModule,
+        providerModule
+      ]
+    }));
 
 
     function expectEntries(contextPad, element, entries) {
@@ -282,20 +335,79 @@ describe('features/context-pad', function() {
     }
 
 
-    it('should open', inject(function(canvas, contextPad) {
+    describe('is open', function() {
 
-      // given
-      var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+      it('single element', inject(function(canvas, contextPad) {
 
-      canvas.addShape(shape);
+        // given
+        var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+
+        canvas.addShape(shape);
+
+        // when
+        contextPad.open(shape);
+
+        // then
+        expect(contextPad.isOpen(shape)).to.be.true;
+      }));
 
 
-      // when
-      contextPad.open(shape);
+      it('multiple elements', inject(function(canvas, contextPad) {
 
-      // then
-      expect(contextPad.isOpen()).to.be.true;
-    }));
+        // given
+        var shape1 = { id: 's1', type: 'A', width: 100, height: 100, x: 10, y: 10 };
+        var shape2 = { id: 's2', type: 'A', width: 100, height: 100, x: 210, y: 10 };
+
+        canvas.addShape(shape1);
+        canvas.addShape(shape2);
+
+        // when
+        contextPad.open([ shape1, shape2 ]);
+
+        // then
+        expect(contextPad.isOpen(shape1)).to.be.false;
+        expect(contextPad.isOpen([ shape2 ])).to.be.false;
+        expect(contextPad.isOpen([ shape1, shape2 ])).to.be.true;
+
+      }));
+
+    });
+
+
+    describe('should open', function() {
+
+      it('single element', inject(function(canvas, contextPad) {
+
+        // given
+        var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+
+        canvas.addShape(shape);
+
+        // when
+        contextPad.open(shape);
+
+        // then
+        expect(contextPad.isOpen()).to.be.true;
+      }));
+
+
+      it('multiple elements', inject(function(canvas, contextPad) {
+
+        // given
+        var shape1 = { id: 's1', type: 'A', width: 100, height: 100, x: 10, y: 10 };
+        var shape2 = { id: 's2', type: 'A', width: 100, height: 100, x: 210, y: 10 };
+
+        canvas.addShape(shape1);
+        canvas.addShape(shape2);
+
+        // when
+        contextPad.open([ shape1, shape2 ]);
+
+        // then
+        expect(contextPad.isOpen()).to.be.true;
+      }));
+
+    });
 
 
     it('should provide context dependent entries', inject(function(canvas, contextPad) {
@@ -303,16 +415,17 @@ describe('features/context-pad', function() {
       // given
       var shapeA = { id: 's1', type: 'A', width: 100, height: 100, x: 10, y: 10 };
       var shapeB = { id: 's2', type: 'B', width: 100, height: 100, x: 210, y: 10 };
+      var shapeA2 = { id: 's3', type: 'A', width: 100, height: 100, x: 410, y: 10 };
 
       canvas.addShape(shapeA);
       canvas.addShape(shapeB);
+      canvas.addShape(shapeA2);
 
       // when (1)
       contextPad.open(shapeA);
 
       // then (1)
       expectEntries(contextPad, shapeA, [ 'action.a', 'action.b' ]);
-
 
       // when (2)
       contextPad.open(shapeB);
@@ -322,6 +435,19 @@ describe('features/context-pad', function() {
 
       // when (3)
       contextPad.open(shapeA);
+
+      // when (4)
+      contextPad.open([ shapeA, shapeA2 ]);
+
+      // then (4)
+      expectEntries(contextPad, [ shapeA, shapeA2 ], [ 'action.a' ]);
+
+      // when (5)
+      contextPad.open([ shapeA, shapeB ]);
+
+      // then (5)
+      expectEntries(contextPad, [ shapeA, shapeB ], [ ]);
+
       contextPad.close();
 
       // then (3)
@@ -354,7 +480,6 @@ describe('features/context-pad', function() {
 
       canvas.addShape(shape);
 
-
       contextPad.open(shape);
       contextPad.close();
 
@@ -365,44 +490,237 @@ describe('features/context-pad', function() {
       expectEntries(contextPad, shape, [ 'action.c', 'action.no-image' ]);
     }));
 
+  });
 
-    it('should reopen if current element changed', inject(function(eventBus, canvas, contextPad) {
 
-      // given
-      var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+  describe('integration', function() {
 
-      canvas.addShape(shape);
-
-      contextPad.open(shape);
-
-      var open = sinon.spy(contextPad, 'open');
-
-      // when
-      eventBus.fire('elements.changed', { elements: [ shape ] });
-
-      // then
-      expect(open).to.have.been.calledWith(shape, true);
+    beforeEach(bootstrapDiagram({
+      modules: [
+        contextPadModule,
+        selectionModule,
+        providerModule
+      ]
     }));
 
 
-    it('should not reopen if other element changed', inject(function(eventBus, canvas, contextPad) {
+    var openSpy, closeSpy;
 
-      // given
-      var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+    function expectOpened(target) {
+      expect(openSpy).to.have.been.calledOnceWith(target);
 
-      canvas.addShape(shape);
+      openSpy.resetHistory();
+      closeSpy.resetHistory();
+    }
 
-      contextPad.open(shape);
+    function expectUntouched() {
+      expect(openSpy).not.to.have.been.called;
+      expect(closeSpy).not.to.have.been.called;
+    }
 
-      var open = sinon.spy(contextPad, 'open');
+    function expectClosed() {
+      expect(closeSpy).to.have.been.calledOnce;
 
-      // when
-      eventBus.fire('elements.changed', { elements: [ canvas.getRootElement() ] });
+      openSpy.resetHistory();
+      closeSpy.resetHistory();
+    }
 
-      // then
-      expect(open).not.to.have.been.called;
+    beforeEach(inject(function(eventBus) {
+      openSpy = sinon.spy();
+      closeSpy = sinon.spy();
+
+      eventBus.on('contextPad.open', function(event) {
+        openSpy(event.current.target);
+      });
+
+      eventBus.on('contextPad.close', closeSpy);
     }));
 
+
+    describe('<elements.changed>', function() {
+
+      function change(elements) {
+        getDiagramJS().invoke(function(eventBus) {
+          eventBus.fire('elements.changed', {
+            elements: isArray(elements) ? elements : [ elements ]
+          });
+        });
+      }
+
+
+      describe('should handle changed', function() {
+
+        it('single target', inject(function(eventBus, canvas, contextPad) {
+
+          // given
+          var shape_1 = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+
+          canvas.addShape(shape_1);
+
+          // assume
+          contextPad.open(shape_1);
+
+          // then
+          expectOpened(shape_1);
+
+          // when
+          change(shape_1);
+
+          // then
+          expectOpened(shape_1);
+        }));
+
+
+        it('multiple targets', inject(function(eventBus, canvas, contextPad) {
+
+          // given
+          var shape_1 = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+          var shape_2 = { id: 's2', width: 50, height: 50, x: 210, y: 10 };
+
+          canvas.addShape(shape_1);
+          canvas.addShape(shape_2);
+
+          // assume
+          contextPad.open([ shape_1, shape_2 ]);
+
+          // then
+          expectOpened([ shape_1, shape_2 ]);
+
+          // when
+          change(shape_1);
+
+          // then
+          expectOpened([ shape_1, shape_2 ]);
+        }));
+
+      });
+
+
+      describe('should ignore unrelated', function() {
+
+        it('single target', inject(function(eventBus, canvas, contextPad) {
+
+          // given
+          var shape_1 = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+          var shape_2 = { id: 's2', width: 100, height: 100, x: 210, y: 10 };
+
+          canvas.addShape(shape_1);
+          canvas.addShape(shape_2);
+
+          // assume
+          contextPad.open(shape_1);
+
+          // then
+          expectOpened(shape_1);
+
+          // when
+          change(shape_2);
+
+          // then
+          expectUntouched();
+        }));
+
+
+        it('multiple targets', inject(function(eventBus, canvas, contextPad) {
+
+          // given
+          var shape_1 = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+          var shape_2 = { id: 's2', width: 50, height: 50, x: 210, y: 10 };
+          var shape_3 = { id: 's3', width: 50, height: 50, x: 410, y: 10 };
+
+          canvas.addShape(shape_1);
+          canvas.addShape(shape_2);
+          canvas.addShape(shape_3);
+
+          // assume
+          contextPad.open([ shape_1, shape_2 ]);
+
+          // then
+          expectOpened([ shape_1, shape_2 ]);
+
+          // when
+          change(shape_3);
+
+          // then
+          expectUntouched();
+        }));
+
+      });
+
+    });
+
+
+    describe('<selection.changed>', function() {
+
+      function select(elements) {
+        getDiagramJS().invoke(function(selection) {
+          selection.select(isArray(elements) ? elements : [ elements ]);
+        });
+      }
+
+
+      describe('should handle select', function() {
+
+        it('single target', inject(function(eventBus, canvas, contextPad) {
+
+          // given
+          var shape_1 = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+          var shape_2 = { id: 's2', width: 100, height: 100, x: 10, y: 10 };
+
+          canvas.addShape(shape_1);
+          canvas.addShape(shape_2);
+
+          // assume
+          contextPad.open(shape_1);
+
+          // then
+          expectOpened(shape_1);
+
+          // when
+          select(shape_2);
+
+          // then
+          expectOpened(shape_2);
+
+          // when
+          select([]);
+
+          // then
+          expectClosed();
+        }));
+
+
+        it('multiple targets', inject(function(eventBus, canvas, contextPad) {
+
+          // given
+          var shape_1 = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+          var shape_2 = { id: 's2', width: 50, height: 50, x: 210, y: 10 };
+
+          canvas.addShape(shape_1);
+          canvas.addShape(shape_2);
+
+          // assume
+          contextPad.open([ shape_1, shape_2 ]);
+
+          // then
+          expectOpened([ shape_1, shape_2 ]);
+
+          // when
+          select(shape_1);
+
+          // then
+          expectOpened(shape_1);
+
+          // when
+          select([ shape_1, shape_2 ]);
+
+          // then
+          expectOpened([ shape_1, shape_2 ]);
+        }));
+
+      });
+
+    });
 
   });
 

--- a/test/spec/features/selection/SelectionVisualsSpec.js
+++ b/test/spec/features/selection/SelectionVisualsSpec.js
@@ -4,15 +4,22 @@ import {
 } from 'test/TestHelper';
 
 import selectionModule from 'lib/features/selection';
+import modelingModule from 'lib/features/modeling';
 
 import {
   query as domQuery
 } from 'min-dom';
 
+import { getBBox } from 'lib/util/Elements';
+
+import {
+  resizeBounds
+} from 'lib/features/resize/ResizeUtil';
+
 
 describe('features/selection/SelectionVisuals', function() {
 
-  beforeEach(bootstrapDiagram({ modules: [ selectionModule ] }));
+  beforeEach(bootstrapDiagram({ modules: [ selectionModule, modelingModule ] }));
 
   describe('bootstrap', function() {
 
@@ -55,19 +62,132 @@ describe('features/selection/SelectionVisuals', function() {
       canvas.addConnection(connection);
     }));
 
+    describe('single element', function() {
 
-    it('should show box on select', inject(function(selection, canvas) {
+      it('should show box on select', inject(function(selection, canvas) {
 
-      // when
-      selection.select(connection);
+        // when
+        selection.select(connection);
 
-      // then
-      var gfx = canvas.getGraphics(connection),
-          outline = domQuery('.djs-outline', gfx);
+        // then
+        var gfx = canvas.getGraphics(connection),
+            outline = domQuery('.djs-outline', gfx);
 
-      expect(outline).to.exist;
-    }));
+        expect(outline).to.exist;
+      }));
+
+    });
+
+
+    describe('multi element', function() {
+
+      var selectedShapes, outline, bounds;
+
+      beforeEach(inject(function(selection) {
+
+        selectedShapes = [ connection, shape2 ];
+        selection.select(selectedShapes);
+
+        outline = domQuery('.djs-selection-outline');
+
+        bounds = getBounds(outline);
+      }));
+
+
+      it('should show box', inject(function(selection) {
+        expect(outline).to.exist;
+      }));
+
+
+      it('selection box should contain all selected elements', inject(function(selection) {
+
+        // then
+        selectedShapes.forEach(function(shape) {
+          var bbox = getBBox(shape);
+
+          expect(bbox.x).to.be.at.least(bounds.x);
+          expect(bbox.y).to.be.at.least(bounds.y);
+          expect(bbox.x + bbox.width).to.be.at.most(bounds.x + bounds.width);
+          expect(bbox.y + bbox.height).to.be.at.most(bounds.y + bounds.height);
+        });
+
+      }));
+
+
+      it('selection box should react to element changes', inject(function(selection, modeling) {
+
+        // when
+        modeling.resizeShape(shape2, resizeBounds(bounds, 'nw', { x: 10, y: 20 }));
+
+        outline = domQuery('.djs-selection-outline');
+
+        var newBounds = getBounds(outline);
+
+        // then
+        expect(newBounds).to.not.eql(bounds);
+
+        // then
+        selectedShapes.forEach(function(shape) {
+          var bbox = getBBox(shape);
+
+          expect(bbox.x).to.be.at.least(newBounds.x);
+          expect(bbox.y).to.be.at.least(newBounds.y);
+          expect(bbox.x + bbox.width).to.be.at.most(newBounds.x + newBounds.width);
+          expect(bbox.y + bbox.height).to.be.at.most(newBounds.y + newBounds.height);
+        });
+
+      }));
+
+
+      it('selection box should react to undo/redo', inject(function(selection, modeling, commandStack) {
+
+        // given
+        modeling.resizeShape(shape2, resizeBounds(shape, 'nw', { x: 10, y: 20 }));
+
+        var outline = domQuery('.djs-selection-outline');
+
+        var bounds = getBounds(outline);
+
+        // when
+        commandStack.undo();
+
+        outline = domQuery('.djs-selection-outline');
+
+        var newBounds = getBounds(outline);
+
+        // then
+        expect(bounds).to.not.eql(newBounds);
+
+        // then
+        selectedShapes.forEach(function(shape) {
+          expectShapeToBeWithinLimits(shape, newBounds);
+        });
+
+      }));
+
+    });
 
   });
 
 });
+
+
+// helpers /////
+
+function getBounds(outline) {
+  return {
+    width: parseInt(outline.getAttribute('width')),
+    height: parseInt(outline.getAttribute('height')),
+    x: parseInt(outline.getAttribute('x')),
+    y: parseInt(outline.getAttribute('y'))
+  };
+}
+
+function expectShapeToBeWithinLimits(shape, limits) {
+  var bbox = getBBox(shape);
+
+  expect(bbox.x).to.be.at.least(limits.x);
+  expect(bbox.y).to.be.at.least(limits.y);
+  expect(bbox.x + bbox.width).to.be.at.most(limits.x + limits.width);
+  expect(bbox.y + bbox.height).to.be.at.most(limits.y + limits.height);
+}

--- a/test/util/MockEvents.js
+++ b/test/util/MockEvents.js
@@ -11,7 +11,7 @@ import {
  * specified canvas local coordinates.
  *
  * @param {Point} point of the event local the canvas (closure)
- * @param {Object} data
+ * @param {Object} [data]
  *
  * @return {Event} event, scoped to the given canvas
  */


### PR DESCRIPTION
Adds the ability to create a context pad around more than one element:

* [x] dedicated selection box surrounds all selected elements
    * [x] implement
    * [x] test 
* [x] a new context pad provider APIs allows provider to provide pads for more than one element (c.f. https://github.com/bpmn-io/bpmn-js/pull/1525)
    * [x] implement
    * [x] test 
* [x] context pad is now single _and_ multi-element aware. Target now generalized to `djs.model.Base || djs.model.Base[]` accordingly.
* [x] even out popup menu entries so that image only entries are possible (https://github.com/bpmn-io/diagram-js/pull/587/commits/366b5c9190b871031b171d8a5333243f50d96dc3).
* [x] fix selection not updating if selected elements changed (undo/redo)
* [x] test `isOpen` api

---

Capture of the thing in action for "delete" example (with reaction to undo/redo): 

<!--![capture PpZoLk_optimized (1)](https://user-images.githubusercontent.com/58601/140742674-559f1221-6692-4672-b823-ab2641f36169.gif)-->

https://user-images.githubusercontent.com/25825387/169019635-83b14574-1a2f-4eaa-b603-645ee357fb50.mov



Delete can be tested by using https://github.com/bpmn-io/bpmn-js/pull/1525 and linking this instance of diagram-js

Closes https://github.com/bpmn-io/diagram-js/issues/278