### PR TITLE
feat: make truely multi-root aware

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -6,7 +6,8 @@ import {
   debounce,
   bind,
   reduce,
-  find
+  find,
+  isDefined
 } from 'min-dash';
 
 import {
@@ -26,7 +27,8 @@ import {
   attr as svgAttr,
   classes as svgClasses,
   create as svgCreate,
-  transform as svgTransform
+  transform as svgTransform,
+  remove as svgRemove
 } from 'tiny-svg';
 
 import { createMatrix as createMatrix } from 'tiny-svg';
@@ -123,6 +125,12 @@ export default function Canvas(config, eventBus, graphicsFactory, elementRegistr
   this._elementRegistry = elementRegistry;
   this._graphicsFactory = graphicsFactory;
 
+  this._rootsIdx = 0;
+
+  this._layers = {};
+  this._planes = [];
+  this._rootElement = null;
+
   this._init(config || {});
 }
 
@@ -160,9 +168,6 @@ Canvas.prototype._init = function(config) {
 
   var viewport = this._viewport = createGroup(svg, 'viewport');
 
-  this._layers = {};
-  this._planes = {};
-
   // debounce canvas.viewbox.changed events
   // for smoother diagram interaction
   if (config.deferUpdate !== false) {
@@ -197,7 +202,7 @@ Canvas.prototype._init = function(config) {
     'shape.removed',
     'connection.removed',
     'elements.changed',
-    'plane.set'
+    'root.set'
   ], function() {
     delete this._cachedViewbox;
   }, this);
@@ -222,7 +227,7 @@ Canvas.prototype._destroy = function(emit) {
   delete this._container;
   delete this._layers;
   delete this._planes;
-  delete this._activePlane;
+  delete this._rootElement;
   delete this._viewport;
 };
 
@@ -237,15 +242,15 @@ Canvas.prototype._clear = function() {
     var type = getType(element);
 
     if (type === 'root') {
-      self.setRootElementForPlane(null, self.findPlane(element), true);
+      self.removeRootElement(element);
     } else {
       self._removeElement(element, type);
     }
   });
 
   // remove all planes
-  this._activePlane = null;
-  this._planes = {};
+  this._planes = [];
+  this._rootElement = null;
 
   // force recomputation of view box
   delete this._cachedViewbox;
@@ -326,132 +331,16 @@ Canvas.prototype._createLayer = function(name, index) {
 
 };
 
-/**
- * Renames a given layer and returns it.
- *
- * @param {string} oldName
- * @param {string} newName
- *
- * @returns {Object} layer descriptor with { index, group: SVGGroup }
- */
-Canvas.prototype._renameLayer = function(oldName, newName) {
-  var layer = this._layers[oldName];
 
-  if (!layer) {
-    throw new Error('must specify layer');
+Canvas.prototype._removeLayer = function(name) {
+
+  var layer = this._layers[name];
+
+  if (layer) {
+    delete this._layers[name];
+
+    svgRemove(layer.group);
   }
-  var group = layer.group;
-
-  svgClasses(group).remove('layer-' + oldName);
-  svgClasses(group).add('layer-' + newName);
-
-  this._layers[newName] = layer;
-  delete this._layers[oldName];
-};
-
-
-/**
- * Returns a plane that is used to draw elements on it.
- *
- * @param {string} name
- *
- * @return {Object} plane descriptor with { layer, rootElement, name }
- */
-Canvas.prototype.getPlane = function(name) {
-  if (!name) {
-    throw new Error('must specify a name');
-  }
-
-  return this._planes[name];
-};
-
-/**
- * Creates a plane that is used to draw elements on it. If no
- * root element is provided, an implicit root will be used.
- *
- * @param {string|Object} plane
- * @param {Object|djs.model.Root} [rootElement] optional root element
- *
- * @return {Object} plane descriptor with { layer, rootElement, name }
- */
-Canvas.prototype.createPlane = function(plane, rootElement) {
-  if (!plane) {
-    throw new Error('must specify a plane');
-  }
-
-  if (this._planes[plane] || this._planes[plane.name]) {
-    throw new Error('plane <' + plane + '> already exists');
-  }
-
-  if (typeof plane === 'string') {
-    plane = { name: plane };
-  }
-
-  if (!plane.layer) {
-    var svgLayer = this.getLayer(plane.name, PLANE_LAYER_INDEX);
-    svgAttr(svgLayer, 'display', 'none');
-
-    plane.layer = svgLayer;
-  }
-
-  if (!plane.rootElement) {
-    plane.rootElement = rootElement || {
-      id: '__implicitroot' + plane.name,
-      children: [],
-      isImplicit: true
-    };
-  }
-
-  this._addRoot(plane.rootElement, plane);
-
-  this._planes[plane.name] = plane;
-
-  return plane;
-};
-
-/**
- * Sets the active plane and hides the previously active plane.
- *
- * @param {string|Object} plane
- *
- * @return {Object} plane descriptor with { layer, rootElement, name }
- */
-Canvas.prototype.setActivePlane = function(plane) {
-  if (!plane) {
-    throw new Error('must specify a plane');
-  }
-
-  if (typeof plane === 'string') {
-    var name = plane;
-    plane = this.getPlane(name);
-    if (!plane) {
-      throw new Error('plane <' + name + '> does not exist');
-    }
-  }
-
-  var previousPlane = this._activePlane;
-
-  // hide previous Plane
-  if (previousPlane) {
-    svgAttr(this._activePlane.layer, 'display', 'none');
-
-    // svg should only have one associated element
-    if (previousPlane.rootElement) {
-      this._elementRegistry.updateGraphics(previousPlane.rootElement, null, true);
-    }
-  }
-  this._activePlane = plane;
-
-  // show current Plane
-  svgAttr(plane.layer, 'display', null);
-
-  if (plane.rootElement) {
-    this._elementRegistry.updateGraphics(plane.rootElement, this._svg, true);
-  }
-
-  this._eventBus.fire('plane.set', { plane: plane });
-
-  return plane;
 };
 
 /**
@@ -459,112 +348,51 @@ Canvas.prototype.setActivePlane = function(plane) {
  *
  * @returns {SVGElement}
  */
-
 Canvas.prototype.getActiveLayer = function() {
-  return this.getActivePlane().layer;
+  return this._findPlaneForRoot(this.getRootElement()).layer;
 };
 
-/**
- * Returns the currently active plane.
- *
- * @return {Object} plane descriptor with { layer, rootElement, name }
- */
-Canvas.prototype.getActivePlane = function() {
-  var plane = this._activePlane;
-
-  if (!plane) {
-    if (!this.getPlane(BASE_LAYER)) {
-      this.createPlane(BASE_LAYER);
-    }
-
-    plane = this.setActivePlane(BASE_LAYER);
-  }
-
-  return plane;
-};
 
 /**
  * Returns the plane which contains the given element.
  *
  * @param {string|djs.model.Base} element
  *
- * @return {Object} plane descriptor with { layer, rootElement, name }
+ * @return {djs.model.Base} root for element
  */
-Canvas.prototype.findPlane = function(element) {
+Canvas.prototype.findRoot = function(element) {
   if (typeof element === 'string') {
     element = this._elementRegistry.get(element);
   }
 
-  var root = findRoot(element);
+  if (!element) {
+    return;
+  }
 
-  return find(this._planes, function(plane) {
-    return plane.rootElement === root;
+  var plane = this._findPlaneForRoot(
+    findRoot(element)
+  ) || {};
+
+  return plane.rootElement;
+};
+
+/**
+ * Return a list of all root elements on the diagram.
+ *
+ * @return {djs.model.Root[]}
+ */
+Canvas.prototype.getRootElements = function() {
+  return this._planes.map(function(plane) {
+    return plane.rootElement;
   });
 };
 
-
-/**
- * Removes the given plane.
- *
- * @param {string|djs.model.Base} plane
- *
- * @returns {Object} removed plane
- */
-Canvas.prototype.removePlane = function(plane) {
-  if (typeof plane === 'string') {
-    plane = this.getPlane(plane);
-  }
-
-  if (!plane) {
-    throw new Error('must specify a plane');
-  }
-
-  delete this._planes[plane.name];
-
-  this._removeRoot(plane.rootElement);
-
-  if (plane === this._activePlane) {
-    this._activePlane = null;
-  }
-
-  return plane;
+Canvas.prototype._findPlaneForRoot = function(rootElement) {
+  return find(this._planes, function(plane) {
+    return plane.rootElement === rootElement;
+  });
 };
 
-
-/**
- * Renames the given plane.
- *
- * @param {string|djs.model.Base} plane
- * @param {string} newName
- */
-Canvas.prototype.renamePlane = function(plane, newName) {
-  if (typeof plane === 'string') {
-    plane = this.getPlane(plane);
-  }
-
-  if (!plane) {
-    throw new Error('must specify a plane');
-  }
-
-  if (!newName) {
-    throw new Error('must specify a name');
-  }
-
-  if (this._planes[newName]) {
-    throw new Error('plane <' + newName + '> already exists');
-  }
-
-  var oldName = plane.name;
-
-  this._renameLayer(oldName, newName);
-  plane.name = newName;
-  this._planes[newName] = plane;
-
-  // delete old plane reference
-  delete this._planes[oldName];
-
-  return plane;
-};
 
 /**
  * Returns the html element that encloses the
@@ -687,11 +515,63 @@ Canvas.prototype.toggleMarker = function(element, marker) {
 };
 
 Canvas.prototype.getRootElement = function() {
-  var plane = this.getActivePlane();
+  var rootElement = this._rootElement;
 
-  return plane.rootElement;
+  if (rootElement) {
+    return rootElement;
+  }
+
+  return this.setRootElement(this.addRootElement(null));
 };
 
+Canvas.prototype.addRootElement = function(rootElement) {
+  var idx = this._rootsIdx++;
+
+  if (!rootElement) {
+    rootElement = {
+      id: '__implicitroot_' + idx,
+      children: [],
+      isImplicit: true
+    };
+  }
+
+  var layerName = rootElement.layer = 'root-' + idx;
+
+  this._ensureValid('root', rootElement);
+
+  var layer = this.getLayer(layerName, PLANE_LAYER_INDEX);
+
+  svgAttr(layer, 'display', 'none');
+
+  this._addRoot(rootElement, layer);
+
+  this._planes.push({
+    rootElement: rootElement,
+    layer: layer
+  });
+
+  return rootElement;
+};
+
+Canvas.prototype.removeRootElement = function(rootElement) {
+
+  var plane = this._findPlaneForRoot(rootElement);
+
+  if (!plane) {
+    return;
+  }
+
+  // hook up life-cycle events
+  this._removeRoot(rootElement);
+
+  // cleanup layer
+  this._removeLayer(rootElement.layer);
+
+  // clean up plane
+  this._planes = this._planes.filter(function(plane) {
+    return plane.rootElement !== rootElement;
+  });
+};
 
 
 // root element handling //////////////////////
@@ -700,63 +580,37 @@ Canvas.prototype.getRootElement = function() {
  * Sets a given element as the new root element for the canvas
  * and returns the new root element.
  *
- * @param {Object|djs.model.Root} element
- * @param {boolean} [override] whether to override the current root element, if any
+ * @param {Object|djs.model.Root} rootElement
+ * @param {boolean} override
  *
  * @return {Object|djs.model.Root} new root element
  */
-Canvas.prototype.setRootElement = function(element, override) {
-  var activePlane = this._activePlane;
+Canvas.prototype.setRootElement = function(rootElement, override) {
 
-  if (activePlane) {
-    return this.setRootElementForPlane(element, activePlane, override);
-  } else {
-    var basePlane = this.createPlane(BASE_LAYER, element);
-
-    this.setActivePlane(basePlane);
-
-    return basePlane.rootElement;
-  }
-};
-
-
-/**
- * Sets a given element as the new root element for the canvas
- * and returns the new root element.
- *
- * @param {Object|djs.model.Root} element
- * @param {Object|djs.model.Root} plane
- * @param {boolean} [override] whether to override the current root element, if any
- *
- * @return {Object|djs.model.Root} new root element
- */
-Canvas.prototype.setRootElementForPlane = function(element, plane, override) {
-
-  if (typeof plane === 'string') {
-    plane = this.getPlane(plane);
+  if (isDefined(override)) {
+    throw new Error('override not supported');
   }
 
-  if (element) {
-    this._ensureValid('root', element);
+  if (rootElement === this._rootElement) {
+    return;
   }
 
-  var currentRoot = plane.rootElement;
+  var plane;
 
-  if (currentRoot) {
-    if (!override) {
-      throw new Error('rootElement already set, need to specify override');
-    }
-
-    this._removeRoot(currentRoot);
+  if (!rootElement) {
+    throw new Error('rootElement required');
   }
 
-  if (element) {
-    this._addRoot(element, plane);
+  plane = this._findPlaneForRoot(rootElement);
+
+  // give set add semantics for backwards compatibility
+  if (!plane) {
+    rootElement = this.addRootElement(rootElement);
   }
 
-  plane.rootElement = element;
+  this._setRoot(rootElement);
 
-  return element;
+  return rootElement;
 };
 
 
@@ -772,11 +626,9 @@ Canvas.prototype._removeRoot = function(element) {
 };
 
 
-Canvas.prototype._addRoot = function(element, plane) {
+Canvas.prototype._addRoot = function(element, gfx) {
   var elementRegistry = this._elementRegistry,
       eventBus = this._eventBus;
-
-  var gfx = plane.layer;
 
   // resemble element add event sequence
   eventBus.fire('root.add', { element: element });
@@ -784,11 +636,42 @@ Canvas.prototype._addRoot = function(element, plane) {
   elementRegistry.add(element, gfx);
 
   eventBus.fire('root.added', { element: element, gfx: gfx });
+};
 
-  // associate SVG with root element when active
-  if (plane === this._activePlane) {
-    this._elementRegistry.updateGraphics(element, this._svg, true);
+
+Canvas.prototype._setRoot = function(rootElement, layer) {
+
+  var currentRoot = this._rootElement;
+
+  var currentLayer;
+
+  if (currentRoot) {
+
+    // un-associate previous root element <svg>
+    this._elementRegistry.updateGraphics(currentRoot, null, true);
+
+    // hide previous layer
+    currentLayer = this._findPlaneForRoot(currentRoot).layer;
+
+    svgAttr(currentLayer, 'display', 'none');
   }
+
+  if (rootElement) {
+
+    if (!layer) {
+      layer = this._findPlaneForRoot(rootElement).layer;
+    }
+
+    // associate element with <svg>
+    this._elementRegistry.updateGraphics(rootElement, this._svg, true);
+
+    // show root layer
+    svgAttr(layer, 'display', null);
+  }
+
+  this._rootElement = rootElement;
+
+  this._eventBus.fire('root.set', { element: rootElement });
 };
 
 // add functionality //////////////////////
@@ -1089,6 +972,7 @@ Canvas.prototype.viewbox = function(box) {
       innerBox,
       outerBox = this.getSize(),
       matrix,
+      activeLayer,
       transform,
       scale,
       x, y;
@@ -1096,10 +980,11 @@ Canvas.prototype.viewbox = function(box) {
   if (!box) {
 
     // compute the inner box based on the
-    // diagrams active plane. This allows us to exclude
+    // diagrams active layer. This allows us to exclude
     // external components, such as overlays
 
-    innerBox = (this._activePlane && this._activePlane.layer.getBBox()) || {};
+    activeLayer = this._rootElement ? this.getActiveLayer() : null;
+    innerBox = activeLayer && activeLayer.getBBox() || {};
 
     transform = svgTransform(viewport);
     matrix = transform ? transform.matrix : createMatrix();
@@ -1182,10 +1067,11 @@ Canvas.prototype.scrollToElement = function(element, padding) {
     element = this._elementRegistry.get(element);
   }
 
-  // switch to correct Plane
-  var targetPlane = this.findPlane(element);
-  if (targetPlane !== this._activePlane) {
-    this.setActivePlane(targetPlane);
+  // set to correct rootElement
+  var rootElement = this.findRoot(element);
+
+  if (rootElement !== this.getRootElement()) {
+    this.setRootElement(rootElement);
   }
 
   if (!padding) {

--- a/lib/features/overlays/Overlays.js
+++ b/lib/features/overlays/Overlays.js
@@ -457,12 +457,12 @@ Overlays.prototype._addOverlay = function(overlay) {
     domClasses(htmlContainer).add('djs-overlay-' + overlay.type);
   }
 
-  var plane = this._canvas.findPlane(element);
-  var activePlane = this._canvas.getActivePlane();
-  overlay.plane = plane;
-  if (plane !== activePlane) {
-    setVisible(htmlContainer, false);
-  }
+  var elementRoot = this._canvas.findRoot(element);
+  var activeRoot = this._canvas.getRootElement();
+
+  overlay.rootElement = elementRoot;
+
+  setVisible(htmlContainer, elementRoot === activeRoot);
 
   overlay.htmlContainer = htmlContainer;
 
@@ -478,14 +478,14 @@ Overlays.prototype._addOverlay = function(overlay) {
 
 Overlays.prototype._updateOverlayVisibilty = function(overlay, viewbox) {
   var show = overlay.show,
-      plane = overlay.plane,
+      rootElement = overlay.rootElement,
       minZoom = show && show.minZoom,
       maxZoom = show && show.maxZoom,
       htmlContainer = overlay.htmlContainer,
-      activePlane = this._canvas.getActivePlane(),
+      activeRootElement = this._canvas.getRootElement(),
       visible = true;
 
-  if (plane !== activePlane) {
+  if (rootElement !== activeRootElement) {
     visible = false;
   } else if (show) {
     if (
@@ -621,9 +621,9 @@ Overlays.prototype._init = function() {
   });
 
 
-  eventBus.on('plane.set', function(e) {
+  eventBus.on('root.set', function(event) {
     forEach(self._overlays, function(el) {
-      setVisible(el.htmlContainer, el.plane === e.plane);
+      setVisible(el.htmlContainer, el.rootElement === event.element);
     });
   });
 

--- a/lib/features/planes/PlanesBehavior.js
+++ b/lib/features/planes/PlanesBehavior.js
@@ -2,29 +2,38 @@ import inherits from 'inherits';
 
 import CommandInterceptor from '../../command/CommandInterceptor';
 
-export default function PlanesBehaviour(canvas, eventBus, injector) {
+
+/**
+ * A modeling behavior that ensures we change the planes
+ * as we undo and redo commands.
+ *
+ * @param {Canvas} canvas
+ * @param {EventBus} eventBus
+ * @param {didi.Injector} injector
+ */
+export default function PlanesBehavior(canvas, eventBus, injector) {
 
   injector.invoke(CommandInterceptor, this);
 
   this.executed(function(event) {
     var context = event.context;
 
-    if (context.plane) {
-      canvas.setActivePlane(context.plane);
+    if (context.rootElement) {
+      canvas.setRootElement(context.rootElement);
     } else {
-      context.plane = canvas.getActivePlane();
+      context.rootElement = canvas.getRootElement();
     }
   });
 
   this.revert(function(event) {
     var context = event.context;
 
-    if (context.plane) {
-      canvas.setActivePlane(context.plane);
+    if (context.rootElement) {
+      canvas.setRootElement(context.rootElement);
     }
   });
 }
 
-inherits(PlanesBehaviour, CommandInterceptor);
+inherits(PlanesBehavior, CommandInterceptor);
 
-PlanesBehaviour.$inject = [ 'canvas', 'eventBus', 'injector'];
+PlanesBehavior.$inject = [ 'canvas', 'eventBus', 'injector'];

--- a/lib/features/planes/index.js
+++ b/lib/features/planes/index.js
@@ -1,6 +1,0 @@
-import PlanesBehavior from './PlanesBehavior';
-
-export default {
-  __init__: [ 'planesBehavior' ],
-  planesBehavior: [ 'type', PlanesBehavior ]
-};

--- a/lib/features/root-elements/RootElementsBehavior.js
+++ b/lib/features/root-elements/RootElementsBehavior.js
@@ -4,14 +4,13 @@ import CommandInterceptor from '../../command/CommandInterceptor';
 
 
 /**
- * A modeling behavior that ensures we change the planes
+ * A modeling behavior that ensures we set the correct root element
  * as we undo and redo commands.
  *
  * @param {Canvas} canvas
- * @param {EventBus} eventBus
  * @param {didi.Injector} injector
  */
-export default function PlanesBehavior(canvas, eventBus, injector) {
+export default function RootElementsBehavior(canvas, injector) {
 
   injector.invoke(CommandInterceptor, this);
 
@@ -34,6 +33,6 @@ export default function PlanesBehavior(canvas, eventBus, injector) {
   });
 }
 
-inherits(PlanesBehavior, CommandInterceptor);
+inherits(RootElementsBehavior, CommandInterceptor);
 
-PlanesBehavior.$inject = [ 'canvas', 'eventBus', 'injector'];
+RootElementsBehavior.$inject = [ 'canvas', 'injector'];

--- a/lib/features/root-elements/index.js
+++ b/lib/features/root-elements/index.js
@@ -1,0 +1,6 @@
+import RootElementsBehavior from './RootElementsBehavior';
+
+export default {
+  __init__: [ 'rootElementsBehavior' ],
+  rootElementsBehavior: [ 'type', RootElementsBehavior ]
+};

--- a/lib/features/selection/Selection.js
+++ b/lib/features/selection/Selection.js
@@ -26,7 +26,7 @@ export default function Selection(eventBus, canvas) {
     self.deselect(element);
   });
 
-  eventBus.on([ 'diagram.clear', 'plane.set' ], function(e) {
+  eventBus.on([ 'diagram.clear', 'root.set' ], function(e) {
     self.select(null);
   });
 }
@@ -79,10 +79,12 @@ Selection.prototype.select = function(elements, add) {
 
   var canvas = this._canvas;
 
-  elements = elements.filter(function(element) {
-    var plane = canvas.findPlane(element);
+  var rootElement = canvas.getRootElement();
 
-    return plane === canvas.getActivePlane();
+  elements = elements.filter(function(element) {
+    var elementRoot = canvas.findRoot(element);
+
+    return rootElement === elementRoot;
   });
 
   // selection may be cleared by passing an empty array or null

--- a/test/spec/command/CommandStackSpec.js
+++ b/test/spec/command/CommandStackSpec.js
@@ -622,7 +622,7 @@ describe('command/CommandStack', function() {
       // then
       expect(function() {
         commandStack.undo();
-      }).not.to.throw;
+      }).not.to.throw();
     }));
 
   });

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -671,6 +671,16 @@ describe('Canvas', function() {
 
     describe('layers', function() {
 
+      it('should require layer name', inject(function(canvas) {
+
+        // then
+        expect(function() {
+          canvas.getLayer();
+        }).to.throw(/must specify a name/);
+
+      }));
+
+
       it('should create layer below utility planes', inject(function(canvas) {
 
         // given

--- a/test/spec/features/interaction-events/InteractionEventsSpec.js
+++ b/test/spec/features/interaction-events/InteractionEventsSpec.js
@@ -247,7 +247,7 @@ describe('features/interaction-events', function() {
           interactionEvents.unregisterEvent(
             node, 'mousemove', 'element.mousemove'
           );
-        }).not.to.throw;
+        }).not.to.throw();
       }
     ));
 

--- a/test/spec/features/overlays/OverlaysSpec.js
+++ b/test/spec/features/overlays/OverlaysSpec.js
@@ -631,11 +631,13 @@ describe('features/overlays', function() {
       }));
 
 
-      it('should not display overlays on hidden plane', inject(function(overlays, canvas) {
+      it('should hide on hidden plane', inject(function(overlays, canvas) {
 
         // given
-        canvas.createPlane('a');
-        canvas.setActivePlane('a');
+        var rootA = canvas.addRootElement({ id: 'a' });
+
+        canvas.setRootElement(rootA);
+
         var html = createOverlay();
 
         // when
@@ -649,10 +651,11 @@ describe('features/overlays', function() {
       }));
 
 
-      it('should hide overlays when switching planes', inject(function(overlays, canvas) {
+      it('should hide when switching planes', inject(function(overlays, canvas) {
 
         // given
-        canvas.createPlane('a');
+        var rootA = canvas.addRootElement({ id: 'a' });
+
         var html = createOverlay();
 
         overlays.add(shape, {
@@ -661,17 +664,38 @@ describe('features/overlays', function() {
         });
 
         // when
-        canvas.setActivePlane('a');
+        canvas.setRootElement(rootA);
 
         // then
         expect(isVisible(html)).to.be.false;
+      }));
+
+
+      it('should show when switching plane', inject(function(overlays, canvas) {
+
+        // given
+        canvas.setRootElement({ id: 'a' });
+
+        var html = createOverlay();
+
+        // when
+        overlays.add(shape, {
+          html: html,
+          position: { left: 20, bottom: 0 }
+        });
+
+        // when
+        canvas.setRootElement(shape.parent);
+
+        // then
+        expect(isVisible(html)).to.be.true;
       }));
 
 
       it('should override `show` when switching planes', inject(function(overlays, canvas) {
 
         // given
-        canvas.createPlane('a');
+        var rootA = canvas.addRootElement({ id: 'a' });
         var html = createOverlay();
 
         overlays.add(shape, {
@@ -687,7 +711,7 @@ describe('features/overlays', function() {
         expect(isVisible(html)).to.be.true;
 
         // when
-        canvas.setActivePlane('a');
+        canvas.setRootElement(rootA);
         canvas.zoom(1);
 
         // then

--- a/test/spec/features/palette/PaletteSpec.js
+++ b/test/spec/features/palette/PaletteSpec.js
@@ -111,7 +111,7 @@ describe('features/palette', function() {
       // then
       expect(function() {
         palette.registerProvider(provider);
-      }).not.to.throw;
+      }).not.to.throw();
     }));
 
 

--- a/test/spec/features/planes/PlanesBehaviorSpec.js
+++ b/test/spec/features/planes/PlanesBehaviorSpec.js
@@ -41,14 +41,14 @@ describe('features/planes/PlanesBehavior', function() {
 
       // given
       modeling.removeShape(shape1);
-      canvas.createPlane('1');
-      canvas.setActivePlane('1');
+
+      canvas.setRootElement(canvas.addRootElement(null));
 
       // when
       commandStack.undo();
 
       // then
-      expect(canvas.getActivePlane().name).to.equal('base');
+      expect(canvas.getRootElement()).to.equal(shape1.parent);
     }));
 
   });
@@ -59,16 +59,19 @@ describe('features/planes/PlanesBehavior', function() {
     it('should switch to affected plane', inject(function(canvas, modeling, commandStack) {
 
       // given
-      canvas.createPlane('1');
+      var rootElement = canvas.getRootElement();
+
+      var otherRootElement = canvas.addRootElement(null);
+
       modeling.removeShape(shape1);
       commandStack.undo();
-      canvas.setActivePlane('1');
+      canvas.setRootElement(otherRootElement);
 
       // when
       commandStack.redo();
 
       // then
-      expect(canvas.getActivePlane().name).to.equal('base');
+      expect(canvas.getRootElement()).to.equal(rootElement);
     }));
 
   });

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -397,7 +397,9 @@ describe('features/popup', function() {
       popupMenu.close();
 
       // then
-      expect(popupMenu.close).not.to.throw;
+      expect(function() {
+        popupMenu.close();
+      }).not.to.throw();
     }));
 
   });

--- a/test/spec/features/root-elements/RootElementsBehaviorSpec.js
+++ b/test/spec/features/root-elements/RootElementsBehaviorSpec.js
@@ -6,17 +6,17 @@ import {
 import coreModule from 'lib/core';
 import commandModule from 'lib/command';
 import modelingModule from 'lib/features/modeling';
-import planesModule from 'lib/features/planes';
+import rootElementsModule from 'lib/features/root-elements';
 
 
-describe('features/planes/PlanesBehavior', function() {
+describe('features/planes/RootElementsBehavior', function() {
 
   beforeEach(bootstrapDiagram({
     modules: [
       coreModule,
       commandModule,
       modelingModule,
-      planesModule
+      rootElementsModule
     ]
   }));
 
@@ -37,7 +37,7 @@ describe('features/planes/PlanesBehavior', function() {
 
   describe('undo', function() {
 
-    it('should switch to affected plane', inject(function(canvas, modeling, commandStack) {
+    it('should switch to affected root', inject(function(canvas, modeling, commandStack) {
 
       // given
       modeling.removeShape(shape1);
@@ -56,7 +56,7 @@ describe('features/planes/PlanesBehavior', function() {
 
   describe('redo', function() {
 
-    it('should switch to affected plane', inject(function(canvas, modeling, commandStack) {
+    it('should switch to affected root', inject(function(canvas, modeling, commandStack) {
 
       // given
       var rootElement = canvas.getRootElement();

--- a/test/spec/features/selection/SelectionSpec.js
+++ b/test/spec/features/selection/SelectionSpec.js
@@ -155,8 +155,7 @@ describe('features/selection/Selection', function() {
     it('should not select elements on other plane', inject(function(canvas, selection) {
 
       // given
-      var shapeRoot = { id: 'root' };
-      canvas.createPlane('a', shapeRoot);
+      var shapeRoot = canvas.addRootElement({ id: 'root' });
 
       var shape3 = canvas.addShape({
         id: 'shape3',

--- a/test/spec/features/tooltips/TooltipsSpec.js
+++ b/test/spec/features/tooltips/TooltipsSpec.js
@@ -134,7 +134,7 @@ describe('features/tooltips', function() {
 
       expect(function() {
         tooltips.remove('non-existing');
-      }).not.to.throw;
+      }).not.to.throw();
 
     }));
 


### PR DESCRIPTION
This adds the capability to add multiple root elements to the Canvas. 
As a side-effect, it drops our leaky plane abstraction from the public 
API.

The following `Canvas` APIs make the magic happen:

* `Canvas#addRootElement` - add a root element without showing it

* `Canvas#removeRootElement` - remove a root element

* `Canvas#setRootElement` - set to a specific root element; for 
  backwards compatibility the add-during-set semantic is kept

* `Canvas#getRootElements` - returns a list of root elements that can 
  be switched to

Under the hood we continue to rely on root element specific layers.
However, we clean these layers up once the root element is removed.

---

#### BREAKING CHANGES:

* All plane related APIs got removed, use the newly introduced
  `(add|set)RootElement` APIs to accomplish the same thing.
* INTERNAL: Every root element gets it's own layer now; there is no 
  magic re-use of the BASE_LAYER happening anymore.
* `setRootElement` does not have single root semantics anymore. As such, 
  it does not blow up if a non-existing root is being passed; rather, it 
  adds that new root and shows it.
* `setRootElement` has on `override` semantics anymore. To replace the 
  current root, set a new root and remove the old one.

----

#### TODO

* [x] Don't make `set***` have add semantics

---

Closes https://github.com/bpmn-io/diagram-js/issues/600