### PR TITLE
fix(canvas): `getRootElement` returns null during import

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -344,12 +344,18 @@ Canvas.prototype._removeLayer = function(name) {
 };
 
 /**
- * Returns the currently active layer
+ * Returns the currently active layer. Can be null.
  *
- * @returns {SVGElement}
+ * @returns {SVGElement|null}
  */
 Canvas.prototype.getActiveLayer = function() {
-  return this._findPlaneForRoot(this.getRootElement()).layer;
+  var plane = this._findPlaneForRoot(this.getRootElement());
+
+  if (!plane) {
+    return null;
+  }
+
+  return plane.layer;
 };
 
 

--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -517,12 +517,23 @@ Canvas.prototype.toggleMarker = function(element, marker) {
 /**
  * Returns the current root element.
  *
- * @returns {Object|djs.model.Root} rootElement.
+ * Supports two different modes for handling root elements:
+ *
+ * 1. if no root element has been added before, an implicit root will be added
+ * and returned. This is used in applications that don't require explicit
+ * root elements.
+ *
+ * 2. when root elements have been added before calling `getRootElement`,
+ * root elements can be null. This is used for applications that want to manage
+ * root elements themselves.
+ *
+ * @returns {Object|djs.model.Root|null} rootElement.
  */
 Canvas.prototype.getRootElement = function() {
   var rootElement = this._rootElement;
 
-  if (rootElement) {
+  // can return null if root elements are present but none was set yet
+  if (rootElement || this._planes.length) {
     return rootElement;
   }
 

--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -599,13 +599,18 @@ Canvas.prototype.removeRootElement = function(rootElement) {
   // hook up life-cycle events
   this._removeRoot(rootElement);
 
-  // cleanup layer
+  // clean up layer
   this._removeLayer(rootElement.layer);
 
   // clean up plane
   this._planes = this._planes.filter(function(plane) {
     return plane.rootElement !== rootElement;
   });
+
+  // clean up active root
+  if (this._rootElement === rootElement) {
+    this._rootElement = null;
+  }
 
   return rootElement;
 };

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -545,6 +545,21 @@ describe('Canvas', function() {
     }));
 
 
+    it('should not create implicit roots when explicit elements are present',
+      inject(function(canvas) {
+
+        // given
+        // root element is added but not set yet
+        canvas.addRootElement({ id: 'foo' });
+
+        // when
+        var rootElement = canvas.getRootElement();
+
+        // then
+        expect(rootElement).not.to.exist;
+      }));
+
+
     it('should use implicit root element', inject(function(canvas) {
 
       // when

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -2240,6 +2240,25 @@ describe('Canvas', function() {
         expect(activeLayer).to.eql(aLayer);
       }));
 
+
+      it('should not get layer when none is active',
+        inject(function(canvas) {
+
+          // given
+          var rootA = canvas.addRootElement({ id: 'a' });
+
+          // when
+          var activeLayer = canvas.getActiveLayer();
+
+          // then
+          expectLayersOrder(canvas._viewport, [
+            rootA
+          ]);
+
+          expect(activeLayer).not.to.exist;
+        })
+      );
+
     });
 
 

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -686,6 +686,28 @@ describe('Canvas', function() {
       }));
 
 
+      it('should remove active root', inject(function(canvas) {
+
+        // given
+        var root = canvas.setRootElement({ id: 'root' });
+        var otherRoot = canvas.addRootElement({ id: 'otherRoot' });
+
+        // when
+        canvas.removeRootElement(root);
+
+        // then
+        expect(canvas.getRootElement()).to.not.exist;
+
+        expect(canvas.getRootElements()).to.eql([
+          otherRoot
+        ]);
+
+        expectLayersOrder(canvas._viewport, [
+          otherRoot
+        ]);
+      }));
+
+
       it('should return removed root element', inject(function(canvas) {
 
         // given


### PR DESCRIPTION
This PR fixes the following scenario:

1. In bpmn-js, we import all diagrams without setting an active root element
2. Once all imports are done, we set the root element (either a process or subprocess)
3. If an extensions reacts to `shape.add` during import and uses `canvas.getRootElement()`, an implicit root is created

Therefore, we do not want to create implicit roots when root elements are already present but not active.
We still ensure that we support simple use-cases, where no explicit root element is needed.
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
