### PR TITLE
feat: clearly distinguish select and hover states

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -97,17 +97,18 @@
 .djs-element.selected .djs-outline {
   visibility: visible;
   shape-rendering: geometricPrecision;
+}
+
+.djs-element.hover .djs-outline {
+  stroke: var(--element-hover-outline-fill-color);
   stroke-dasharray: 3,3;
+  stroke-width: 1px;
 }
 
 .djs-element.selected .djs-outline {
   stroke: var(--element-selected-outline-stroke-color);
   stroke-width: 1px;
-}
-
-.djs-element.hover .djs-outline {
-  stroke: var(--element-hover-outline-fill-color);
-  stroke-width: 1px;
+  stroke-dasharray: none;
 }
 
 .djs-shape.connect-ok .djs-visual > :nth-child(1) {

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -814,3 +814,9 @@ marker.djs-dragger tspan {
 .djs-label-hidden .djs-label {
   display: none !important;
 }
+
+.djs-element .djs-hit-stroke,
+.djs-element .djs-hit-click-stroke,
+.djs-element .djs-hit-all {
+  cursor: move;
+}

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -15,6 +15,7 @@
   --color-blue-205-100-45: hsl(205, 100%, 45%);
   --color-blue-205-100-45-opacity-30: hsla(205, 100%, 45%, 30%);
   --color-blue-205-100-50: hsl(205, 100%, 50%);
+  --color-blue-205-100-50-opacity-15: hsla(205, 100%, 50%, 15%);
   --color-blue-205-100-70: hsl(205, 100%, 75%);
   --color-blue-205-100-95: hsl(205, 100%, 95%);
 
@@ -27,7 +28,6 @@
 
   --color-white: hsl(0, 0%, 100%);
   --color-black: hsl(0, 0%, 0%);
-  --color-black-opacity-05: hsla(0, 0%, 0%, 5%);
   --color-black-opacity-10: hsla(0, 0%, 0%, 10%);
 
   --canvas-fill-color: var(--color-white);
@@ -43,8 +43,8 @@
   --element-selected-outline-stroke-color: var(--color-blue-205-100-50);
   --element-selected-outline-secondary-stroke-color: var(--color-blue-205-100-70);
 
-  --lasso-fill-color: var(--color-black-opacity-05);
-  --lasso-stroke-color: var(--color-black);
+  --lasso-fill-color: var(--color-blue-205-100-50-opacity-15);
+  --lasso-stroke-color: var(--element-selected-outline-stroke-color);
 
   --palette-entry-color: var(--color-grey-225-10-15);
   --palette-entry-hover-color: var(--color-blue-205-100-45);
@@ -171,10 +171,8 @@ svg.new-parent {
 */
 .djs-lasso-overlay {
   fill: var(--lasso-fill-color);
-
-  stroke-dasharray: 5 1 3 1;
   stroke: var(--lasso-stroke-color);
-
+  stroke-width: 2px;
   shape-rendering: geometricPrecision;
   pointer-events: none;
 }
@@ -200,7 +198,7 @@ svg.new-parent {
   fill: var(--resizer-fill-color);
   stroke-width: 1px;
   stroke: var(--resizer-stroke-color);
-  shape-rendering: geometricprecision;
+  shape-rendering: geometricPrecision;
 }
 
 .djs-resizer:hover .djs-resizer-visual {

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -15,6 +15,7 @@
   --color-blue-205-100-45: hsl(205, 100%, 45%);
   --color-blue-205-100-45-opacity-30: hsla(205, 100%, 45%, 30%);
   --color-blue-205-100-50: hsl(205, 100%, 50%);
+  --color-blue-205-100-70: hsl(205, 100%, 75%);
   --color-blue-205-100-95: hsl(205, 100%, 95%);
 
   --color-green-150-86-44: hsl(150, 86%, 44%);
@@ -40,6 +41,7 @@
   --element-dragger-color: var(--color-blue-205-100-50);
   --element-hover-outline-fill-color: var(--color-blue-205-100-45);
   --element-selected-outline-stroke-color: var(--color-blue-205-100-50);
+  --element-selected-outline-secondary-stroke-color: var(--color-blue-205-100-70);
 
   --lasso-fill-color: var(--color-black-opacity-05);
   --lasso-stroke-color: var(--color-black);
@@ -90,17 +92,29 @@
  * outline styles
  */
 
-.djs-outline {
+.djs-outline,
+.djs-selection-outline {
   fill: none;
+  shape-rendering: geometricPrecision;
+  stroke-width: 2px;
+}
+
+.djs-outline {
   visibility: hidden;
+}
+
+.djs-selection-outline {
+  stroke: var(--element-selected-outline-stroke-color);
 }
 
 .djs-element.selected .djs-outline {
   visibility: visible;
-  shape-rendering: geometricPrecision;
 
   stroke: var(--element-selected-outline-stroke-color);
-  stroke-width: 1px;
+}
+
+.djs-multi-select .djs-element.selected .djs-outline {
+  stroke: var(--element-selected-outline-secondary-stroke-color);
 }
 
 .djs-shape.connect-ok .djs-visual > :nth-child(1) {
@@ -667,6 +681,8 @@ marker.djs-dragger tspan {
 .djs-updating .djs-context-pad,
 .djs-updating .djs-outline,
 .djs-updating .djs-bendpoint,
+.djs-multi-select .djs-bendpoint,
+.djs-multi-select .djs-segment-dragger,
 .connect-ok .djs-bendpoint,
 .connect-not-ok .djs-bendpoint,
 .drop-ok .djs-bendpoint,
@@ -799,11 +815,4 @@ marker.djs-dragger tspan {
 .djs-element-hidden .djs-outline,
 .djs-label-hidden .djs-label {
   display: none !important;
-}
-
-.djs-selection-outline {
-  shape-rendering: geometricPrecision;
-  stroke: var(--element-selected-outline-stroke-color);
-  stroke-dasharray: 1,1;
-  stroke-width: 1px;
 }

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -29,8 +29,10 @@
   --color-black-opacity-05: hsla(0, 0%, 0%, 5%);
   --color-black-opacity-10: hsla(0, 0%, 0%, 10%);
 
-  --bendpoint-fill-color: var(--color-blue-205-100-45-opacity-30);
-  --bendpoint-stroke-color: var(--color-blue-205-100-50);
+  --canvas-fill-color: var(--color-white);
+
+  --bendpoint-fill-color: var(--color-blue-205-100-45);
+  --bendpoint-stroke-color: var(--canvas-fill-color);
 
   --context-pad-entry-background-color: var(--color-white);
   --context-pad-entry-hover-background-color: var(--color-grey-225-10-95);
@@ -57,8 +59,8 @@
   --popup-background-color: var(--color-grey-225-10-97);
   --popup-border-color: var(--color-grey-225-10-75);
 
-  --resizer-fill-color: var(--color-blue-205-100-45-opacity-30);
-  --resizer-stroke-color: var(--color-blue-205-100-50);
+  --resizer-fill-color: var(--color-blue-205-100-45);
+  --resizer-stroke-color: var(--canvas-fill-color);
 
   --search-container-background-color: var(--color-grey-225-10-97);
   --search-container-border-color: var(--color-blue-205-100-50);
@@ -93,22 +95,12 @@
   visibility: hidden;
 }
 
-.djs-element.hover .djs-outline,
 .djs-element.selected .djs-outline {
   visibility: visible;
   shape-rendering: geometricPrecision;
-}
 
-.djs-element.hover .djs-outline {
-  stroke: var(--element-hover-outline-fill-color);
-  stroke-dasharray: 3,3;
-  stroke-width: 1px;
-}
-
-.djs-element.selected .djs-outline {
   stroke: var(--element-selected-outline-stroke-color);
   stroke-width: 1px;
-  stroke-dasharray: none;
 }
 
 .djs-shape.connect-ok .djs-visual > :nth-child(1) {
@@ -193,7 +185,6 @@ svg.new-parent {
 .djs-resizer-visual {
   fill: var(--resizer-fill-color);
   stroke-width: 1px;
-  stroke-opacity: 0.5;
   stroke: var(--resizer-stroke-color);
   shape-rendering: geometricprecision;
 }
@@ -618,7 +609,6 @@ marker.djs-dragger tspan {
   fill: var(--bendpoint-fill-color);
   stroke: var(--bendpoint-stroke-color);
   stroke-width: 1px;
-  stroke-opacity: 0.5;
 }
 
 .djs-segment-dragger:hover,

--- a/lib/features/bendpoints/BendpointUtil.js
+++ b/lib/features/bendpoints/BendpointUtil.js
@@ -94,8 +94,8 @@ function createParallelDragger(parentGfx, segmentStart, segmentEnd, alignment) {
 
   svgAppend(parentGfx, draggerGfx);
 
-  var width = 14,
-      height = 3,
+  var width = 18,
+      height = 6,
       padding = 11,
       hitWidth = calculateHitWidth(segmentStart, segmentEnd, alignment),
       hitHeight = height + padding;

--- a/lib/features/connect/Connect.js
+++ b/lib/features/connect/Connect.js
@@ -97,7 +97,7 @@ export default function Connect(eventBus, dragging, modeling, rules) {
       attrs = canExecute;
     }
 
-    modeling.connect(source, target, attrs, hints);
+    context.connection = modeling.connect(source, target, attrs, hints);
   });
 
 

--- a/lib/features/outline/Outline.js
+++ b/lib/features/outline/Outline.js
@@ -41,6 +41,7 @@ export default function Outline(eventBus, styles, elementRegistry) {
     svgAttr(outline, assign({
       x: 10,
       y: 10,
+      rx: 3,
       width: 100,
       height: 100
     }, OUTLINE_STYLE));

--- a/lib/features/resize/ResizeHandles.js
+++ b/lib/features/resize/ResizeHandles.js
@@ -26,7 +26,7 @@ import {
 import { getReferencePoint } from './Resize';
 
 var HANDLE_OFFSET = -6,
-    HANDLE_SIZE = 4,
+    HANDLE_SIZE = 8,
     HANDLE_HIT_SIZE = 20;
 
 var CLS_RESIZER = 'djs-resizer';

--- a/lib/features/resize/ResizeHandles.js
+++ b/lib/features/resize/ResizeHandles.js
@@ -146,19 +146,17 @@ ResizeHandles.prototype.createResizer = function(element, direction) {
 /**
  * Add resizers for a given element.
  *
- * @param {djs.model.Shape} shape
+ * @param {djs.model.Element} element
  */
-ResizeHandles.prototype.addResizer = function(shape) {
+ResizeHandles.prototype.addResizer = function(element) {
   var self = this;
 
-  var resize = this._resize;
-
-  if (!resize.canResize({ shape: shape })) {
+  if (isConnection(element) || !this._resize.canResize({ shape: element })) {
     return;
   }
 
   forEach(directions, function(direction) {
-    self.createResizer(shape, direction);
+    self.createResizer(element, direction);
   });
 };
 
@@ -203,4 +201,8 @@ function getHandleOffset(direction) {
   }
 
   return offset;
+}
+
+function isConnection(element) {
+  return !!element.waypoints;
 }

--- a/lib/features/selection/SelectionBehavior.js
+++ b/lib/features/selection/SelectionBehavior.js
@@ -40,11 +40,10 @@ export default function SelectionBehavior(eventBus, selection, canvas, elementRe
   // Select connection targets on connect
   eventBus.on('connect.end', 500, function(event) {
     var context = event.context,
-        canExecute = context.canExecute,
-        hover = context.hover;
+        connection = context.connection;
 
-    if (canExecute && hover) {
-      selection.select(hover);
+    if (connection) {
+      selection.select(connection);
     }
   });
 

--- a/lib/features/selection/SelectionVisuals.js
+++ b/lib/features/selection/SelectionVisuals.js
@@ -100,7 +100,13 @@ SelectionVisuals.prototype._updateSelectionOutline = function(selection) {
 
   svgClear(layer);
 
-  if (selection.length <= 1) {
+  var enabled = selection.length > 1;
+
+  var container = this._canvas.getContainer();
+
+  svgClasses(container)[enabled ? 'add' : 'remove']('djs-multi-select');
+
+  if (!enabled) {
     return;
   }
 
@@ -109,7 +115,7 @@ SelectionVisuals.prototype._updateSelectionOutline = function(selection) {
   var rect = svgCreate('rect');
 
   svgAttr(rect, assign({
-    fill: 'none'
+    rx: 3
   }, bBox));
 
   svgClasses(rect).add('djs-selection-outline');

--- a/test/spec/features/bendpoints/BendpointsSpec.js
+++ b/test/spec/features/bendpoints/BendpointsSpec.js
@@ -431,7 +431,7 @@ describe('features/bendpoints', function() {
       var bendpointGfx,
           listenerSpy;
 
-      beforeEach(inject(function(bendpoints, eventBus) {
+      beforeEach(inject(function(bendpoints) {
         bendpoints.addHandles(connection);
 
         bendpointGfx = domQuery('.djs-bendpoint', bendpoints.getBendpointsContainer(connection));
@@ -571,7 +571,7 @@ describe('features/bendpoints', function() {
 
         // then
         expect(newBounds).to.not.eql(oldBounds);
-        expect(newBounds.left).to.be.closeTo(453, 2);
+        expect(newBounds.left).to.be.closeTo(451, 2);
       }
     ));
 

--- a/test/spec/features/connect/ConnectSpec.js
+++ b/test/spec/features/connect/ConnectSpec.js
@@ -221,6 +221,30 @@ describe('features/connect', function() {
       );
     }));
 
+
+    it('should expose created connection on <connect.end>', inject(
+      function(connect, dragging, eventBus) {
+
+        // given
+        var connectSpy = sinon.spy(function(event) {
+          expect(event.context.connection).to.exist;
+        });
+
+        eventBus.on('connect.end', connectSpy);
+
+        // when
+        connect.start(canvasEvent({ x: 250, y: 250 }), shape1);
+
+        dragging.move(canvasEvent({ x: 550, y: 150 }));
+
+        dragging.hover(canvasEvent({ x: 550, y: 150 }, { element: shape2 }));
+        dragging.end();
+
+        // then
+        expect(connectSpy).to.have.been.calledOnce;
+      }
+    ));
+
   });
 
 

--- a/test/spec/features/resize/ResizeSpec.js
+++ b/test/spec/features/resize/ResizeSpec.js
@@ -75,7 +75,7 @@ describe('features/resize - Resize', function() {
       // then
       var resizeAnchors = getResizeHandles();
 
-      expect(resizeAnchors.length).to.equal(8);
+      expect(resizeAnchors).to.have.length(8);
     }));
 
 
@@ -88,7 +88,7 @@ describe('features/resize - Resize', function() {
       // then
       var resizeAnchors = getResizeHandles();
 
-      expect(resizeAnchors.length).to.equal(0);
+      expect(resizeAnchors).to.have.length(0);
     }));
 
 
@@ -106,7 +106,7 @@ describe('features/resize - Resize', function() {
       // then
       var resizeAnchors = getResizeHandles();
 
-      expect(resizeAnchors.length).to.equal(8);
+      expect(resizeAnchors).to.have.length(8);
     }));
 
 
@@ -130,7 +130,7 @@ describe('features/resize - Resize', function() {
 
       // then
       var resizeAnchors = getResizeHandles();
-      expect(resizeAnchors).to.be.empty;
+      expect(resizeAnchors).to.have.length(0);
     }));
 
   });
@@ -434,7 +434,7 @@ describe('features/resize - Resize', function() {
       // then
       var frames = domQueryAll('.djs-resize-overlay', canvas.getActiveLayer());
 
-      expect(frames.length).to.equal(1);
+      expect(frames).to.have.length(1);
     }));
 
 
@@ -495,7 +495,7 @@ describe('features/resize - Resize', function() {
         // then
         var resizeAnchors = domQueryAll('.resize', shapeGfx);
 
-        expect(resizeAnchors.length).to.equal(0);
+        expect(resizeAnchors).to.have.length(0);
       })
     );
 

--- a/test/spec/features/resize/ResizeSpec.js
+++ b/test/spec/features/resize/ResizeSpec.js
@@ -40,7 +40,7 @@ describe('features/resize - Resize', function() {
   }));
 
 
-  var shape, gfx, rootShape;
+  var shape, shapeGfx, rootShape;
 
   beforeEach(inject(function(canvas, elementFactory, elementRegistry) {
     rootShape = elementFactory.createRoot({
@@ -49,14 +49,13 @@ describe('features/resize - Resize', function() {
 
     canvas.setRootElement(rootShape);
 
-    var s = elementFactory.createShape({
+    shape = canvas.addShape({
       id: 'c1',
       resizable: true, // checked by our rules
       x: 100, y: 100, width: 100, height: 100
     });
 
-    shape = canvas.addShape(s);
-    gfx = elementRegistry.getGraphics(shape);
+    shapeGfx = elementRegistry.getGraphics(shape);
   }));
 
 
@@ -108,6 +107,30 @@ describe('features/resize - Resize', function() {
       var resizeAnchors = getResizeHandles();
 
       expect(resizeAnchors.length).to.equal(8);
+    }));
+
+
+    it('should not add for connection', inject(function(canvas, selection) {
+
+      // given
+      var targetShape = canvas.addShape({
+        id: 'target',
+        x: 400, y: 100, width: 100, height: 100
+      });
+
+      var connection = canvas.addConnection({
+        id: 'connection',
+        waypoints: [ { x: 150, y: 150 }, { x: 450, y: 150 } ],
+        source: shape,
+        target: targetShape
+      });
+
+      // when
+      selection.select(connection);
+
+      // then
+      var resizeAnchors = getResizeHandles();
+      expect(resizeAnchors).to.be.empty;
     }));
 
   });
@@ -470,7 +493,7 @@ describe('features/resize - Resize', function() {
         selection.select(nonResizable);
 
         // then
-        var resizeAnchors = domQueryAll('.resize', gfx);
+        var resizeAnchors = domQueryAll('.resize', shapeGfx);
 
         expect(resizeAnchors.length).to.equal(0);
       })

--- a/test/spec/features/selection/SelectionBehaviorSpec.js
+++ b/test/spec/features/selection/SelectionBehaviorSpec.js
@@ -207,7 +207,7 @@ describe('features/selection/Selection', function() {
     }));
 
 
-    it('should select target of connect interaction', inject(
+    it('should select connection', inject(
       function(connect, dragging, selection) {
 
         // given
@@ -224,12 +224,13 @@ describe('features/selection/Selection', function() {
         var selected = selection.get();
 
         expect(selected).to.exist;
-        expect(selected).to.eql([ targetOnly ]);
+        expect(selected).to.eql([ targetOnly.incoming[0] ]);
+        expect(selected).to.eql([ shape.outgoing[0] ]);
       }
     ));
 
 
-    it('should select target of connect interaction - reversed connection', inject(
+    it('should select connection (reversed connect)', inject(
       function(connect, dragging, selection) {
 
         // given
@@ -246,7 +247,8 @@ describe('features/selection/Selection', function() {
         var selected = selection.get();
 
         expect(selected).to.exist;
-        expect(selected).to.eql([ shape ]);
+        expect(selected).to.eql([ targetOnly.incoming[0] ]);
+        expect(selected).to.eql([ shape.outgoing[0] ]);
       }
     ));
 

--- a/test/spec/features/selection/SelectionVisualsSpec.js
+++ b/test/spec/features/selection/SelectionVisualsSpec.js
@@ -7,6 +7,7 @@ import selectionModule from 'lib/features/selection';
 import modelingModule from 'lib/features/modeling';
 
 import {
+  classes as domClasses,
   query as domQuery
 } from 'min-dom';
 
@@ -62,6 +63,7 @@ describe('features/selection/SelectionVisuals', function() {
       canvas.addConnection(connection);
     }));
 
+
     describe('single element', function() {
 
       it('should show box on select', inject(function(selection, canvas) {
@@ -74,6 +76,16 @@ describe('features/selection/SelectionVisuals', function() {
             outline = domQuery('.djs-outline', gfx);
 
         expect(outline).to.exist;
+      }));
+
+
+      it('should not add djs-multi-select marker', inject(function(canvas) {
+
+        // when
+        var element = canvas.getContainer();
+
+        // then
+        expect(domClasses(element).has('djs-multi-select'));
       }));
 
     });
@@ -94,12 +106,28 @@ describe('features/selection/SelectionVisuals', function() {
       }));
 
 
-      it('should show box', inject(function(selection) {
+      it('should show box', inject(function() {
         expect(outline).to.exist;
       }));
 
 
-      it('selection box should contain all selected elements', inject(function(selection) {
+      it('should add djs-multi-select marker', inject(function(selection, canvas) {
+
+        // when
+        var element = canvas.getContainer();
+
+        // then
+        expect(domClasses(element).has('djs-multi-select')).to.be.true;
+
+        // but when
+        selection.select(null);
+
+        // then
+        expect(domClasses(element).has('djs-multi-select')).to.be.false;
+      }));
+
+
+      it('selection box should contain all selected elements', inject(function() {
 
         // then
         selectedShapes.forEach(function(shape) {
@@ -110,11 +138,10 @@ describe('features/selection/SelectionVisuals', function() {
           expect(bbox.x + bbox.width).to.be.at.most(bounds.x + bounds.width);
           expect(bbox.y + bbox.height).to.be.at.most(bounds.y + bounds.height);
         });
-
       }));
 
 
-      it('selection box should react to element changes', inject(function(selection, modeling) {
+      it('selection box should react to element changes', inject(function(modeling) {
 
         // when
         modeling.resizeShape(shape2, resizeBounds(bounds, 'nw', { x: 10, y: 20 }));
@@ -139,7 +166,7 @@ describe('features/selection/SelectionVisuals', function() {
       }));
 
 
-      it('selection box should react to undo/redo', inject(function(selection, modeling, commandStack) {
+      it('selection box should react to undo/redo', inject(function(modeling, commandStack) {
 
         // given
         modeling.resizeShape(shape2, resizeBounds(shape, 'nw', { x: 10, y: 20 }));


### PR DESCRIPTION
This proposes a rework of our hover and select outline, as well as interaction (resize, drag, ...) handles:

* No hover state (no blinking as you move the mouse)
* Clear, solid outline for selected elements
* Clear, no opacity, unified size handles to interact with diagram elements (resize, bendpoints, ...)

Role model for this change is Google Slides, but similar approaches can be found in many different apps.

----


![capture WUR6jb_optimized](https://user-images.githubusercontent.com/58601/169303246-28c23f66-e46e-4be4-b1e2-9ce7affea552.gif)

----

Try it out locally:

```
npx @bpmn-io/sr bpmn-io/bpmn-js#develop -l bpmn-io/diagram-js#select-hover-states
```

---

### TODO

* [x] Settle down on variation
* [x] Make this work with multi selection (#278)

----

Related to https://github.com/bpmn-io/bpmn-js/issues/1616