### PR TITLE
feat(css): remove higlighting for connections

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -138,19 +138,20 @@ svg.new-parent {
   background: var(--shape-drop-allowed-fill-color) !important;
 }
 
-.djs-connection.connect-ok .djs-visual > :nth-child(1),
-.djs-connection.drop-ok .djs-visual > :nth-child(1) {
-  stroke: var(--shape-drop-allowed-fill-color) !important;
-}
 
-.djs-connection.connect-not-ok .djs-visual > :nth-child(1),
-.djs-connection.drop-not-ok .djs-visual > :nth-child(1) {
-  stroke: var(--shape-drop-not-allowed-fill-color) !important;
-}
-
+/* Override move cursor during drop and connect */
 .drop-not-ok,
-.connect-not-ok {
-  cursor: not-allowed;
+.connect-not-ok,
+.drop-not-ok *,
+.connect-not-ok * {
+  cursor: not-allowed !important;
+}
+
+.drop-ok,
+.connect-ok,
+.drop-ok *,
+.connect-ok * {
+  cursor: default !important;
 }
 
 .djs-element.attach-ok .djs-visual > :nth-child(1) {


### PR DESCRIPTION
Instead of making the Connection nearly invisible, use cursor style to show allowed drop targets. This is consistent with shapes, as the outline is not changed when highlighted.

We can think about another highlight option in a follow-up.

![Recording 2022-05-24 at 12 38 36](https://user-images.githubusercontent.com/21984219/170013798-d1678ac7-8c92-4092-a1ff-eeda19cdba1e.gif)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
