### PR TITLE
fix(keyboard): don't use ES6 code

### DIFF
--- a/lib/features/keyboard/Keyboard.js
+++ b/lib/features/keyboard/Keyboard.js
@@ -118,7 +118,7 @@ Keyboard.prototype._isModifiedKeyIgnored = function(event) {
   }
 
   var allowedModifiers = this._getAllowedModifiers(event.target);
-  return !allowedModifiers.includes(event.key);
+  return allowedModifiers.indexOf(event.key) === -1;
 };
 
 Keyboard.prototype._getAllowedModifiers = function(element) {


### PR DESCRIPTION
Webpack polyfills `array.includes`, so our phantomJS tests are green even when they should not be.

https://github.com/bpmn-io/diagram-js/blob/develop/package-lock.json#L3385

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
