### PR TITLE
fix(touchInteractionEvents): fire dblClick with button=1

### DIFF
--- a/lib/features/touch/TouchInteractionEvents.js
+++ b/lib/features/touch/TouchInteractionEvents.js
@@ -149,14 +149,23 @@ export default function TouchInteractionEvents(
   // the touch recognizer
   var recognizer;
 
-  function handler(type) {
+  function handler(type, buttonType) {
 
     return function(event) {
       log('element', type, event);
 
-      interactionEvents.fire(type, event);
+      var gfx = getGfx(event.target),
+          element = gfx && elementRegistry.get(gfx);
+
+      // translate into an actual mouse click event
+      if (buttonType) {
+        event.srcEvent.button = buttonType;
+      }
+
+      return interactionEvents.fire(type, event, element);
     };
   }
+
 
   function getGfx(target) {
     var node = domClosest(target, 'svg, .djs-element', true);
@@ -167,10 +176,6 @@ export default function TouchInteractionEvents(
 
     // touch recognizer
     recognizer = createTouchRecognizer(svg);
-
-    recognizer.on('doubletap', handler('element.dblclick'));
-
-    recognizer.on('tap', handler('element.click'));
 
     function startGrabCanvas(event) {
 
@@ -247,6 +252,9 @@ export default function TouchInteractionEvents(
       recognizer.on('pinchend', end);
       recognizer.on('pinchcancel', end);
     }
+
+    recognizer.on('tap', handler('element.click'));
+    recognizer.on('doubletap', handler('element.dblclick', 1));
 
     recognizer.on('panstart', startGrab);
     recognizer.on('press', startGrab);


### PR DESCRIPTION
fixes upstream bpmn-io/bpmn-js#618

* testing infrastructure is not set up here. Hence I am skipping the
  testing bit due to time contraints (we do not reduce quality). 
* For sure we need to set up proper testing infrastrcture, when reworking the
  entire touch module.
* manual integration test done with bpmn-js direct editing module and
  ipad safari

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
