### PR TITLE
fix: limit size of context pad entry image

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -501,11 +501,6 @@ marker.djs-dragger tspan {
   background: var(--context-pad-entry-hover-background-color);
 }
 
-.djs-context-pad .entry img {
-  max-width: 100%;
-  max-height: 100%;
-}
-
 .djs-context-pad.open {
   display: block;
 }

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -501,6 +501,11 @@ marker.djs-dragger tspan {
   background: var(--context-pad-entry-hover-background-color);
 }
 
+.djs-context-pad .entry img {
+  max-width: 100%;
+  max-height: 100%;
+}
+
 .djs-context-pad.open {
   display: block;
 }

--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -271,7 +271,8 @@ ContextPad.prototype._getProviders = function() {
 ContextPad.prototype._updateAndOpen = function(target) {
   var entries = this.getEntries(target),
       pad = this.getPad(target),
-      html = pad.html;
+      html = pad.html,
+      image;
 
   forEach(entries, function(entry, id) {
     var grouping = entry.group || 'default',
@@ -297,7 +298,11 @@ ContextPad.prototype._updateAndOpen = function(target) {
     }
 
     if (entry.imageUrl) {
-      control.appendChild(domify('<img src="' + entry.imageUrl + '">'));
+      image = domify('<img src="' + entry.imageUrl + '">');
+      image.style.width = '100%';
+      image.style.height = '100%';
+
+      control.appendChild(image);
     }
   });
 

--- a/test/spec/features/context-pad/ContextPadProvider.js
+++ b/test/spec/features/context-pad/ContextPadProvider.js
@@ -40,6 +40,15 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
         }
       }
     };
+  } else if (element.type === 'bigImage') {
+    return {
+      'action.c': {
+        imageUrl: 'data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20height%3D%222048%22%20width%3D%222048%22%3E%3Cpath%20style%3D%22fill%3Anone%3Bfill-rule%3Aevenodd%3Bstroke%3A%23282828%3Bstroke-width%3A146%3Bstroke-linecap%3Abutt%3Bstroke-linejoin%3Amiter%3Bstroke-miterlimit%3A4%3Bstroke-dasharray%3Anone%3Bstroke-dashoffset%3A0%3Bstroke-opacity%3A1%22%20d%3D%22M1027.973%201318v146%22%20transform%3D%22rotate(90%201022%201026)%22%2F%3E%3Cpath%20style%3D%22fill%3A%23fff%3Bfill-opacity%3A1%3Bstroke%3A%23282828%3Bstroke-width%3A146%3Bstroke-miterlimit%3A4%3Bstroke-dasharray%3Anone%3Bstroke-opacity%3A1%22%20d%3D%22M365%20515h1314V77H365v438zM657%201245h730V807H657v438z%22%20transform%3D%22rotate(90%201022%201026)%22%2F%3E%3Cpath%20style%3D%22fill%3Anone%3Bfill-rule%3Aevenodd%3Bstroke%3A%23282828%3Bstroke-width%3A146%3Bstroke-linecap%3Abutt%3Bstroke-linejoin%3Amiter%3Bstroke-miterlimit%3A4%3Bstroke-dasharray%3Anone%3Bstroke-dashoffset%3A0%3Bstroke-opacity%3A1%22%20d%3D%22M1022%20588v146%22%20transform%3D%22rotate(90%201022%201026)%22%2F%3E%3Cpath%20style%3D%22fill%3A%23fff%3Bfill-opacity%3A1%3Bstroke%3A%23282828%3Bstroke-width%3A146%3Bstroke-miterlimit%3A4%3Bstroke-dasharray%3Anone%3Bstroke-opacity%3A1%22%20d%3D%22M365%201975h1314v-438H365v438z%22%20transform%3D%22rotate(90%201022%201026)%22%2F%3E%3C%2Fsvg%3E',
+        action: function(e) {
+          e.__handled = true;
+        }
+      }
+    };
   } else {
     return {
       'action.c': {

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -951,4 +951,65 @@ describe('features/context-pad', function() {
 
   });
 
+
+  describe('icons size', function() {
+
+    beforeEach(bootstrapDiagram({
+      modules: [
+        contextPadModule,
+        providerModule
+      ]
+    }));
+
+
+    it('should limit image size', function(done) {
+
+      function verify(entry, image) {
+        var imageBox = image.getBoundingClientRect(),
+            entryBox = entry.getBoundingClientRect();
+
+        try {
+          expect(entryBox.width).to.be.gte(imageBox.width);
+          expect(entryBox.height).to.be.gte(imageBox.width);
+
+          done();
+        } catch (error) {
+          done(error);
+        }
+      }
+
+      var test = inject(function(canvas, contextPad) {
+
+        // given
+        var shape = { id: 's1', type: 'bigImage', width: 100, height: 100, x: 10, y: 10 };
+
+        canvas.addShape(shape);
+
+        // when
+        contextPad.open(shape);
+
+        // then
+        var pad = contextPad.getPad(shape),
+            padContainer = pad.html;
+
+        var entry = domQuery('[data-action="action.c"]', padContainer),
+            image = domQuery('img', entry);
+
+        if (image.complete) {
+          return verify(entry, image);
+        }
+
+        image.onload = function() {
+          verify(entry, image);
+        };
+
+        image.onerror = function(error) {
+          done(error);
+        };
+      });
+
+      test();
+    });
+  });
+
 });

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -969,8 +969,8 @@ describe('features/context-pad', function() {
             entryBox = entry.getBoundingClientRect();
 
         try {
-          expect(entryBox.width).to.be.gte(imageBox.width);
-          expect(entryBox.height).to.be.gte(imageBox.width);
+          expect(entryBox.width).to.eql(imageBox.width);
+          expect(entryBox.height).to.eql(imageBox.width);
 
           done();
         } catch (error) {


### PR DESCRIPTION
This is to make sure that I can provide SVGs without worrying about the icon size.