### PR TITLE
feat(palette): expose pallete state to djs-container

### DIFF
--- a/lib/features/palette/Palette.js
+++ b/lib/features/palette/Palette.js
@@ -20,7 +20,9 @@ var TOGGLE_SELECTOR = '.djs-palette-toggle',
     ENTRY_SELECTOR = '.entry',
     ELEMENT_SELECTOR = TOGGLE_SELECTOR + ', ' + ENTRY_SELECTOR;
 
-var PALETTE_OPEN_CLS = 'open',
+var PALETTE_PREFIX = 'djs-palette-',
+    PALETTE_AVAILABLE_CLS = 'available',
+    PALETTE_OPEN_CLS = 'open',
     PALETTE_TWO_COLUMN_CLS = 'two-column';
 
 var DEFAULT_PRIORITY = 1000;
@@ -138,6 +140,7 @@ Palette.prototype._init = function() {
   var container = this._container = domify(Palette.HTML_MARKUP);
 
   parentContainer.appendChild(container);
+  domClasses(parentContainer).add(PALETTE_PREFIX + PALETTE_AVAILABLE_CLS);
 
   domDelegate.bind(container, ELEMENT_SELECTOR, 'click', function(event) {
 
@@ -195,7 +198,8 @@ Palette.prototype._toggleState = function(state) {
 
   var twoColumn;
 
-  var cls = domClasses(container);
+  var cls = domClasses(container),
+      parentCls = domClasses(parent);
 
   if ('twoColumn' in state) {
     twoColumn = state.twoColumn;
@@ -205,9 +209,11 @@ Palette.prototype._toggleState = function(state) {
 
   // always update two column
   cls.toggle(PALETTE_TWO_COLUMN_CLS, twoColumn);
+  parentCls.toggle(PALETTE_PREFIX + PALETTE_TWO_COLUMN_CLS, twoColumn);
 
   if ('open' in state) {
     cls.toggle(PALETTE_OPEN_CLS, state.open);
+    parentCls.toggle(PALETTE_PREFIX + PALETTE_OPEN_CLS, state.open);
   }
 
   eventBus.fire('palette.changed', {

--- a/test/spec/features/palette/PaletteSpec.js
+++ b/test/spec/features/palette/PaletteSpec.js
@@ -360,8 +360,12 @@ describe('features/palette', function() {
       // then
       expect(palette.isOpen()).to.be.true;
 
-      // marker class on .djs-container
+      // marker class on .djs-palette
       expectPaletteCls('open', true);
+
+      // marker class on .djs-container
+      expectContainerCls('djs-palette-open', true);
+      expectContainerCls('djs-palette-available', true);
     }));
 
 
@@ -381,8 +385,13 @@ describe('features/palette', function() {
       // then
       expect(palette.isOpen()).to.be.false;
 
-      // no marker class on .djs-container
+      // no marker class on .djs-palette
       expectPaletteCls('open', false);
+
+      // no marker class on .djs-container
+      expectContainerCls('djs-palette-open', false);
+      expectContainerCls('djs-palette-available', true);
+
 
       expect(changedSpy).to.have.been.called;
     }));
@@ -406,8 +415,12 @@ describe('features/palette', function() {
       // then
       expect(palette.isOpen()).to.be.true;
 
-      // no marker class on .djs-container
+      // marker class on .djs-palette
       expectPaletteCls('open', true);
+
+      // marker class on .djs-container
+      expectContainerCls('djs-palette-open', true);
+      expectContainerCls('djs-palette-available', true);
 
       expect(changedSpy).to.have.been.called;
     }));
@@ -465,6 +478,7 @@ describe('features/palette', function() {
 
         // then
         expectPaletteCls('two-column', false);
+        expectContainerCls('djs-palette-two-column', false);
 
         expect(changedSpy).to.have.been.called;
       })
@@ -491,6 +505,7 @@ describe('features/palette', function() {
 
         // then
         expectPaletteCls('two-column', true);
+        expectContainerCls('djs-palette-two-column', true);
 
         expect(changedSpy).to.have.been.called;
       })
@@ -517,6 +532,7 @@ describe('features/palette', function() {
 
         // then
         expectPaletteCls('two-column', false);
+        expectContainerCls('djs-palette-two-column', false);
 
         expect(changedSpy).to.have.been.called;
       })
@@ -605,6 +621,14 @@ function is(node, cls) {
 function expectPaletteCls(marker, expectedActive) {
   getDiagramJS().invoke(function(palette) {
     var isActive = is(palette._container, marker);
+
+    expect(isActive).to.eql(expectedActive);
+  });
+}
+
+function expectContainerCls(marker, expectedActive) {
+  getDiagramJS().invoke(function(canvas) {
+    var isActive = is(canvas._container, marker);
 
     expect(isActive).to.eql(expectedActive);
   });


### PR DESCRIPTION
closes #591

- we still keep the classes on `.djs-palette` to not break existing css adjustments
- also expose `djs-palette-available` to differentiate no palette and closed palette

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
