### PR TITLE
feat(canvas): allow creating planes from descriptors

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -369,38 +369,43 @@ Canvas.prototype.getPlane = function(name) {
  * Creates a plane that is used to draw elements on it. If no
  * root element is provided, an implicit root will be used.
  *
- * @param {string} name
+ * @param {string|Object} plane
  * @param {Object|djs.model.Root} [rootElement] optional root element
  *
  * @return {Object} plane descriptor with { layer, rootElement, name }
  */
-Canvas.prototype.createPlane = function(name, rootElement) {
-  if (!name) {
-    throw new Error('must specify a name');
+Canvas.prototype.createPlane = function(plane, rootElement) {
+  if (!plane) {
+    throw new Error('must specify a plane');
   }
 
-  if (this._planes[name]) {
-    throw new Error('plane <' + name + '> already exists');
+  if (this._planes[plane] || this._planes[plane.name]) {
+    throw new Error('plane <' + plane + '> already exists');
   }
 
-  if (!rootElement) {
-    rootElement = {
-      id: '__implicitroot' + name,
+  if (typeof plane === 'string') {
+    plane = { name: plane };
+  }
+
+  if (!plane.layer) {
+    var svgLayer = this.getLayer(plane.name, PLANE_LAYER_INDEX);
+    svgAttr(svgLayer, 'display', 'none');
+
+    plane.layer = svgLayer;
+  }
+
+  if (!plane.rootElement) {
+    rootElement = rootElement || {
+      id: '__implicitroot' + plane.name,
       children: [],
       isImplicit: true
     };
+
+
+    this.setRootElementForPlane(rootElement, plane);
   }
 
-  var svgLayer = this.getLayer(name, PLANE_LAYER_INDEX);
-  svgAttr(svgLayer, 'display', 'none');
-
-  var plane = this._planes[name] = {
-    layer: svgLayer,
-    name: name,
-    rootElement: null
-  };
-
-  this.setRootElementForPlane(rootElement, plane);
+  this._planes[plane.name] = plane;
 
   return plane;
 };

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -2232,13 +2232,13 @@ describe('Canvas', function() {
 
     describe('#createPlane', function() {
 
-      it('should expect a name', inject(function(canvas) {
+      it('should expect a plane', inject(function(canvas) {
 
         expect(function() {
 
           // when
           canvas.createPlane();
-        }).to.throw('must specify a name');
+        }).to.throw('must specify a plane');
       }));
 
 
@@ -2414,6 +2414,42 @@ describe('Canvas', function() {
           // when
           canvas.renamePlane(plane);
         }).to.throw('must specify a name');
+      }));
+
+
+      it('should accept a plane descriptor', inject(function(canvas) {
+
+        // given
+        var plane = {
+          name: 'a',
+          rootElement: { id: 'root' },
+          layer: canvas.getLayer('a')
+        };
+
+        // when
+        canvas.createPlane(plane);
+
+        // then
+        expect(canvas.getPlane('a')).to.exist;
+        expect(canvas.getPlane('a')).to.equal(plane);
+      }));
+
+
+      it('should fill missing plane attributes', inject(function(canvas) {
+
+        // given
+        var plane = {
+          name: 'a'
+        };
+
+        // when
+        canvas.createPlane(plane);
+
+        // then
+        expect(canvas.getPlane('a')).to.exist;
+        expect(canvas.getPlane('a')).to.equal(plane);
+        expect(plane.rootElement).to.exist;
+        expect(plane.layer).to.exist;
       }));
 
 


### PR DESCRIPTION
- Allows us to reuse plane descriptors when undo/redoing plane removals.

superceds #598

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
