### PR TITLE
fix(overlays): ensure overlays update on root change

### DIFF
--- a/lib/features/overlays/Overlays.js
+++ b/lib/features/overlays/Overlays.js
@@ -620,7 +620,7 @@ Overlays.prototype._init = function() {
 
 
   eventBus.on('root.set', function() {
-    self._updateOverlaysVisibilty();
+    self._updateOverlaysVisibilty(self._canvas.viewbox());
   });
 
   // clear overlays with diagram

--- a/test/spec/features/overlays/OverlaysSpec.js
+++ b/test/spec/features/overlays/OverlaysSpec.js
@@ -643,7 +643,10 @@ describe('features/overlays', function() {
         // when
         overlays.add(shape, {
           html: html,
-          position: { left: 20, bottom: 0 }
+          position: { left: 20, bottom: 0 },
+          show: {
+            minZoom: 0.5
+          }
         });
 
         // then
@@ -660,7 +663,10 @@ describe('features/overlays', function() {
 
         overlays.add(shape, {
           html: html,
-          position: { left: 20, bottom: 0 }
+          position: { left: 20, bottom: 0 },
+          show: {
+            minZoom: 0.5
+          }
         });
 
         // when
@@ -681,7 +687,10 @@ describe('features/overlays', function() {
         // when
         overlays.add(shape, {
           html: html,
-          position: { left: 20, bottom: 0 }
+          position: { left: 20, bottom: 0 },
+          show: {
+            minZoom: 0.5
+          }
         });
 
         // when


### PR DESCRIPTION
Overlay update fails when `show` is used, because the viewbox is missing here: https://github.com/bpmn-io/diagram-js/blob/develop/lib/features/overlays/Overlays.js#L489-L492

I adjusted existing tests to fail in this scenario instead of creating new ones.

closes #614

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
