### PR TITLE
fix(snapping): use existing color variable

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -75,7 +75,7 @@
   --shape-drop-not-allowed-fill-color: var(--color-red-360-100-97);
   --shape-resize-preview-stroke-color: var(--color-blue-205-100-50);
 
-  --snap-line-stroke-color: var(--color-blue-205-100-50-opacity-30);
+  --snap-line-stroke-color: var(--color-blue-205-100-45-opacity-30);
 
   --space-tool-crosshair-stroke-color: var(--color-black);
 


### PR DESCRIPTION
related to https://github.com/bpmn-io/bpmn-js/issues/1564


This is caused by referencing a non-existing color variable. I used `color-blue-205-100-45-opacity-30` instead of adding a new one as the existing one is very close to the requested one
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
