### PR TITLE
feat(canvas): allow removing planes

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -425,11 +425,17 @@ Canvas.prototype.setActivePlane = function(plane) {
     }
   }
 
-  // hide previous Plane
-  if (this._activePlane) {
-    svgAttr(this._activePlane.layer, 'display', 'none');
-  }
+  var previousPlane = this._activePlane;
 
+  // hide previous Plane
+  if (previousPlane) {
+    svgAttr(this._activePlane.layer, 'display', 'none');
+
+    // svg should only have one associated element
+    if (previousPlane.rootElement) {
+      this._elementRegistry.updateGraphics(previousPlane.rootElement, null, true);
+    }
+  }
   this._activePlane = plane;
 
   // show current Plane

--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -327,6 +327,30 @@ Canvas.prototype._createLayer = function(name, index) {
 };
 
 /**
+ * Renames a given layer and returns it.
+ *
+ * @param {string} oldName
+ * @param {string} newName
+ *
+ * @returns {Object} layer descriptor with { index, group: SVGGroup }
+ */
+Canvas.prototype._renameLayer = function(oldName, newName) {
+  var layer = this._layers[oldName];
+
+  if (!layer) {
+    throw new Error('must specify layer');
+  }
+  var group = layer.group;
+
+  svgClasses(group).remove('layer-' + oldName);
+  svgClasses(group).add('layer-' + newName);
+
+  this._layers[newName] = layer;
+  delete this._layers[oldName];
+};
+
+
+/**
  * Returns a plane that is used to draw elements on it.
  *
  * @param {string} name
@@ -462,6 +486,42 @@ Canvas.prototype.findPlane = function(element) {
   return find(this._planes, function(plane) {
     return plane.rootElement === root;
   });
+};
+
+
+/**
+ * Renames the given plane
+ *
+ * @param {string|djs.model.Base} plane
+ * @param {string} newName
+ */
+Canvas.prototype.renamePlane = function(plane, newName) {
+  if (typeof plane === 'string') {
+    plane = this.getPlane(plane);
+  }
+
+  if (!plane) {
+    throw new Error('must specify a plane');
+  }
+
+  if (!newName) {
+    throw new Error('must specify a name');
+  }
+
+  if (this._planes[newName]) {
+    throw new Error('plane <' + newName + '> already exists');
+  }
+
+  var oldName = plane.name;
+
+  this._renameLayer(oldName, newName);
+  plane.name = newName;
+  this._planes[newName] = plane;
+
+  // delete old plane reference
+  delete this._planes[oldName];
+
+  return plane;
 };
 
 /**

--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -467,9 +467,13 @@ Canvas.prototype.getActiveLayer = function() {
  */
 Canvas.prototype.getActivePlane = function() {
   var plane = this._activePlane;
+
   if (!plane) {
-    plane = this.createPlane(BASE_LAYER);
-    this.setActivePlane(BASE_LAYER);
+    if (!this.getPlane(BASE_LAYER)) {
+      this.createPlane(BASE_LAYER);
+    }
+
+    plane = this.setActivePlane(BASE_LAYER);
   }
 
   return plane;
@@ -496,7 +500,33 @@ Canvas.prototype.findPlane = function(element) {
 
 
 /**
- * Renames the given plane
+ * Removes the given plane.
+ *
+ * @param {string|djs.model.Base} plane
+ *
+ * @returns {Object} removed plane
+ */
+Canvas.prototype.removePlane = function(plane) {
+  if (typeof plane === 'string') {
+    plane = this.getPlane(plane);
+  }
+
+  if (!plane) {
+    throw new Error('must specify a plane');
+  }
+
+  delete this._planes[plane.name];
+
+  if (plane === this._activePlane) {
+    this._activePlane = null;
+  }
+
+  return plane;
+};
+
+
+/**
+ * Renames the given plane.
  *
  * @param {string|djs.model.Base} plane
  * @param {string} newName

--- a/lib/core/ElementRegistry.js
+++ b/lib/core/ElementRegistry.js
@@ -109,7 +109,9 @@ ElementRegistry.prototype.updateGraphics = function(filter, gfx, secondary) {
     container.gfx = gfx;
   }
 
-  svgAttr(gfx, ELEMENT_ID, id);
+  if (gfx) {
+    svgAttr(gfx, ELEMENT_ID, id);
+  }
 
   return gfx;
 };

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -2337,6 +2337,61 @@ describe('Canvas', function() {
     });
 
 
+    describe('#removePlane', function() {
+
+      it('should expect a name', inject(function(canvas) {
+
+        expect(function() {
+
+          // when
+          canvas.removePlane();
+        }).to.throw('must specify a plane');
+      }));
+
+
+      it('should accept names', inject(function(canvas) {
+
+        // given
+        canvas.createPlane('a');
+
+        // when
+        canvas.removePlane('a');
+
+        // then
+        expect(canvas.getPlane('a')).not.to.exist;
+      }));
+
+
+      it('should remove active plane', inject(function(canvas) {
+
+        // given
+        canvas.createPlane('a');
+        canvas.setActivePlane('a');
+
+        // when
+        canvas.removePlane('a');
+
+        // then
+        expect(canvas._activePlane).to.not.exist;
+      }));
+
+
+      it('should default to base plane after active plane is removed', inject(function(canvas) {
+
+        // given
+        canvas.createPlane('a');
+        canvas.setActivePlane('a');
+
+        // when
+        canvas.removePlane('a');
+
+        // then
+        expect(canvas.getActivePlane().name).to.equal('base');
+      }));
+
+    });
+
+
     describe('#renamePlane', function() {
 
       it('should expect a plane', inject(function(canvas) {
@@ -2407,7 +2462,7 @@ describe('Canvas', function() {
       }));
 
 
-      it('should not remove canvas data-element-id', inject(function(canvas) {
+      it('should not remove canvas data-element-id', inject(function(canvas, elementRegistry) {
 
         // given
         var rootA = { id: 'A' };
@@ -2423,6 +2478,7 @@ describe('Canvas', function() {
 
         // then
         expect(svgAttr(canvas._svg, 'data-element-id')).to.equal('A');
+        expect(elementRegistry.get(canvas._svg)).to.equal(rootA);
       }));
 
 
@@ -2530,7 +2586,7 @@ describe('Canvas', function() {
         // assume
         expect(elementRegistry.getGraphics('A', true)).to.exist;
         expect(elementRegistry.getGraphics('B', true)).to.not.exist;
-        expect(svgAttr(canvas._svg, 'data-element-id')).to.equal('A');
+        expect(elementRegistry.get(canvas._svg)).to.equal(rootA);
 
         // when
         canvas.setActivePlane('b');
@@ -2538,7 +2594,7 @@ describe('Canvas', function() {
         // then
         expect(elementRegistry.getGraphics('A', true)).to.not.exist;
         expect(elementRegistry.getGraphics('B', true)).to.exist;
-        expect(svgAttr(canvas._svg, 'data-element-id')).to.equal('B');
+        expect(elementRegistry.get(canvas._svg)).to.equal(rootB);
       }));
 
 
@@ -2626,7 +2682,6 @@ describe('Canvas', function() {
       }));
 
     });
-
 
 
     describe('#findPlane', function() {

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -2407,6 +2407,25 @@ describe('Canvas', function() {
       }));
 
 
+      it('should not remove canvas data-element-id', inject(function(canvas) {
+
+        // given
+        var rootA = { id: 'A' };
+        var rootB = { id: 'B' };
+
+        canvas.createPlane('a', rootA);
+        canvas.createPlane('b', rootB);
+
+        canvas.setActivePlane('a');
+
+        // when
+        canvas.removePlane('b');
+
+        // then
+        expect(svgAttr(canvas._svg, 'data-element-id')).to.equal('A');
+      }));
+
+
       it('should accept IDs', inject(function(canvas) {
 
         // given
@@ -2494,6 +2513,32 @@ describe('Canvas', function() {
         var gfx = plane.layer;
         expect(svgClasses(gfx).has('djs-element-hidden')).to.be.false;
         expect(canvas.getActivePlane()).to.eq(plane);
+      }));
+
+
+      it('should update root element link on svg', inject(function(canvas, elementRegistry) {
+
+        // given
+        var rootA = { id: 'A' };
+        var rootB = { id: 'B' };
+
+        canvas.createPlane('a', rootA);
+        canvas.createPlane('b', rootB);
+
+        canvas.setActivePlane('a');
+
+        // assume
+        expect(elementRegistry.getGraphics('A', true)).to.exist;
+        expect(elementRegistry.getGraphics('B', true)).to.not.exist;
+        expect(svgAttr(canvas._svg, 'data-element-id')).to.equal('A');
+
+        // when
+        canvas.setActivePlane('b');
+
+        // then
+        expect(elementRegistry.getGraphics('A', true)).to.not.exist;
+        expect(elementRegistry.getGraphics('B', true)).to.exist;
+        expect(svgAttr(canvas._svg, 'data-element-id')).to.equal('B');
       }));
 
 

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -2337,6 +2337,138 @@ describe('Canvas', function() {
     });
 
 
+    describe('#renamePlane', function() {
+
+      it('should expect a plane', inject(function(canvas) {
+
+        expect(function() {
+
+          // when
+          canvas.renamePlane();
+        }).to.throw('must specify a plane');
+      }));
+
+
+      it('should expect a name', inject(function(canvas) {
+
+        // given
+        var plane = canvas.createPlane('a');
+
+        expect(function() {
+
+          // when
+          canvas.renamePlane(plane);
+        }).to.throw('must specify a name');
+      }));
+
+
+      it('should rename the plane', inject(function(canvas) {
+
+        // given
+        var plane = canvas.createPlane('a');
+
+        // when
+        canvas.renamePlane(plane, 'b');
+
+        // then
+        expect(canvas.getPlane('a')).not.to.exist;
+        expect(canvas.getPlane('b')).to.exist;
+        expect(plane.name).to.equal('b');
+      }));
+
+
+      it('should keep active plane', inject(function(canvas) {
+
+        // given
+        var plane = canvas.createPlane('a');
+        canvas.setActivePlane('a');
+
+        // when
+        canvas.renamePlane(plane, 'b');
+
+        // then
+        expect(canvas.getActivePlane()).to.eql(plane);
+
+      }));
+
+
+      it('should not override existing planes', inject(function(canvas) {
+
+        // given
+        var plane = canvas.createPlane('a');
+        canvas.createPlane('b');
+
+
+        expect(function() {
+
+          // when
+          canvas.renamePlane(plane, 'b');
+        }).to.throw('plane <b> already exists');
+      }));
+
+
+      it('should accept IDs', inject(function(canvas) {
+
+        // given
+        var plane = canvas.createPlane('a');
+
+        // when
+        canvas.renamePlane('a', 'b');
+
+        // then
+        expect(canvas.getPlane('a')).not.to.exist;
+        expect(canvas.getPlane('b')).to.exist;
+        expect(plane.name).to.equal('b');
+      }));
+
+
+      it('should rename associated layers', inject(function(canvas) {
+
+        // given
+        var plane = canvas.createPlane('a');
+
+        // when
+        canvas.renamePlane(plane, 'b');
+
+        // then
+        expect(canvas._layers['a']).not.to.exist;
+        expect(canvas._layers['b']).to.exist;
+        expect(svgClasses(plane.layer).has('layer-b')).to.be.true;
+      }));
+
+
+      it('should rename associated layers', inject(function(canvas) {
+
+        // given
+        var plane = canvas.createPlane('a');
+
+        // when
+        canvas.renamePlane(plane, 'b');
+
+        // then
+        expect(canvas._layers['a']).not.to.exist;
+        expect(canvas._layers['b']).to.exist;
+        expect(svgClasses(plane.layer).has('layer-b')).to.be.true;
+      }));
+
+
+      it('should move children', inject(function(canvas) {
+
+        // given
+        var plane = canvas.createPlane('a');
+        canvas.setActivePlane(plane);
+        var shape = canvas.addShape({ id: 'shape', x: 10, y: 20, width: 50, height: 50 });
+
+        // when
+        canvas.renamePlane(plane, 'b');
+
+        // then
+        expect(canvas.findPlane(shape)).to.eql(plane);
+      }));
+
+    });
+
+
     describe('#setActivePlane', function() {
 
       it('should expect a plane', inject(function(canvas) {

--- a/test/spec/core/ElementRegistrySpec.js
+++ b/test/spec/core/ElementRegistrySpec.js
@@ -53,7 +53,7 @@ describe('ElementRegistry', function() {
 
   describe('updateId', function() {
 
-    it('should update id', inject(function(elementRegistry, canvas) {
+    it('should update id', inject(function(elementRegistry) {
 
       // given
       var oldId = '1',
@@ -79,7 +79,7 @@ describe('ElementRegistry', function() {
     }));
 
 
-    it('should update by id', inject(function(elementRegistry, canvas) {
+    it('should update by id', inject(function(elementRegistry) {
 
       // given
       var oldId = '1',
@@ -106,7 +106,7 @@ describe('ElementRegistry', function() {
 
   describe('updateGraphics', function() {
 
-    it('should update graphics', inject(function(elementRegistry, canvas, graphicsFactory) {
+    it('should update graphics', inject(function(elementRegistry, graphicsFactory) {
 
       // given
       var shape = elementRegistry.get('1');
@@ -121,7 +121,22 @@ describe('ElementRegistry', function() {
     }));
 
 
-    it('should update secondary graphics', inject(function(elementRegistry, canvas, graphicsFactory) {
+    it('should remove graphics', inject(function(elementRegistry, graphicsFactory) {
+
+      // given
+      var shape = elementRegistry.get('1');
+      var newGfx = graphicsFactory.create('shape', shape);
+      elementRegistry.updateGraphics(shape, newGfx);
+
+      // when
+      elementRegistry.updateGraphics(shape, null);
+
+      // then
+      expect(elementRegistry.getGraphics(shape)).to.not.exist;
+    }));
+
+
+    it('should update secondary graphics', inject(function(elementRegistry, graphicsFactory) {
 
       // given
       var shape = elementRegistry.get('1');
@@ -135,6 +150,23 @@ describe('ElementRegistry', function() {
       expect(elementRegistry.getGraphics(shape, true)).to.be.equal(newGfx);
     }));
 
+
+    it('should remove secondary graphics', inject(function(elementRegistry, graphicsFactory) {
+
+      // given
+      var shape = elementRegistry.get('1');
+      var newGfx = graphicsFactory.create('shape', shape);
+      elementRegistry.updateGraphics(shape, newGfx, true);
+
+      // assume
+      expect(elementRegistry.getGraphics(shape, true)).to.exist;
+
+      // when
+      elementRegistry.updateGraphics(shape, null, true);
+
+      // then
+      expect(elementRegistry.getGraphics(shape, true)).to.not.exist;
+    }));
   });
 
 


### PR DESCRIPTION
This enables us to remove planes, e.g. when they are renamed.

This is used in https://github.com/bpmn-io/bpmn-js/pull/1538. Example use case here:
https://github.com/bpmn-io/bpmn-js/blob/0370ae612341d2c20227bb6b20bfd9fb6f2669c9/lib/features/modeling/behavior/SubProcessPlaneBehavior.js#L155-L173
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
