### PR TITLE
Add hit box to disable move interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+## 8.3.0
+
+* `FEAT`: add hit box type to disable move interaction: `no-move`
+
 ## 8.2.2
 
 * `FIX`: ensure compliance with strict style-src CSP ([#636](https://github.com/bpmn-io/diagram-js/pull/636))

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -9,7 +9,7 @@
   --color-grey-225-10-80: hsl(225, 10%, 80%);
   --color-grey-225-10-85: hsl(225, 10%, 85%);
   --color-grey-225-10-90: hsl(225, 10%, 90%);
-  --color-grey-225-10-95: hsl(225, 10%, 95%); 
+  --color-grey-225-10-95: hsl(225, 10%, 95%);
   --color-grey-225-10-97: hsl(225, 10%, 97%);
 
   --color-blue-205-100-45: hsl(205, 100%, 45%);
@@ -25,8 +25,8 @@
   --color-red-360-100-97: hsl(360, 100%, 97%);
 
   --color-white: hsl(0, 0%, 100%);
-  --color-black: hsl(0, 0%, 0%); 
-  --color-black-opacity-05: hsla(0, 0%, 0%, 5%); 
+  --color-black: hsl(0, 0%, 0%);
+  --color-black-opacity-05: hsla(0, 0%, 0%, 5%);
   --color-black-opacity-10: hsla(0, 0%, 0%, 10%);
 
   --bendpoint-fill-color: var(--color-blue-205-100-45-opacity-30);
@@ -296,20 +296,14 @@ marker.djs-dragger tspan {
 /**
  * all pointer events for hit shape
  */
-.djs-element > .djs-hit-all {
+.djs-element > .djs-hit-all,
+.djs-element > .djs-hit-no-move {
   pointer-events: all;
 }
 
 .djs-element > .djs-hit-stroke,
 .djs-element > .djs-hit-click-stroke {
   pointer-events: stroke;
-}
-
-/**
- * all pointer events for hit shape
- */
-.djs-drag-active .djs-element > .djs-hit-click-stroke {
-  pointer-events: all;
 }
 
 /**

--- a/lib/features/interaction-events/InteractionEvents.js
+++ b/lib/features/interaction-events/InteractionEvents.js
@@ -258,10 +258,13 @@ export default function InteractionEvents(eventBus, elementRegistry, styles) {
 
   var ALL_HIT_STYLE = createHitStyle('djs-hit djs-hit-all');
 
+  var NO_MOVE_HIT_STYLE = createHitStyle('djs-hit djs-hit-no-move');
+
   var HIT_TYPES = {
     'all': ALL_HIT_STYLE,
     'click-stroke': CLICK_STROKE_HIT_STYLE,
-    'stroke': STROKE_HIT_STYLE
+    'stroke': STROKE_HIT_STYLE,
+    'no-move': NO_MOVE_HIT_STYLE
   };
 
   function createHitStyle(classNames, attrs) {

--- a/lib/features/move/Move.js
+++ b/lib/features/move/Move.js
@@ -5,6 +5,10 @@ import {
   isObject
 } from 'min-dash';
 
+import {
+  classes as svgClasses
+} from 'tiny-svg';
+
 var LOW_PRIORITY = 500,
     MEDIUM_PRIORITY = 1250,
     HIGH_PRIORITY = 1500;
@@ -199,6 +203,11 @@ export default function MoveEvents(
 
     // do not move connections or the root element
     if (element.waypoints || !element.parent) {
+      return;
+    }
+
+    // ignore non-draggable hits
+    if (svgClasses(event.target).has('djs-hit-no-move')) {
       return;
     }
 

--- a/test/spec/features/move/MoveSpec.js
+++ b/test/spec/features/move/MoveSpec.js
@@ -180,6 +180,21 @@ describe('features/move - Move', function() {
       }
     ));
 
+
+    it('should NOT start if triggered on `no-move` hit', inject(function(dragging, move) {
+
+      // given
+      var target = document.createElement('svg'),
+          event = canvasEvent({ x: 0, y: 0 }, { target: target });
+
+      target.classList.add('djs-hit-no-move');
+
+      // when
+      move.start(event, childShape);
+
+      // then
+      expect(dragging.context()).not.to.exist;
+    }));
   });
 
 
@@ -214,6 +229,8 @@ describe('features/move - Move', function() {
 // helpers ////////////////
 
 function mouseDownEvent(element, data) {
+
+  data = data || { target: document.createElement('svg') };
 
   return getDiagramJS().invoke(function(eventBus) {
     return eventBus.createEvent({


### PR DESCRIPTION
Use `no-move` type of hit box to disable element movement via hit box.

Related to https://github.com/camunda/camunda-modeler/issues/2859

Test with:

`npx @bpmn-io/sr bpmn-io/bpmn-js#improve-selection-of-a-pool -l bpmn-io/diagram-js#improve-selection-of-a-pool`
