### PR TITLE
fix(popup-menu): display even if no cursor is passed to `open`

### DIFF
--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -393,6 +393,9 @@ PopupMenu.prototype._attachContainer = function(container, parent, cursor) {
   if (cursor) {
     this._assureIsInbounds(container, cursor);
   }
+
+  // display after position adjustment to avoid flickering
+  assignStyle(container, { visibility: 'visible' });
 };
 
 
@@ -481,7 +484,7 @@ PopupMenu.prototype._assureIsInbounds = function(container, cursor) {
     top = cursorPosition.y - containerHeight + 'px';
   }
 
-  assignStyle(container, { left: left, top: top }, { visibility: 'visible', 'zIndex': 1000 });
+  assignStyle(container, { left: left, top: top }, { 'zIndex': 1000 });
 };
 
 

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -261,6 +261,18 @@ describe('features/popup', function() {
     }));
 
 
+    it('should be visible even if no `position.cursor` was passed', inject(function(popupMenu) {
+
+      // when
+      popupMenu.open({}, 'menu' ,{ x: 100, y: 100 });
+
+      var container = popupMenu._current.container;
+
+      // then
+      expect(getComputedStyle(container).visibility).not.to.eql('hidden');
+    }));
+
+
     it('should add entries to menu', inject(function(popupMenu) {
 
       // when


### PR DESCRIPTION
Previously, the popup menu would be stuck with `visibility: hidden`.
