### PR TITLE
fix(context-pad): robust position in line-height != 1 scenarios

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -477,6 +477,7 @@ marker.djs-dragger tspan {
   position: absolute;
   display: none;
   pointer-events: none;
+  line-height: 1;
 }
 
 .djs-context-pad .entry {
@@ -494,10 +495,7 @@ marker.djs-dragger tspan {
   background-color: var(--context-pad-entry-background-color);
   box-shadow: 0 0 2px 1px var(--context-pad-entry-background-color);
   pointer-events: all;
-}
-
-.djs-context-pad .entry:before {
-  vertical-align: top;
+  vertical-align: middle;
 }
 
 .djs-context-pad .entry:hover {


### PR DESCRIPTION
The current context pad styles are prone to break in environments where line-height is != 1.

I.e. reproducible on `demo.bpmn.io` if `body { line-height: 10; }` is added as a CSS directive.

This PR fixes the behavior; it also ensures that mixed images + icon fonts (appropriately sized) are aligned:

_Chrome_

![screenshot 2BZAvz](https://user-images.githubusercontent.com/58601/159777973-6bb3b36f-4209-4382-a35d-e4aae4afd5e2.png)

_Firefox_

![screenshot ORLSCZ](https://user-images.githubusercontent.com/58601/159778006-29fbe0f3-9b56-4a2a-a768-2ac9fbbcb994.png)
