### PR TITLE
chore(palette): rename available -> shown

### DIFF
--- a/lib/features/palette/Palette.js
+++ b/lib/features/palette/Palette.js
@@ -21,7 +21,7 @@ var TOGGLE_SELECTOR = '.djs-palette-toggle',
     ELEMENT_SELECTOR = TOGGLE_SELECTOR + ', ' + ENTRY_SELECTOR;
 
 var PALETTE_PREFIX = 'djs-palette-',
-    PALETTE_AVAILABLE_CLS = 'available',
+    PALETTE_SHOWN_CLS = 'shown',
     PALETTE_OPEN_CLS = 'open',
     PALETTE_TWO_COLUMN_CLS = 'two-column';
 
@@ -140,7 +140,7 @@ Palette.prototype._init = function() {
   var container = this._container = domify(Palette.HTML_MARKUP);
 
   parentContainer.appendChild(container);
-  domClasses(parentContainer).add(PALETTE_PREFIX + PALETTE_AVAILABLE_CLS);
+  domClasses(parentContainer).add(PALETTE_PREFIX + PALETTE_SHOWN_CLS);
 
   domDelegate.bind(container, ELEMENT_SELECTOR, 'click', function(event) {
 

--- a/test/spec/features/palette/PaletteSpec.js
+++ b/test/spec/features/palette/PaletteSpec.js
@@ -365,7 +365,7 @@ describe('features/palette', function() {
 
       // marker class on .djs-container
       expectContainerCls('djs-palette-open', true);
-      expectContainerCls('djs-palette-available', true);
+      expectContainerCls('djs-palette-shown', true);
     }));
 
 
@@ -390,7 +390,7 @@ describe('features/palette', function() {
 
       // no marker class on .djs-container
       expectContainerCls('djs-palette-open', false);
-      expectContainerCls('djs-palette-available', true);
+      expectContainerCls('djs-palette-shown', true);
 
 
       expect(changedSpy).to.have.been.called;
@@ -420,7 +420,7 @@ describe('features/palette', function() {
 
       // marker class on .djs-container
       expectContainerCls('djs-palette-open', true);
-      expectContainerCls('djs-palette-available', true);
+      expectContainerCls('djs-palette-shown', true);
 
       expect(changedSpy).to.have.been.called;
     }));


### PR DESCRIPTION
Let us rename `available` to `shown`. It better matches the fact that the palette is on the Canvas (and must be reacted to). 

Let us also patch release this before things get widely adopted :+1: 