### PR TITLE
fix(canvas): ensure planes work without diagram-js.css

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -93,7 +93,6 @@ function createGroup(parent, cls, childIndex) {
 }
 
 var BASE_LAYER = 'base';
-var HIDDEN_MARKER = 'djs-element-hidden';
 
 // render plane contents behind utility layers
 var PLANE_LAYER_INDEX = 0;
@@ -369,7 +368,7 @@ Canvas.prototype.createPlane = function(name, rootElement) {
   }
 
   var svgLayer = this.getLayer(name, PLANE_LAYER_INDEX);
-  svgClasses(svgLayer).add(HIDDEN_MARKER);
+  svgAttr(svgLayer, 'display', 'none');
 
   var plane = this._planes[name] = {
     layer: svgLayer,
@@ -404,13 +403,13 @@ Canvas.prototype.setActivePlane = function(plane) {
 
   // hide previous Plane
   if (this._activePlane) {
-    svgClasses(this._activePlane.layer).add(HIDDEN_MARKER);
+    svgAttr(this._activePlane.layer, 'display', 'none');
   }
 
   this._activePlane = plane;
 
   // show current Plane
-  svgClasses(plane.layer).remove(HIDDEN_MARKER);
+  svgAttr(plane.layer, 'display', null);
 
   if (plane.rootElement) {
     this._elementRegistry.updateGraphics(plane.rootElement, this._svg, true);

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -2259,7 +2259,7 @@ describe('Canvas', function() {
         var plane1 = canvas.createPlane('a');
 
         // then
-        expect(svgClasses(plane1.layer).has('djs-element-hidden')).to.be.true;
+        expect(svgAttr(plane1.layer, 'display')).to.equal('none');
       }));
 
 
@@ -2404,8 +2404,8 @@ describe('Canvas', function() {
         var gfxA = canvas.getPlane('a').layer;
         var gfxB = canvas.getPlane('b').layer;
 
-        expect(svgClasses(gfxA).has('djs-element-hidden')).to.be.true;
-        expect(svgClasses(gfxB).has('djs-element-hidden')).to.be.false;
+        expect(svgAttr(gfxA, 'display')).to.equal('none');
+        expect(svgAttr(gfxB, 'display')).to.equal('');
       }));
 
     });


### PR DESCRIPTION
Allows the use of planes in the viewer without including `diagram-js.css`

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
