### PR TITLE
feat(editor-actions): only copy if selected elements

### DIFF
--- a/lib/features/editor-actions/EditorActions.js
+++ b/lib/features/editor-actions/EditorActions.js
@@ -89,7 +89,9 @@ EditorActions.prototype._registerDefaultActions = function(injector) {
     this.register('copy', function() {
       var selectedElements = selection.get();
 
-      copyPaste.copy(selectedElements);
+      if (selectedElements.length) {
+        return copyPaste.copy(selectedElements);
+      }
     });
   }
 


### PR DESCRIPTION
Also, properly indicate copy result ("did I copy?").

----

This ensures we can use state of the art copy behavior consistently across our lib (i.e. also in cross browser copy + paste: https://github.com/nikku/bpmn-js-copy-paste-example)