### PR TITLE
deps: replace inherits with inherits-browser

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -77,7 +77,6 @@ module.exports = function(karma) {
       resolve: {
         mainFields: [
           'dev:module',
-          'browser',
           'module',
           'main'
         ],

--- a/lib/command/CommandInterceptor.js
+++ b/lib/command/CommandInterceptor.js
@@ -17,7 +17,7 @@ var DEFAULT_PRIORITY = 1000;
  *
  * @example
  *
- * import inherits from 'inherits';
+ * import inherits from 'inherits-browser';
  *
  * import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
  *

--- a/lib/draw/DefaultRenderer.js
+++ b/lib/draw/DefaultRenderer.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import BaseRenderer from './BaseRenderer';
 

--- a/lib/features/attach-support/AttachSupport.js
+++ b/lib/features/attach-support/AttachSupport.js
@@ -11,7 +11,7 @@ import { saveClear } from '../../util/Removal';
 
 import { getNewAttachShapeDelta } from '../../util/AttachUtil';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from '../../command/CommandInterceptor';
 

--- a/lib/features/auto-resize/AutoResize.js
+++ b/lib/features/auto-resize/AutoResize.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import { getBBox as getBoundingBox } from '../../util/Elements';
 

--- a/lib/features/auto-resize/AutoResizeProvider.js
+++ b/lib/features/auto-resize/AutoResizeProvider.js
@@ -1,6 +1,6 @@
 import RuleProvider from '../rules/RuleProvider';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 /**
  * This is a base rule provider for the element.autoResize rule.

--- a/lib/features/grid-snapping/behavior/ResizeBehavior.js
+++ b/lib/features/grid-snapping/behavior/ResizeBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from '../../../command/CommandInterceptor';
 

--- a/lib/features/label-support/LabelSupport.js
+++ b/lib/features/label-support/LabelSupport.js
@@ -3,7 +3,7 @@ import {
   filter
 } from 'min-dash';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 var LOW_PRIORITY = 250,
     HIGH_PRIORITY = 1400;

--- a/lib/features/modeling/cmd/CreateLabelHandler.js
+++ b/lib/features/modeling/cmd/CreateLabelHandler.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CreateShapeHandler from './CreateShapeHandler';
 

--- a/lib/features/ordering/OrderingProvider.js
+++ b/lib/features/ordering/OrderingProvider.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from '../../command/CommandInterceptor';
 

--- a/lib/features/root-elements/RootElementsBehavior.js
+++ b/lib/features/root-elements/RootElementsBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from '../../command/CommandInterceptor';
 

--- a/lib/features/rules/RuleProvider.js
+++ b/lib/features/rules/RuleProvider.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from '../../command/CommandInterceptor';
 

--- a/lib/model/index.js
+++ b/lib/model/index.js
@@ -1,5 +1,5 @@
 import { assign } from 'min-dash';
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import Refs from 'object-refs';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3299,7 +3299,13 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "inherits-browser": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.0.1.tgz",
+      "integrity": "sha512-kaDA3DkCdCpvrKIo/1T/3yVn+qpFUHLjYtSHmTYewb+QfjfaQy6FGQ7LwBu7st0tG9UvYad/XAlqQmdIh6CICw=="
     },
     "internal-slot": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "css.escape": "^1.5.1",
     "didi": "^5.2.1",
     "hammerjs": "^2.0.1",
-    "inherits": "^2.0.4",
+    "inherits-browser": "0.0.1",
     "min-dash": "^3.5.2",
     "min-dom": "^3.1.3",
     "object-refs": "^0.3.0",

--- a/test/spec/command/CommandInterceptorSpec.js
+++ b/test/spec/command/CommandInterceptorSpec.js
@@ -3,7 +3,7 @@ import {
   inject
 } from 'test/TestHelper';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import cmdModule from 'lib/command';
 

--- a/test/spec/features/attach-support/rules/AttachRules.js
+++ b/test/spec/features/attach-support/rules/AttachRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 

--- a/test/spec/features/auto-resize/AutoResizeSpec.js
+++ b/test/spec/features/auto-resize/AutoResizeSpec.js
@@ -15,7 +15,7 @@ import replaceModule from 'lib/features/replace';
 import AutoResizeProvider from 'lib/features/auto-resize/AutoResizeProvider';
 import AutoResize from 'lib/features/auto-resize/AutoResize';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 
 /**

--- a/test/spec/features/bendpoints/rules/BendpointRules.js
+++ b/test/spec/features/bendpoints/rules/BendpointRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 

--- a/test/spec/features/connect/rules/ConnectRules.js
+++ b/test/spec/features/connect/rules/ConnectRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 

--- a/test/spec/features/copy-paste/rules/CopyPasteRules.js
+++ b/test/spec/features/copy-paste/rules/CopyPasteRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 

--- a/test/spec/features/create/rules/CreateRules.js
+++ b/test/spec/features/create/rules/CreateRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 

--- a/test/spec/features/editor-actions/rules/CustomRules.js
+++ b/test/spec/features/editor-actions/rules/CustomRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 

--- a/test/spec/features/global-connect/rules/GlobalConnectRules.js
+++ b/test/spec/features/global-connect/rules/GlobalConnectRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 

--- a/test/spec/features/grid-snapping/behavior/ResizeBehaviorSpec.js
+++ b/test/spec/features/grid-snapping/behavior/ResizeBehaviorSpec.js
@@ -11,7 +11,7 @@ import moveModule from 'lib/features/move';
 import AutoResizeProvider from 'lib/features/auto-resize/AutoResizeProvider';
 import AutoResize from 'lib/features/auto-resize/AutoResize';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 /**
  * Custom auto-resize provider.

--- a/test/spec/features/keyboard-move-selection/rules/KeyboardMoveRules.js
+++ b/test/spec/features/keyboard-move-selection/rules/KeyboardMoveRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 

--- a/test/spec/features/label-support/rules/LabelSupportRules.js
+++ b/test/spec/features/label-support/rules/LabelSupportRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 

--- a/test/spec/features/move/renderer/MarkerRenderer.js
+++ b/test/spec/features/move/renderer/MarkerRenderer.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import {
   append as svgAppend,

--- a/test/spec/features/move/rules/MoveRules.js
+++ b/test/spec/features/move/rules/MoveRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 

--- a/test/spec/features/ordering/provider/TestOrderingProvider.js
+++ b/test/spec/features/ordering/provider/TestOrderingProvider.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import OrderingProvider from 'lib/features/ordering/OrderingProvider';
 

--- a/test/spec/features/resize/rules/ResizeRules.js
+++ b/test/spec/features/resize/rules/ResizeRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 

--- a/test/spec/features/rules/RuleProviderSpec.js
+++ b/test/spec/features/rules/RuleProviderSpec.js
@@ -11,7 +11,7 @@ import modelingModule from 'lib/features/modeling';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 
 describe('features/rules - RuleProvider', function() {

--- a/test/spec/features/rules/priority-rules/PriorityRules.js
+++ b/test/spec/features/rules/priority-rules/PriorityRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 

--- a/test/spec/features/rules/rules/TestRules.js
+++ b/test/spec/features/rules/rules/TestRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 

--- a/test/spec/features/rules/say-no-rules/SayNoRules.js
+++ b/test/spec/features/rules/say-no-rules/SayNoRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 

--- a/test/spec/features/selection/rules/ConnectRules.js
+++ b/test/spec/features/selection/rules/ConnectRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 

--- a/test/spec/features/space-tool/auto-resize/CustomAutoResizeProvider.js
+++ b/test/spec/features/space-tool/auto-resize/CustomAutoResizeProvider.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import AutoResizeProvider from 'lib/features/auto-resize/AutoResizeProvider';
 

--- a/test/spec/features/space-tool/rules/SpaceRules.js
+++ b/test/spec/features/space-tool/rules/SpaceRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'lib/features/rules/RuleProvider';
 


### PR DESCRIPTION
This increase the safety of our build; external consumers
do no longer need to account for the `browser` field to
bundle this library (or bundle a Node shim, unintentionally).

----

Related to https://github.com/bpmn-io/bpmn-js/pull/1651