### PR TITLE
fix: comply with style-src CSP

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -11,6 +11,10 @@ import {
 } from 'min-dash';
 
 import {
+  assignStyle
+} from 'min-dom';
+
+import {
   add as collectionAdd,
   remove as collectionRemove
 } from '../util/Collections';
@@ -69,7 +73,7 @@ function createContainer(options) {
   var parent = document.createElement('div');
   parent.setAttribute('class', 'djs-container');
 
-  assign(parent.style, {
+  assignStyle(parent, {
     position: 'relative',
     overflow: 'hidden',
     width: ensurePx(options.width),

--- a/lib/features/overlays/Overlays.js
+++ b/lib/features/overlays/Overlays.js
@@ -11,6 +11,7 @@ import {
 } from 'min-dash';
 
 import {
+  assignStyle,
   domify,
   classes as domClasses,
   attr as domAttr,
@@ -378,7 +379,8 @@ Overlays.prototype._updateOverlay = function(overlay) {
 
 
 Overlays.prototype._createOverlayContainer = function(element) {
-  var html = domify('<div class="djs-overlays" style="position: absolute" />');
+  var html = domify('<div class="djs-overlays" />');
+  assignStyle(html, { position: 'absolute' });
 
   this._overlayRoot.appendChild(html);
 
@@ -449,7 +451,8 @@ Overlays.prototype._addOverlay = function(overlay) {
 
   overlayContainer = this._getOverlayContainer(element);
 
-  htmlContainer = domify('<div class="djs-overlay" data-overlay-id="' + id + '" style="position: absolute">');
+  htmlContainer = domify('<div class="djs-overlay" data-overlay-id="' + id + '">');
+  assignStyle(htmlContainer, { position: 'absolute' });
 
   htmlContainer.appendChild(html);
 
@@ -634,8 +637,14 @@ Overlays.prototype._init = function() {
 
 function createRoot(parentNode) {
   var root = domify(
-    '<div class="djs-overlay-container" style="position: absolute; width: 0; height: 0;" />'
+    '<div class="djs-overlay-container" />'
   );
+
+  assignStyle(root, {
+    position: 'absolute',
+    width: 0,
+    height: 0
+  });
 
   parentNode.insertBefore(root, parentNode.firstChild);
 
@@ -643,7 +652,7 @@ function createRoot(parentNode) {
 }
 
 function setPosition(el, x, y) {
-  assign(el.style, { left: x + 'px', top: y + 'px' });
+  assignStyle(el, { left: x + 'px', top: y + 'px' });
 }
 
 function setVisible(el, visible) {

--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -8,6 +8,7 @@ import {
 } from 'min-dash';
 
 import {
+  assignStyle,
   delegate as domDelegate,
   domify as domify,
   classes as domClasses,
@@ -357,7 +358,7 @@ PopupMenu.prototype._createContainer = function() {
       position = this._current.position,
       className = this._current.className;
 
-  assign(container.style, {
+  assignStyle(container, {
     position: 'absolute',
     left: position.x + 'px',
     top: position.y + 'px',
@@ -480,7 +481,7 @@ PopupMenu.prototype._assureIsInbounds = function(container, cursor) {
     top = cursorPosition.y - containerHeight + 'px';
   }
 
-  assign(container.style, { left: left, top: top }, { visibility: 'visible', 'z-index': 1000 });
+  assignStyle(container, { left: left, top: top }, { visibility: 'visible', 'zIndex': 1000 });
 };
 
 

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -1,4 +1,5 @@
 import {
+  assignStyle,
   clear as domClear,
   delegate as domDelegate,
   query as domQuery,
@@ -447,10 +448,14 @@ function constructOverlay(box) {
   var w = box.width + offset * 2;
   var h = box.height + offset * 2;
 
-  var styles = [
-    'width: ' + w + 'px',
-    'height: ' + h + 'px'
-  ].join('; ');
+  var styles = {
+    width: w + 'px',
+    height: h + 'px'
+  };
+
+  var html = domify('<div class="' + SearchPad.OVERLAY_CLASS + '"></div>');
+
+  assignStyle(html, styles);
 
   return {
     position: {
@@ -458,7 +463,7 @@ function constructOverlay(box) {
       right: w - offset
     },
     show: true,
-    html: '<div style="' + styles + '" class="' + SearchPad.OVERLAY_CLASS + '"></div>'
+    html: html
   };
 }
 

--- a/lib/features/tooltips/Tooltips.js
+++ b/lib/features/tooltips/Tooltips.js
@@ -5,6 +5,7 @@ import {
 } from 'min-dash';
 
 import {
+  assignStyle,
   domify,
   attr as domAttr,
   classes as domClasses,
@@ -20,8 +21,14 @@ var ids = new Ids('tt');
 
 function createRoot(parentNode) {
   var root = domify(
-    '<div class="djs-tooltip-container" style="position: absolute; width: 0; height: 0;" />'
+    '<div class="djs-tooltip-container" />'
   );
+
+  assignStyle(root, {
+    position: 'absolute',
+    width: '0',
+    height: '0'
+  });
 
   parentNode.insertBefore(root, parentNode.firstChild);
 
@@ -30,7 +37,7 @@ function createRoot(parentNode) {
 
 
 function setPosition(el, x, y) {
-  assign(el.style, { left: x + 'px', top: y + 'px' });
+  assignStyle(el, { left: x + 'px', top: y + 'px' });
 }
 
 function setVisible(el, visible) {
@@ -294,7 +301,8 @@ Tooltips.prototype._addTooltip = function(tooltip) {
     html = domify(html);
   }
 
-  htmlContainer = domify('<div data-tooltip-id="' + id + '" class="' + tooltipClass + '" style="position: absolute">');
+  htmlContainer = domify('<div data-tooltip-id="' + id + '" class="' + tooltipClass + '">');
+  assignStyle(htmlContainer, { position: 'absolute' });
 
   htmlContainer.appendChild(html);
 

--- a/lib/util/Text.js
+++ b/lib/util/Text.js
@@ -197,7 +197,8 @@ function getHelperSvg() {
       id: 'helper-svg',
       width: 0,
       height: 0,
-      style: 'visibility: hidden; position: fixed'
+      visibility: 'hidden',
+      position: 'fixed'
     });
 
     document.body.appendChild(helperSvg);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1918,9 +1918,9 @@
       }
     },
     "domify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.0.tgz",
-      "integrity": "sha1-EUg2F/dk+GlZdbS9x5sU8IA7Yps="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.1.tgz",
+      "integrity": "sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -4271,14 +4271,15 @@
       "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
     },
     "min-dom": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.1.3.tgz",
-      "integrity": "sha512-Lbi1NZjLV9Hg6/bEe2Lfk2Fzsv1MwheR61whqTLP+FxLndYo9TxpksEgM5Kr1khjfCtFTMr0waeEfwIpStkRdw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.0.tgz",
+      "integrity": "sha512-IUNBVNMFR0fND5RM2rBPqTG/qch8SOWtxpNgc2L+yHqp8raz3tEoe9SfXObHuidyLSMrbF7gSnBPrFGaUHBnHg==",
       "requires": {
         "component-event": "^0.1.4",
         "domify": "^1.3.1",
         "indexof": "0.0.1",
-        "matches-selector": "^1.2.0"
+        "matches-selector": "^1.2.0",
+        "min-dash": "^3.8.1"
       }
     },
     "minimatch": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "hammerjs": "^2.0.1",
     "inherits": "^2.0.4",
     "min-dash": "^3.5.2",
-    "min-dom": "^3.1.3",
+    "min-dom": "^3.2.0",
     "object-refs": "^0.3.0",
     "path-intersection": "^2.2.1",
     "tiny-svg": "^2.2.2"

--- a/test/spec/features/overlays/OverlaysSpec.js
+++ b/test/spec/features/overlays/OverlaysSpec.js
@@ -10,7 +10,8 @@ import {
 } from 'min-dash';
 
 import {
-  domify
+  domify,
+  assignStyle
 } from 'min-dom';
 
 import overlayModule from 'lib/features/overlays';
@@ -1333,7 +1334,7 @@ function isVisible(element) {
 }
 
 function highlight(element) {
-  assign(element.style, { background: 'fuchsia', minWidth: '10px', minHeight: '10px' });
+  assignStyle(element, { background: 'fuchsia', minWidth: '10px', minHeight: '10px' });
   return element;
 }
 
@@ -1343,7 +1344,7 @@ function queryOverlay(id) {
 
 function createOverlay() {
   var element = highlight(domify('<div>OV<br/>#' + (overlaysCounter++) + '</div>'));
-  assign(element.style, { width: 40, height: 40 });
+  assignStyle(element, { width: 40, height: 40 });
   return element;
 }
 

--- a/test/spec/features/tooltips/TooltipsSpec.js
+++ b/test/spec/features/tooltips/TooltipsSpec.js
@@ -4,11 +4,13 @@ import {
 } from 'test/TestHelper';
 
 import {
-  forEach,
-  assign
+  forEach
 } from 'min-dash';
 
-import { domify } from 'min-dom';
+import {
+  domify,
+  assignStyle
+} from 'min-dom';
 
 import tooltipsModule from 'lib/features/tooltips';
 
@@ -391,14 +393,14 @@ function isVisible(element) {
 }
 
 function highlight(element) {
-  assign(element.style, { background: 'fuchsia', minWidth: '10px', minHeight: '10px' });
+  assignStyle(element, { background: 'fuchsia', minWidth: '10px', minHeight: '10px' });
   return element;
 }
 
 
 function createOverlay() {
   var element = highlight(domify('<div>TEST<br/>TEST</div>'));
-  assign(element.style, { width: 40, height: 40 });
+  assignStyle(element, { width: 40, height: 40 });
   return element;
 }
 


### PR DESCRIPTION
This PR removes all inline styles and replaces them with direct assignment to Comply with CSP style-src.

Related to https://github.com/bpmn-io/bpmn-js/issues/1625
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->