### PR TITLE
Select connection

### DIFF
--- a/lib/features/connect/Connect.js
+++ b/lib/features/connect/Connect.js
@@ -97,7 +97,7 @@ export default function Connect(eventBus, dragging, modeling, rules) {
       attrs = canExecute;
     }
 
-    modeling.connect(source, target, attrs, hints);
+    context.connection = modeling.connect(source, target, attrs, hints);
   });
 
 

--- a/lib/features/resize/ResizeHandles.js
+++ b/lib/features/resize/ResizeHandles.js
@@ -146,19 +146,17 @@ ResizeHandles.prototype.createResizer = function(element, direction) {
 /**
  * Add resizers for a given element.
  *
- * @param {djs.model.Shape} shape
+ * @param {djs.model.Element} element
  */
-ResizeHandles.prototype.addResizer = function(shape) {
+ResizeHandles.prototype.addResizer = function(element) {
   var self = this;
 
-  var resize = this._resize;
-
-  if (!resize.canResize({ shape: shape })) {
+  if (isConnection(element) || !this._resize.canResize({ shape: element })) {
     return;
   }
 
   forEach(directions, function(direction) {
-    self.createResizer(shape, direction);
+    self.createResizer(element, direction);
   });
 };
 
@@ -203,4 +201,8 @@ function getHandleOffset(direction) {
   }
 
   return offset;
+}
+
+function isConnection(element) {
+  return !!element.waypoints;
 }

--- a/lib/features/selection/SelectionBehavior.js
+++ b/lib/features/selection/SelectionBehavior.js
@@ -40,11 +40,10 @@ export default function SelectionBehavior(eventBus, selection, canvas, elementRe
   // Select connection targets on connect
   eventBus.on('connect.end', 500, function(event) {
     var context = event.context,
-        canExecute = context.canExecute,
-        hover = context.hover;
+        connection = context.connection;
 
-    if (canExecute && hover) {
-      selection.select(hover);
+    if (connection) {
+      selection.select(connection);
     }
   });
 

--- a/test/spec/features/connect/ConnectSpec.js
+++ b/test/spec/features/connect/ConnectSpec.js
@@ -221,6 +221,30 @@ describe('features/connect', function() {
       );
     }));
 
+
+    it('should expose created connection on <connect.end>', inject(
+      function(connect, dragging, eventBus) {
+
+        // given
+        var connectSpy = sinon.spy(function(event) {
+          expect(event.context.connection).to.exist;
+        });
+
+        eventBus.on('connect.end', connectSpy);
+
+        // when
+        connect.start(canvasEvent({ x: 250, y: 250 }), shape1);
+
+        dragging.move(canvasEvent({ x: 550, y: 150 }));
+
+        dragging.hover(canvasEvent({ x: 550, y: 150 }, { element: shape2 }));
+        dragging.end();
+
+        // then
+        expect(connectSpy).to.have.been.calledOnce;
+      }
+    ));
+
   });
 
 

--- a/test/spec/features/resize/ResizeSpec.js
+++ b/test/spec/features/resize/ResizeSpec.js
@@ -75,7 +75,7 @@ describe('features/resize - Resize', function() {
       // then
       var resizeAnchors = getResizeHandles();
 
-      expect(resizeAnchors.length).to.equal(8);
+      expect(resizeAnchors).to.have.length(8);
     }));
 
 
@@ -88,7 +88,7 @@ describe('features/resize - Resize', function() {
       // then
       var resizeAnchors = getResizeHandles();
 
-      expect(resizeAnchors.length).to.equal(0);
+      expect(resizeAnchors).to.have.length(0);
     }));
 
 
@@ -106,7 +106,7 @@ describe('features/resize - Resize', function() {
       // then
       var resizeAnchors = getResizeHandles();
 
-      expect(resizeAnchors.length).to.equal(8);
+      expect(resizeAnchors).to.have.length(8);
     }));
 
 
@@ -130,7 +130,7 @@ describe('features/resize - Resize', function() {
 
       // then
       var resizeAnchors = getResizeHandles();
-      expect(resizeAnchors).to.be.empty;
+      expect(resizeAnchors).to.have.length(0);
     }));
 
   });
@@ -434,7 +434,7 @@ describe('features/resize - Resize', function() {
       // then
       var frames = domQueryAll('.djs-resize-overlay', canvas.getActiveLayer());
 
-      expect(frames.length).to.equal(1);
+      expect(frames).to.have.length(1);
     }));
 
 
@@ -495,7 +495,7 @@ describe('features/resize - Resize', function() {
         // then
         var resizeAnchors = domQueryAll('.resize', shapeGfx);
 
-        expect(resizeAnchors.length).to.equal(0);
+        expect(resizeAnchors).to.have.length(0);
       })
     );
 

--- a/test/spec/features/resize/ResizeSpec.js
+++ b/test/spec/features/resize/ResizeSpec.js
@@ -40,7 +40,7 @@ describe('features/resize - Resize', function() {
   }));
 
 
-  var shape, gfx, rootShape;
+  var shape, shapeGfx, rootShape;
 
   beforeEach(inject(function(canvas, elementFactory, elementRegistry) {
     rootShape = elementFactory.createRoot({
@@ -49,14 +49,13 @@ describe('features/resize - Resize', function() {
 
     canvas.setRootElement(rootShape);
 
-    var s = elementFactory.createShape({
+    shape = canvas.addShape({
       id: 'c1',
       resizable: true, // checked by our rules
       x: 100, y: 100, width: 100, height: 100
     });
 
-    shape = canvas.addShape(s);
-    gfx = elementRegistry.getGraphics(shape);
+    shapeGfx = elementRegistry.getGraphics(shape);
   }));
 
 
@@ -108,6 +107,30 @@ describe('features/resize - Resize', function() {
       var resizeAnchors = getResizeHandles();
 
       expect(resizeAnchors.length).to.equal(8);
+    }));
+
+
+    it('should not add for connection', inject(function(canvas, selection) {
+
+      // given
+      var targetShape = canvas.addShape({
+        id: 'target',
+        x: 400, y: 100, width: 100, height: 100
+      });
+
+      var connection = canvas.addConnection({
+        id: 'connection',
+        waypoints: [ { x: 150, y: 150 }, { x: 450, y: 150 } ],
+        source: shape,
+        target: targetShape
+      });
+
+      // when
+      selection.select(connection);
+
+      // then
+      var resizeAnchors = getResizeHandles();
+      expect(resizeAnchors).to.be.empty;
     }));
 
   });
@@ -470,7 +493,7 @@ describe('features/resize - Resize', function() {
         selection.select(nonResizable);
 
         // then
-        var resizeAnchors = domQueryAll('.resize', gfx);
+        var resizeAnchors = domQueryAll('.resize', shapeGfx);
 
         expect(resizeAnchors.length).to.equal(0);
       })

--- a/test/spec/features/selection/SelectionBehaviorSpec.js
+++ b/test/spec/features/selection/SelectionBehaviorSpec.js
@@ -207,7 +207,7 @@ describe('features/selection/Selection', function() {
     }));
 
 
-    it('should select target of connect interaction', inject(
+    it('should select connection', inject(
       function(connect, dragging, selection) {
 
         // given
@@ -224,12 +224,13 @@ describe('features/selection/Selection', function() {
         var selected = selection.get();
 
         expect(selected).to.exist;
-        expect(selected).to.eql([ targetOnly ]);
+        expect(selected).to.eql([ targetOnly.incoming[0] ]);
+        expect(selected).to.eql([ shape.outgoing[0] ]);
       }
     ));
 
 
-    it('should select target of connect interaction - reversed connection', inject(
+    it('should select connection (reversed connect)', inject(
       function(connect, dragging, selection) {
 
         // given
@@ -246,7 +247,8 @@ describe('features/selection/Selection', function() {
         var selected = selection.get();
 
         expect(selected).to.exist;
-        expect(selected).to.eql([ shape ]);
+        expect(selected).to.eql([ targetOnly.incoming[0] ]);
+        expect(selected).to.eql([ shape.outgoing[0] ]);
       }
     ));
 


### PR DESCRIPTION
This fixes what bugged me for a long time: The fact that we do not select newly created connections, but rather the target of the connect operation. 

![capture kjTAff_optimized](https://user-images.githubusercontent.com/58601/169532146-2d40e39d-1ce4-4ec3-8993-785a19f0530a.gif)

As you see from the commits we were not even ready for this "fixed interaction".

----

Try it out via 

```
npx @bpmn-io/sr bpmn-io/bpmn-js#develop -l bpmn-io/diagram-js#select-connection
```