### PR TITLE
Make Canvas Selectable

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -30,6 +30,7 @@
   --color-black: hsl(0, 0%, 0%);
   --color-black-opacity-10: hsla(0, 0%, 0%, 10%);
 
+  --canvas-focus-box-shadow-color: var(--color-blue-205-100-50);
   --canvas-fill-color: var(--color-white);
 
   --bendpoint-fill-color: var(--color-blue-205-100-45);
@@ -89,6 +90,23 @@
 }
 
 /**
+ * SVG styles
+ */
+
+.djs-container svg:focus {
+  box-shadow: inset 0px 0px 0px 1px var(--canvas-focus-box-shadow-color);
+  outline: none;
+}
+
+.djs-container svg.drop-not-ok {
+  background: var(--shape-drop-not-allowed-fill-color) !important;
+}
+
+.djs-container svg.new-parent {
+  background: var(--shape-drop-allowed-fill-color) !important;
+}
+
+/**
  * outline styles
  */
 
@@ -128,14 +146,6 @@
 
 .djs-shape.new-parent .djs-visual > :nth-child(1) {
   fill: var(--shape-drop-allowed-fill-color) !important;
-}
-
-svg.drop-not-ok {
-  background: var(--shape-drop-not-allowed-fill-color) !important;
-}
-
-svg.new-parent {
-  background: var(--shape-drop-allowed-fill-color) !important;
 }
 
 

--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -11,7 +11,8 @@ import {
 } from 'min-dash';
 
 import {
-  assignStyle
+  assignStyle,
+  attr as domAttr
 } from 'min-dom';
 
 import {
@@ -166,7 +167,13 @@ Canvas.prototype._init = function(config) {
   var container = this._container = createContainer(config);
 
   var svg = this._svg = svgCreate('svg');
-  svgAttr(svg, { width: '100%', height: '100%' });
+
+  svgAttr(svg, {
+    width: '100%',
+    height: '100%'
+  });
+
+  domAttr(svg, 'tabindex', 0);
 
   svgAppend(container, svg);
 

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -47,12 +47,18 @@ describe('Canvas', function() {
 
     beforeEach(createDiagram());
 
+
     it('should create <svg> element', inject(function() {
 
-      // then
+      // when
       var svg = container.querySelector('svg');
 
-      expect(svg).not.to.be.null;
+      // then
+      // svg is created
+      expect(svg).to.exist;
+
+      // and user selectable
+      expect(svgAttr(svg, 'tabindex')).to.equal('0');
     }));
 
   });


### PR DESCRIPTION
Makes the canvas selectable by adding a `tabindex` attribute.

### Camunda Modeler

![Camunda_Modeler_28n1swge1e](https://user-images.githubusercontent.com/7633572/184130694-53dacef7-bc21-4ce2-92c8-5aa5b6e4b6d8.gif)

