### PR TITLE
feat(canvas): add API to hide/show layers

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -303,6 +303,25 @@ Canvas.prototype.getLayer = function(name, index) {
 };
 
 /**
+ * For a given index, return the number of layers that have a higher index and
+ * are visible.
+ *
+ * This is used to determine the node a layer should be inserted at.
+ *
+ * @param {Number} index
+ * @returns {Number}
+ */
+Canvas.prototype._getChildIndex = function(index) {
+  return reduce(this._layers, function(childIndex, layer) {
+    if (layer.visible && index >= layer.index) {
+      childIndex++;
+    }
+
+    return childIndex;
+  }, 0);
+};
+
+/**
  * Creates a given layer and returns it.
  *
  * @param {string} name
@@ -316,19 +335,80 @@ Canvas.prototype._createLayer = function(name, index) {
     index = UTILITY_LAYER_INDEX;
   }
 
-  var childIndex = reduce(this._layers, function(childIndex, layer) {
-    if (index >= layer.index) {
-      childIndex++;
-    }
-
-    return childIndex;
-  }, 0);
+  var childIndex = this._getChildIndex(index);
 
   return {
     group: createGroup(this._viewport, 'layer-' + name, childIndex),
-    index: index
+    index: index,
+    visible: true
   };
+};
 
+
+/**
+ * Shows a given layer.
+ *
+ * @param {String} layer
+ * @returns {SVGElement}
+ */
+Canvas.prototype.showLayer = function(name) {
+
+  if (!name) {
+    throw new Error('must specify a name');
+  }
+
+  var layer = this._layers[name];
+
+  if (!layer) {
+    throw new Error('layer <' + name + '> does not exist');
+  }
+
+  var viewport = this._viewport;
+  var group = layer.group;
+  var index = layer.index;
+
+  if (layer.visible) {
+    return group;
+  }
+
+  var childIndex = this._getChildIndex(index);
+
+  viewport.insertBefore(group, viewport.childNodes[childIndex] || null);
+
+  layer.visible = true;
+
+  return group;
+};
+
+/**
+ * Hides a given layer.
+ *
+ * @param {String} layer
+ * @returns {SVGElement}
+ */
+Canvas.prototype.hideLayer = function(name) {
+
+  if (!name) {
+    throw new Error('must specify a name');
+  }
+
+  var layer = this._layers[name];
+
+  if (!layer) {
+    throw new Error('layer <' + name + '> does not exist');
+  }
+
+  var group = layer.group;
+
+  if (!layer.visible) {
+    return group;
+  }
+
+  svgRemove(group);
+
+  layer.visible = false;
+
+  return group;
 };
 
 
@@ -571,7 +651,7 @@ Canvas.prototype.addRootElement = function(rootElement) {
 
   var layer = this.getLayer(layerName, PLANE_LAYER_INDEX);
 
-  svgAttr(layer, 'display', 'none');
+  this.hideLayer(layerName);
 
   this._addRoot(rootElement, layer);
 
@@ -690,17 +770,13 @@ Canvas.prototype._setRoot = function(rootElement, layer) {
 
   var currentRoot = this._rootElement;
 
-  var currentLayer;
-
   if (currentRoot) {
 
     // un-associate previous root element <svg>
     this._elementRegistry.updateGraphics(currentRoot, null, true);
 
     // hide previous layer
-    currentLayer = this._findPlaneForRoot(currentRoot).layer;
-
-    svgAttr(currentLayer, 'display', 'none');
+    this.hideLayer(currentRoot.layer);
   }
 
   if (rootElement) {
@@ -713,7 +789,7 @@ Canvas.prototype._setRoot = function(rootElement, layer) {
     this._elementRegistry.updateGraphics(rootElement, this._svg, true);
 
     // show root layer
-    svgAttr(layer, 'display', null);
+    this.showLayer(rootElement.layer);
   }
 
   this._rootElement = rootElement;

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -742,31 +742,19 @@ describe('Canvas', function() {
 
     describe('layers', function() {
 
-      it('should require layer name', inject(function(canvas) {
-
-        // then
-        expect(function() {
-          canvas.getLayer();
-        }).to.throw(/must specify a name/);
-
-      }));
-
-
       it('should create layer below utility planes', inject(function(canvas) {
 
         // given
         canvas.getLayer('foo');
 
         // when
-        var rootA = canvas.addRootElement({ id: 'A' });
-        var rootB = canvas.addRootElement({ id: 'B' });
+        var rootA = canvas.setRootElement({ id: 'A' });
 
         canvas.getLayer('bar');
 
         // then
         expectLayersOrder(canvas._viewport, [
           rootA,
-          rootB,
           'foo',
           'bar'
         ]);
@@ -776,17 +764,58 @@ describe('Canvas', function() {
       it('should create layer with default priority', inject(function(canvas) {
 
         // when
-        var rootA = canvas.addRootElement({ id: 'A' });
         canvas.getDefaultLayer();
-        var rootB = canvas.addRootElement({ id: 'B' });
+        var rootA = canvas.setRootElement({ id: 'A' });
 
         // then
         expectLayersOrder(canvas._viewport, [
-          rootA,
           'base',
-          rootB
+          rootA
         ]);
       }));
+
+      describe('visibility', function() {
+
+        it('should hide by default', inject(function(canvas) {
+
+          // when
+          canvas.addRootElement({ id: 'A' });
+
+          // then
+          expectLayersOrder(canvas._viewport, []);
+        }));
+
+
+        it('should show active root', inject(function(canvas) {
+
+          // given
+          var rootA = canvas.addRootElement({ id: 'A' });
+
+          // when
+          canvas.setRootElement(rootA);
+
+          // then
+          expectLayersOrder(canvas._viewport, [ rootA ]);
+        }));
+
+
+        it('should hide inactive root', inject(function(canvas) {
+
+          // given
+          var rootA = canvas.setRootElement({ id: 'A' });
+          var rootB = canvas.addRootElement({ id: 'B' });
+
+          // assume
+          expectLayersOrder(canvas._viewport, [ rootA ]);
+
+          // when
+          canvas.setRootElement(rootB);
+
+          // then
+          expectLayersOrder(canvas._viewport, [ rootB ]);
+        }));
+
+      });
 
     });
 
@@ -2189,6 +2218,16 @@ describe('Canvas', function() {
     beforeEach(createDiagram({ canvas: { width: 300, height: 300 } }));
 
 
+    it('should require layer name', inject(function(canvas) {
+
+      // then
+      expect(function() {
+        canvas.getLayer();
+      }).to.throw(/must specify a name/);
+
+    }));
+
+
     it('get default layer', inject(function(canvas) {
 
       // when
@@ -2258,6 +2297,127 @@ describe('Canvas', function() {
           expect(activeLayer).not.to.exist;
         })
       );
+
+    });
+
+
+    describe('visibility', function() {
+
+      it('should show layer by default', inject(function(canvas) {
+
+        // when
+        canvas.getLayer('foo');
+
+        // then
+        expectLayersOrder(canvas._viewport, [
+          'foo'
+        ]);
+      }));
+
+
+      describe('#hideLayer', function() {
+
+        it('should require a name', inject(function(canvas) {
+
+          // then
+          expect(function() {
+            canvas.hideLayer();
+          }).to.throw('must specify a name');
+
+        }));
+
+
+        it('should require the layer to exist', inject(function(canvas) {
+
+          // then
+          expect(function() {
+            canvas.hideLayer('FOO');
+          }).to.throw('layer <FOO> does not exist');
+
+        }));
+
+
+        it('should hide layer', inject(function(canvas) {
+
+          // given
+          canvas.getLayer('1');
+          canvas.getLayer('2');
+
+          // when
+          canvas.hideLayer('2');
+
+          // then
+          expectLayersOrder(canvas._viewport, [
+            '1'
+          ]);
+
+        }));
+
+      });
+
+
+      describe('#showLayer', function() {
+
+        it('should require a name', inject(function(canvas) {
+
+          // then
+          expect(function() {
+            canvas.showLayer();
+          }).to.throw('must specify a name');
+
+        }));
+
+
+        it('should require the layer to exist', inject(function(canvas) {
+
+          // then
+          expect(function() {
+            canvas.showLayer('FOO');
+          }).to.throw('layer <FOO> does not exist');
+
+        }));
+
+
+        it('should show layer', inject(function(canvas) {
+
+          // given
+          canvas.getLayer('1');
+          canvas.getLayer('2');
+
+          // when
+          canvas.hideLayer('2');
+          canvas.showLayer('2');
+
+          // then
+          expectLayersOrder(canvas._viewport, [
+            '1',
+            '2'
+          ]);
+
+        }));
+
+
+        it('should consider the index', inject(function(canvas) {
+
+          // given
+          canvas.getLayer('1', 1);
+          canvas.getLayer('2', 2);
+          canvas.getLayer('3', 3);
+
+          // when
+          canvas.hideLayer('2');
+          canvas.showLayer('2');
+
+          // then
+          expectLayersOrder(canvas._viewport, [
+            '1',
+            '2',
+            '3'
+          ]);
+
+        }));
+
+      });
 
     });
 


### PR DESCRIPTION
For performance reasons, we only want to have layers of visible object present in the DOM tree. For the reasoning behind it, please see the comment in the platform repo: https://github.com/camunda/camunda-modeler/issues/2803#issuecomment-1059163820

You can now:
 - Hide layers (internal implementation: remove them from the DOM tree)
 - Show layers (internal implementation: add them to the DOM tree again)

By default, every layer is visible. We explicitly have to hide them, e.g. when adding an inactive `rootElement`

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
