### PR TITLE
fix(context-pad): robust position in line-height != 1 scenarios #630

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+## 7.8.3
+
+* `FIX`: make context pad robust in `line-height != 1` environments ([#631](https://github.com/bpmn-io/diagram-js/pull/631))
+
 ## 7.8.2
 
 - `FIX`: use know color for snap line ([#609](https://github.com/bpmn-io/diagram-js/pull/609))

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -477,6 +477,7 @@ marker.djs-dragger tspan {
   position: absolute;
   display: none;
   pointer-events: none;
+  line-height: 1;
 }
 
 .djs-context-pad .entry {
@@ -494,10 +495,7 @@ marker.djs-dragger tspan {
   background-color: var(--context-pad-entry-background-color);
   box-shadow: 0 0 2px 1px var(--context-pad-entry-background-color);
   pointer-events: all;
-}
-
-.djs-context-pad .entry:before {
-  vertical-align: top;
+  vertical-align: middle;
 }
 
 .djs-context-pad .entry:hover {


### PR DESCRIPTION
Backports https://github.com/bpmn-io/diagram-js/pull/630 to `7.x`.