### PR TITLE
fix(planes): ensure we switch to existing plane

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -369,38 +369,43 @@ Canvas.prototype.getPlane = function(name) {
  * Creates a plane that is used to draw elements on it. If no
  * root element is provided, an implicit root will be used.
  *
- * @param {string} name
+ * @param {string|Object} plane
  * @param {Object|djs.model.Root} [rootElement] optional root element
  *
  * @return {Object} plane descriptor with { layer, rootElement, name }
  */
-Canvas.prototype.createPlane = function(name, rootElement) {
-  if (!name) {
+Canvas.prototype.createPlane = function(plane, rootElement) {
+  if (!plane) {
     throw new Error('must specify a name');
   }
 
-  if (this._planes[name]) {
-    throw new Error('plane <' + name + '> already exists');
+  if (this._planes[plane] || this._planes[plane.name]) {
+    throw new Error('plane <' + plane + '> already exists');
   }
 
-  if (!rootElement) {
-    rootElement = {
-      id: '__implicitroot' + name,
+  if (typeof plane === 'string') {
+    plane = { name: plane };
+  }
+
+  if (!plane.layer) {
+    var svgLayer = this.getLayer(plane.name, PLANE_LAYER_INDEX);
+    svgAttr(svgLayer, 'display', 'none');
+
+    plane.layer = svgLayer;
+  }
+
+  if (!plane.rootElement) {
+    rootElement = rootElement || {
+      id: '__implicitroot' + plane.name,
       children: [],
       isImplicit: true
     };
+
+
+    this.setRootElementForPlane(rootElement, plane);
   }
 
-  var svgLayer = this.getLayer(name, PLANE_LAYER_INDEX);
-  svgAttr(svgLayer, 'display', 'none');
-
-  var plane = this._planes[name] = {
-    layer: svgLayer,
-    name: name,
-    rootElement: null
-  };
-
-  this.setRootElementForPlane(rootElement, plane);
+  this._planes[plane.name] = plane;
 
   return plane;
 };

--- a/lib/features/planes/PlanesBehavior.js
+++ b/lib/features/planes/PlanesBehavior.js
@@ -2,7 +2,7 @@ import inherits from 'inherits';
 
 import CommandInterceptor from '../../command/CommandInterceptor';
 
-export default function PlanesBehaviour(canvas, eventBus, injector) {
+export default function PlanesBehavior(canvas, injector) {
 
   injector.invoke(CommandInterceptor, this);
 
@@ -12,7 +12,7 @@ export default function PlanesBehaviour(canvas, eventBus, injector) {
     if (context.plane) {
       canvas.setActivePlane(context.plane);
     } else {
-      context.plane = canvas.getActivePlane();
+      context.plane = canvas.getActivePlane().name;
     }
   });
 
@@ -25,6 +25,6 @@ export default function PlanesBehaviour(canvas, eventBus, injector) {
   });
 }
 
-inherits(PlanesBehaviour, CommandInterceptor);
+inherits(PlanesBehavior, CommandInterceptor);
 
-PlanesBehaviour.$inject = [ 'canvas', 'eventBus', 'injector'];
+PlanesBehavior.$inject = [ 'canvas', 'injector'];

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -2413,7 +2413,43 @@ describe('Canvas', function() {
 
           // when
           canvas.renamePlane(plane);
-        }).to.throw('must specify a name');
+        }).to.throw('must specify a plane');
+      }));
+
+
+      it('should accept a plane descriptor', inject(function(canvas) {
+
+        // given
+        var plane = {
+          name: 'a',
+          rootElement: { id: 'root' },
+          layer: canvas.getLayer('a')
+        };
+
+        // when
+        canvas.createPlane(plane);
+
+        // then
+        expect(canvas.getPlane('a')).to.exist;
+        expect(canvas.getPlane('a')).to.equal(plane);
+      }));
+
+
+      it('should fill missing plane attributes', inject(function(canvas) {
+
+        // given
+        var plane = {
+          name: 'a'
+        };
+
+        // when
+        canvas.createPlane(plane);
+
+        // then
+        expect(canvas.getPlane('a')).to.exist;
+        expect(canvas.getPlane('a')).to.equal(plane);
+        expect(plane.rootElement).to.exist;
+        expect(plane.layer).to.exist;
       }));
 
 

--- a/test/spec/features/planes/PlanesBehaviorSpec.js
+++ b/test/spec/features/planes/PlanesBehaviorSpec.js
@@ -51,6 +51,40 @@ describe('features/planes/PlanesBehavior', function() {
       expect(canvas.getActivePlane().name).to.equal('base');
     }));
 
+
+    it('should work after re-adding a plane', inject(function(canvas, modeling, commandStack) {
+
+      // given
+      var plane = canvas.createPlane('1');
+      canvas.setActivePlane('1');
+
+      var shape2 = canvas.addShape({
+        id: 'shape2',
+        x: 10,
+        y: 10,
+        width: 100,
+        height: 100
+      });
+      modeling.removeShape(shape2);
+
+      canvas.setActivePlane('base');
+
+      // when
+
+      // remove and re-add the plane, e.g. when removing a subprocess and undoing it
+      canvas.setRootElementForPlane(null, plane, true);
+      canvas.removePlane(plane);
+      canvas.createPlane('1');
+
+      commandStack.undo();
+
+      // then
+      var activePlane = canvas.getActivePlane();
+      expect(canvas.getRootElement()).to.exist;
+      expect(activePlane).to.not.equal(plane);
+      expect(activePlane.name).to.equal('1');
+    }));
+
   });
 
 
@@ -69,6 +103,40 @@ describe('features/planes/PlanesBehavior', function() {
 
       // then
       expect(canvas.getActivePlane().name).to.equal('base');
+    }));
+
+
+    it('should work after re-adding a plane', inject(function(canvas, modeling, commandStack) {
+
+      // given
+      var plane = canvas.createPlane('1');
+      canvas.setActivePlane('1');
+
+      var shape2 = canvas.addShape({
+        id: 'shape2',
+        x: 10,
+        y: 10,
+        width: 100,
+        height: 100
+      });
+      modeling.removeShape(shape2);
+
+      // remove and re-add the plane, e.g. when removing a subprocess and undoing it
+      canvas.setRootElementForPlane(null, plane, true);
+      canvas.removePlane(plane);
+      canvas.createPlane('1');
+      canvas.setActivePlane('base');
+
+      commandStack.undo();
+
+      // when
+      commandStack.redo();
+
+      // then
+      var activePlane = canvas.getActivePlane();
+      expect(canvas.getRootElement()).to.exist;
+      expect(activePlane).to.not.equal(plane);
+      expect(activePlane.name).to.equal('1');
     }));
 
   });


### PR DESCRIPTION
With the ability to remove planes, we have to adjust the Behavior that switches planes during command executions. We should use names instead of plane object when switching planes.

This fixes a scenario that is caused during bpmn-js modeling:
- Create new Collapsed Subprocess
- Add an element to it
- undo everything --> this removes the plane and the root element
- redo creation of plane --> a new plane with the same root element, name and layer is created
- redo shape add --> we switch to a plane without a root element because we saved the plane element that was removed
- We are on an invalid plane

Because the behavior for adding/removing planes is part of bpmn-js, but switching to the correct plane is a diagram-js concern, I had to manually remove the plane+root element and could not use the command stack in the tests.