### PR TITLE
Make canvas selectable / keyboard binding implicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
-* `FEAT`: make multi-selection outline an outline concern ([#944](https://github.com/bpmn-io/diagram-js/issues/944)
+## 15.0.0
+
+* `FEAT`: make canvas browser selectable ([#659](https://github.com/bpmn-io/diagram-js/pull/659))
+* `FEAT`: make keyboard binding implicit ([#661](https://github.com/bpmn-io/diagram-js/issues/661))
+* `FEAT`: make multi-selection outline an outline concern ([#944](https://github.com/bpmn-io/diagram-js/issues/944))
 
 ### Breaking Changes
 
-* The `selection` feature does not provide visual outline by default anymore. Use the `outline` feature to re-enable it.
+* `Keyboard` binding target can no longer be chosen. Configure keyboard binding via the `keyboard.bind` configuration and rely on keybindings to work if the canvas has browser focus. ([#661](https://github.com/bpmn-io/diagram-js/issues/661))
+* The `Canvas` is now a focusable component, that is recognized accordingly by the browser, with all benefits for UX and interaction. Components that pull focus from the `Canvas` during modeling must ensure to restore the focus (if intended), via `Canvas#restoreFocus`. ([#661](https://github.com/bpmn-io/diagram-js/issues/661))
+* The `selection` feature does not provide visual outline by default anymore. Use the `outline` feature to re-enable it. ([#944](https://github.com/bpmn-io/diagram-js/issues/944))
 
 ## 14.11.3
 

--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -10,7 +10,8 @@ import {
 } from 'min-dash';
 
 import {
-  assignStyle
+  assignStyle,
+  attr as domAttr
 } from 'min-dom';
 
 import {
@@ -189,6 +190,11 @@ export default function Canvas(config, eventBus, graphicsFactory, elementRegistr
    */
   this._rootElement = null;
 
+  /**
+   * @type {boolean}
+   */
+  this._focused = false;
+
   this._init(config || {});
 }
 
@@ -215,14 +221,33 @@ Canvas.$inject = [
  * @param {CanvasConfig} config
  */
 Canvas.prototype._init = function(config) {
-
   const eventBus = this._eventBus;
 
   // html container
   const container = this._container = createContainer(config);
 
   const svg = this._svg = svgCreate('svg');
-  svgAttr(svg, { width: '100%', height: '100%' });
+
+  svgAttr(svg, {
+    width: '100%',
+    height: '100%'
+  });
+
+  domAttr(svg, 'tabindex', 0);
+
+  eventBus.on('element.hover', () => {
+    this.restoreFocus();
+  });
+
+  svg.addEventListener('focusin', () => {
+    this._focused = true;
+    eventBus.fire('canvas.focus.changed', { focused: true });
+  });
+
+  svg.addEventListener('focusout', () => {
+    this._focused = false;
+    eventBus.fire('canvas.focus.changed', { focused: false });
+  });
 
   svgAppend(container, svg);
 
@@ -312,6 +337,31 @@ Canvas.prototype._clear = function() {
 
   // force recomputation of view box
   delete this._cachedViewbox;
+};
+
+/**
+* Sets focus on the canvas SVG element.
+*/
+Canvas.prototype.focus = function() {
+  this._svg.focus({ preventScroll: true });
+};
+
+/**
+* Sets focus on the canvas SVG element if `document.body` is currently focused.
+*/
+Canvas.prototype.restoreFocus = function() {
+  if (document.activeElement === document.body) {
+    this.focus();
+  }
+};
+
+/**
+* Returns true if the canvas is focused.
+*
+* @return {boolean}
+*/
+Canvas.prototype.isFocused = function() {
+  return this._focused;
 };
 
 /**

--- a/lib/features/keyboard/Keyboard.js
+++ b/lib/features/keyboard/Keyboard.js
@@ -3,9 +3,7 @@ import {
 } from 'min-dash';
 
 import {
-  closest as domClosest,
-  event as domEvent,
-  matches as domMatches
+  event as domEvent
 } from 'min-dom';
 
 import {
@@ -24,9 +22,10 @@ import {
 var KEYDOWN_EVENT = 'keyboard.keydown',
     KEYUP_EVENT = 'keyboard.keyup';
 
-var HANDLE_MODIFIER_ATTRIBUTE = 'input-handle-modified-keys';
-
 var DEFAULT_PRIORITY = 1000;
+
+var compatMessage = 'Keyboard binding is now implicit; explicit binding to an element got removed. For more information, see https://github.com/bpmn-io/diagram-js/issues/661';
+
 
 /**
  * A keyboard abstraction that may be activated and
@@ -46,8 +45,8 @@ var DEFAULT_PRIORITY = 1000;
  *
  * All events contain one field which is node.
  *
- * A default binding for the keyboard may be specified via the
- * `keyboard.bindTo` configuration option.
+ * Specify the initial keyboard binding state via the
+ * `keyboard.bind=true|false` configuration option.
  *
  * @param {Object} config
  * @param {EventTarget} [config.bindTo]
@@ -56,7 +55,8 @@ var DEFAULT_PRIORITY = 1000;
 export default function Keyboard(config, eventBus) {
   var self = this;
 
-  this._config = config || {};
+  this._config = config = config || {};
+
   this._eventBus = eventBus;
 
   this._keydownHandler = this._keydownHandler.bind(this);
@@ -69,19 +69,22 @@ export default function Keyboard(config, eventBus) {
     self.unbind();
   });
 
-  eventBus.on('diagram.init', function() {
+  if (config.bindTo) {
+    console.error('unsupported configuration <keyboard.bindTo>', new Error(compatMessage));
+  }
+
+  var bind = config && config.bind !== false;
+
+  eventBus.on('canvas.init', function(event) {
+    self._target = event.svg;
+
+    if (bind) {
+      self.bind();
+    }
+
     self._fire('init');
   });
 
-  eventBus.on('attach', function() {
-    if (config && config.bindTo) {
-      self.bind(config.bindTo);
-    }
-  });
-
-  eventBus.on('detach', function() {
-    self.unbind();
-  });
 }
 
 Keyboard.$inject = [
@@ -116,34 +119,7 @@ Keyboard.prototype._keyHandler = function(event, type) {
 };
 
 Keyboard.prototype._isEventIgnored = function(event) {
-  if (event.defaultPrevented) {
-    return true;
-  }
-
-  return (
-    isInput(event.target) || (
-      isButton(event.target) && isKey([ ' ', 'Enter' ], event)
-    )
-  ) && this._isModifiedKeyIgnored(event);
-};
-
-Keyboard.prototype._isModifiedKeyIgnored = function(event) {
-  if (!isCmd(event)) {
-    return true;
-  }
-
-  var allowedModifiers = this._getAllowedModifiers(event.target);
-  return allowedModifiers.indexOf(event.key) === -1;
-};
-
-Keyboard.prototype._getAllowedModifiers = function(element) {
-  var modifierContainer = domClosest(element, '[' + HANDLE_MODIFIER_ATTRIBUTE + ']', true);
-
-  if (!modifierContainer || (this._node && !this._node.contains(modifierContainer))) {
-    return [];
-  }
-
-  return modifierContainer.getAttribute(HANDLE_MODIFIER_ATTRIBUTE).split(',');
+  return false;
 };
 
 /**
@@ -153,10 +129,14 @@ Keyboard.prototype._getAllowedModifiers = function(element) {
  */
 Keyboard.prototype.bind = function(node) {
 
+  if (node) {
+    console.error('unsupported argument <node>', new Error(compatMessage));
+  }
+
   // make sure that the keyboard is only bound once to the DOM
   this.unbind();
 
-  this._node = node;
+  node = this._node = this._target;
 
   // bind key events
   domEvent.bind(node, 'keydown', this._keydownHandler);
@@ -226,15 +206,3 @@ Keyboard.prototype.hasModifier = hasModifier;
 Keyboard.prototype.isCmd = isCmd;
 Keyboard.prototype.isShift = isShift;
 Keyboard.prototype.isKey = isKey;
-
-
-
-// helpers ///////
-
-function isInput(target) {
-  return target && (domMatches(target, 'input, textarea') || target.contentEditable === 'true');
-}
-
-function isButton(target) {
-  return target && domMatches(target, 'button, input[type=submit], input[type=button], a[href], [aria-role=button]');
-}

--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -262,6 +262,8 @@ PopupMenu.prototype.close = function() {
 
   this.reset();
 
+  this._canvas.restoreFocus();
+
   this._current = null;
 };
 

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -403,6 +403,8 @@ SearchPad.prototype.close = function(restoreCached = true) {
   this._searchInput.blur();
 
   this._eventBus.fire('searchPad.closed');
+
+  this._canvas.restoreFocus();
 };
 
 

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -47,12 +47,18 @@ describe('Canvas', function() {
 
     beforeEach(createDiagram());
 
+
     it('should create <svg> element', inject(function() {
 
-      // then
+      // when
       var svg = container.querySelector('svg');
 
-      expect(svg).not.to.be.null;
+      // then
+      // svg is created
+      expect(svg).to.exist;
+
+      // and user selectable
+      expect(svgAttr(svg, 'tabindex')).to.equal('0');
     }));
 
 
@@ -64,6 +70,106 @@ describe('Canvas', function() {
       expect(diagramContainer).not.to.be.null;
       expect(diagramContainer.className).to.eql('djs-container djs-parent');
     }));
+
+  });
+
+
+  describe('focus handling', function() {
+
+    beforeEach(function() {
+      container = TestContainer.get(this);
+    });
+
+    beforeEach(createDiagram());
+
+
+    it('should be focusable', function() {
+
+      // given
+      var svg = container.querySelector('svg');
+
+      // when
+      svg.focus();
+
+      // then
+      expect(document.activeElement).to.equal(svg);
+    });
+
+
+    describe('<hover>', function() {
+
+      /**
+       * @type { HTMLElement }
+       */
+      let inputEl;
+
+      beforeEach(function() {
+        document.body.focus();
+      });
+
+      afterEach(function() {
+        inputEl && inputEl.remove();
+      });
+
+
+      it('should focus if body is focused', inject(function(canvas, eventBus) {
+
+        // given
+        var svg = container.querySelector('svg');
+
+        // when
+        eventBus.fire('element.hover', {
+          element: canvas.getRootElement(),
+          gfx: svg
+        });
+
+        // then
+        expect(document.activeElement).to.equal(svg);
+      }));
+
+
+      it('should not scroll on focus', inject(function(canvas, eventBus) {
+
+        // given
+        var svg = container.querySelector('svg');
+
+        var clientRect = svg.getBoundingClientRect();
+
+        // when
+        eventBus.fire('element.hover', {
+          element: canvas.getRootElement(),
+          gfx: svg
+        });
+
+        // then
+        expect(clientRect).to.eql(svg.getBoundingClientRect());
+      }));
+
+
+      it('should not focus on existing document focus', inject(function(canvas, eventBus) {
+
+        // given
+        inputEl = document.createElement('input');
+
+        document.body.appendChild(inputEl);
+        inputEl.focus();
+
+        // assume
+        expect(document.activeElement).to.equal(inputEl);
+
+        var svg = container.querySelector('svg');
+
+        // when
+        eventBus.fire('element.hover', {
+          element: canvas.getRootElement(),
+          gfx: svg
+        });
+
+        // then
+        expect(document.activeElement).to.eql(inputEl);
+      }));
+
+    });
 
   });
 
@@ -2652,3 +2758,4 @@ function expectChildren(parent, children) {
   });
 
 }
+

--- a/test/spec/features/keyboard/KeyboardSpec.js
+++ b/test/spec/features/keyboard/KeyboardSpec.js
@@ -1,14 +1,3 @@
-import TestContainer from 'mocha-test-container-support';
-
-import {
-  assign
-} from 'min-dash';
-
-import {
-  domify
-} from 'min-dom';
-
-import modelingModule from 'lib/features/modeling';
 import keyboardModule from 'lib/features/keyboard';
 
 import {
@@ -23,17 +12,11 @@ describe('features/keyboard', function() {
 
   var TEST_KEY = 'Numpad3';
 
-  var defaultDiagramConfig = {
+  beforeEach(bootstrapDiagram({
     modules: [
-      modelingModule,
       keyboardModule
-    ],
-    canvas: {
-      deferUpdate: false
-    }
-  };
-
-  beforeEach(bootstrapDiagram(defaultDiagramConfig));
+    ]
+  }));
 
 
   it('should bootstrap diagram with keyboard', inject(function(keyboard) {
@@ -41,64 +24,26 @@ describe('features/keyboard', function() {
   }));
 
 
-  describe('keyboard binding', function() {
-
-    var keyboardConfig = {
-      keyboard: {
-        bindTo: document
-      }
-    };
-
-    beforeEach(bootstrapDiagram(assign(defaultDiagramConfig, keyboardConfig)));
-
-
-    it('should integrate with <attach> + <detach> events', inject(
-      function(keyboard, eventBus) {
-
-        // assume
-        expect(keyboard._node).not.to.exist;
-
-        // when
-        eventBus.fire('attach');
-
-        expect(keyboard._node).to.eql(document);
-
-        // but when
-        eventBus.fire('detach');
-
-        expect(keyboard._node).not.to.exist;
-      }
-    ));
-
-  });
-
-
   describe('keydown event listener handling', function() {
 
-    var testDiv;
-
-    beforeEach(function() {
-
-      var testContainer = TestContainer.get(this);
-
-      testDiv = document.createElement('div');
-      testDiv.setAttribute('class', 'testClass');
-      testContainer.appendChild(testDiv);
-    });
-
-
-    it('should bind keyboard events to node', inject(function(keyboard) {
+    it('should bind keyboard events', inject(function(keyboard) {
 
       // given
       var keyHandlerSpy = sinon.spy(keyboard, '_keyHandler');
 
       // when
-      keyboard.bind(testDiv);
+      keyboard.bind();
 
       // then
-      dispatchKeyboardEvent(testDiv, 'keydown');
+      var node = keyboard.getBinding();
 
-      expect(keyHandlerSpy).to.have.been.called;
+      expect(node).to.exist;
+
+      // but when
+      dispatchKeyboardEvent(node, 'keydown');
+
+      // then
+      expect(keyHandlerSpy).to.have.been.calledOnce;
     }));
 
 
@@ -107,13 +52,15 @@ describe('features/keyboard', function() {
       // given
       var keyHandlerSpy = sinon.spy(keyboard, '_keyHandler');
 
-      keyboard.bind(testDiv);
-
       // when
+      keyboard.bind();
+
+      var node = keyboard.getBinding();
+
       keyboard.unbind();
 
       // then
-      dispatchKeyboardEvent(testDiv, 'keydown');
+      dispatchKeyboardEvent(node, 'keydown');
 
       expect(keyHandlerSpy).not.to.have.been.called;
     }));
@@ -126,259 +73,17 @@ describe('features/keyboard', function() {
     }));
 
 
-    it('should return node', inject(function(keyboard) {
+    it('should return node', inject(function(keyboard, canvas) {
 
       // given
-      keyboard.bind(testDiv);
+      keyboard.bind();
 
       // when
       var binding = keyboard.getBinding();
 
       // then
-      expect(binding).to.equal(testDiv);
+      expect(binding).to.equal(canvas._svg);
     }));
-
-
-    describe('should ignore input field targets', function() {
-
-      it('non-modifier event', inject(
-        function(keyboard, eventBus) {
-
-          // given
-          var eventBusSpy = sinon.spy(eventBus, 'fire');
-
-          var inputField = document.createElement('input');
-          testDiv.appendChild(inputField);
-
-          // when
-          keyboard._keyHandler({ key: TEST_KEY, target: inputField });
-          keyboard._keyHandler({ key: TEST_KEY, shiftKey: true, target: inputField });
-
-          // then
-          expect(eventBusSpy).to.not.be.called;
-        })
-      );
-
-      it('modifier event', inject(
-        function(keyboard, eventBus) {
-
-          // given
-          var eventBusSpy = sinon.spy(eventBus, 'fire');
-
-          var inputField = document.createElement('input');
-          testDiv.appendChild(inputField);
-
-          // when
-          keyboard._keyHandler({ key: TEST_KEY, metaKey: true, target: inputField });
-          keyboard._keyHandler({ key: TEST_KEY, ctrlKey: true, target: inputField });
-
-          // then
-          expect(eventBusSpy).to.not.be.called;
-        })
-      );
-
-    });
-
-
-    describe('should ignore ENTER and SPACE on button like elements', function() {
-
-      const SPACE_KEY = ' ';
-      const ENTER_KEY = 'Enter';
-
-      const testScenarios = {
-        'input[type=button]': () => domify('<input type="button" value="BUTTON" />'),
-        'input[type=submit]': () => domify('<input type="submit" value="BUTTON" />'),
-        'button': () => domify('<button>BUTTON</button>'),
-        'a[href]': () => domify('<a href="#">LINK</a>'),
-        '[aria-role=button]': () => domify('<span aria-role="button">FAKE Button</span>')
-      };
-
-      for (const [ name, createElement ] of Object.entries(testScenarios)) {
-
-        it(name, inject(
-          function(keyboard, eventBus) {
-
-            // given
-            var eventBusSpy = sinon.spy(eventBus, 'fire');
-
-            var buttonEl = createElement();
-            testDiv.appendChild(buttonEl);
-
-            // when
-            keyboard._keyHandler({ key: SPACE_KEY, target: buttonEl });
-            keyboard._keyHandler({ key: SPACE_KEY, shiftKey: true, target: buttonEl });
-
-            keyboard._keyHandler({ key: ENTER_KEY, target: buttonEl });
-            keyboard._keyHandler({ key: ENTER_KEY, shiftKey: true, target: buttonEl });
-
-            // then
-            expect(eventBusSpy).to.not.be.called;
-          })
-        );
-      }
-
-    });
-
-
-    it('should ignore propagation stopped events', inject(
-      function(keyboard, eventBus) {
-
-        // given
-        var keyListener = sinon.spy();
-
-        keyboard.bind(testDiv);
-
-        eventBus.on('keyboard.keydown', keyListener);
-        eventBus.on('keyboard.keyup', keyListener);
-
-        var testEl = domify('<div tab-index="-1"></div>');
-
-        testEl.addEventListener('keydown', function(event) {
-          event.stopPropagation();
-        });
-
-        testEl.addEventListener('keyup', function(event) {
-          event.stopPropagation();
-        });
-
-        testDiv.appendChild(testEl);
-
-        // when
-        dispatchKeyboardEvent(testEl, 'keydown');
-        dispatchKeyboardEvent(testEl, 'keyup');
-
-        // then
-        expect(keyListener).not.to.be.called;
-      })
-    );
-
-
-    it('should ignore default prevented events', inject(
-      function(keyboard, eventBus) {
-
-        // given
-        var keyListener = sinon.spy();
-
-        keyboard.bind(testDiv);
-
-        eventBus.on('keyboard.keydown', keyListener);
-        eventBus.on('keyboard.keyup', keyListener);
-
-        var testEl = domify('<div tab-index="-1"></div>');
-
-        testEl.addEventListener('keydown', function(event) {
-          event.preventDefault();
-        });
-
-        testEl.addEventListener('keyup', function(event) {
-          event.preventDefault();
-        });
-
-        testDiv.appendChild(testEl);
-
-        // when
-        dispatchKeyboardEvent(testEl, 'keydown');
-        dispatchKeyboardEvent(testEl, 'keyup');
-
-        // then
-        expect(keyListener).not.to.be.called;
-      })
-    );
-
-
-    describe('input-handle-modified-keys property', function() {
-
-      it('should fire modifier event if requesting it', inject(
-        function(keyboard, eventBus) {
-
-          // given
-          var eventBusSpy = sinon.spy(eventBus, 'fire');
-
-          var inputField = domify('<input></input>');
-          testDiv.appendChild(inputField);
-          testDiv.setAttribute('input-handle-modified-keys', 'a');
-
-          // when
-          keyboard._keyHandler({ key: 'a', metaKey: true, target: inputField });
-          keyboard._keyHandler({ key: 'a', ctrlKey: true, target: inputField });
-
-          // then
-          expect(eventBusSpy).to.have.been.calledTwice;
-        })
-      );
-
-
-      it('should not fire modifier event if not requested', inject(
-        function(keyboard, eventBus) {
-
-          // given
-          var eventBusSpy = sinon.spy(eventBus, 'fire');
-
-          var inputField = domify('<input></input>');
-          testDiv.appendChild(inputField);
-          testDiv.setAttribute('input-handle-modified-keys', 'a');
-
-          // when
-          keyboard._keyHandler({ key: 'b', metaKey: true, target: inputField });
-          keyboard._keyHandler({ key: 'b', ctrlKey: true, target: inputField });
-
-          // then
-          expect(eventBusSpy).to.not.be.called;
-        })
-      );
-
-
-      it('should override handled keys', inject(
-        function(keyboard, eventBus) {
-
-          // given
-          var eventBusSpy = sinon.spy(eventBus, 'fire');
-
-          var inputField = domify('<input input-handle-modified-keys="b"></input>');
-          testDiv.appendChild(inputField);
-          testDiv.setAttribute('input-handle-modified-keys', 'a');
-
-          // when
-          keyboard._keyHandler({ key: 'a', metaKey: true, target: inputField });
-          keyboard._keyHandler({ key: 'a', ctrlKey: true, target: inputField });
-
-          // then
-          expect(eventBusSpy).to.not.be.called;
-
-          // when
-          keyboard._keyHandler({ key: 'b', metaKey: true, target: inputField });
-          keyboard._keyHandler({ key: 'b', ctrlKey: true, target: inputField });
-
-          // then
-          expect(eventBusSpy).to.have.been.calledTwice;
-        })
-      );
-
-
-      it('should not fire modifier event if the requesting element is outside of binding', inject(
-        function(keyboard, eventBus) {
-
-          // given
-          var inputContainer = domify('<div class="container"><input /></div>'),
-              inputField = inputContainer.querySelector('input');
-
-          testDiv.appendChild(inputContainer);
-          testDiv.setAttribute('input-handle-modified-keys', 'a');
-
-          keyboard.bind(inputContainer);
-
-          var eventBusSpy = sinon.spy(eventBus, 'fire');
-
-          // when
-          keyboard._keyHandler({ key: 'a', metaKey: true, target: inputField });
-          keyboard._keyHandler({ key: 'a', ctrlKey: true, target: inputField });
-
-          // then
-          expect(eventBusSpy).to.not.be.called;
-        })
-      );
-
-    });
 
   });
 
@@ -546,6 +251,109 @@ describe('features/keyboard', function() {
   });
 
 });
+
+
+describe('features/keyboard - <keyboard.bind=false> config', function() {
+
+  beforeEach(bootstrapDiagram({
+    modules: [
+      keyboardModule
+    ],
+    keyboard: {
+      bind: false
+    }
+  }));
+
+
+  it('should not bind initially', inject(
+    function(keyboard) {
+
+      // then
+      expect(keyboard.getBinding()).not.to.exist;
+    }
+  ));
+
+});
+
+
+describe('features/keyboard - legacy', function() {
+
+  var errorSpy;
+
+  beforeEach(function() {
+    errorSpy = sinon.spy(console, 'error');
+  });
+
+  afterEach(function() {
+    errorSpy.restore();
+  });
+
+  function expectError(errorSpy, errorMessage) {
+    expect(errorSpy).to.have.been.calledOnce;
+
+    var args = errorSpy.args[0];
+
+    expect(args).to.have.length(2);
+    expect(args[0]).to.eql(errorMessage);
+  }
+
+
+  describe('keyboard.bindTo=document> config', function() {
+
+    beforeEach(bootstrapDiagram({
+      modules: [
+        keyboardModule
+      ],
+      keyboard: {
+        bindTo: document.body
+      }
+    }));
+
+
+    it('should bind but indicate error', inject(
+      function(keyboard) {
+
+        // then
+        // binding happens regardless
+        expect(keyboard.getBinding()).to.exist;
+        expect(keyboard.getBinding()).not.to.equal(document.body);
+
+        // error is indicated
+        expectError(errorSpy, 'unsupported configuration <keyboard.bindTo>');
+      }
+    ));
+
+  });
+
+
+  describe('keyboard.bind(Element)', function() {
+
+    beforeEach(bootstrapDiagram({
+      modules: [
+        keyboardModule
+      ]
+    }));
+
+
+    it('should bind but indicate error', inject(
+      function(keyboard) {
+
+        // when
+        keyboard.bind(document.body);
+
+        // then
+        // binding happens regardless
+        expect(keyboard.getBinding()).to.exist;
+
+        // error is indicated
+        expectError(errorSpy, 'unsupported argument <node>');
+      }
+    ));
+
+  });
+
+});
+
 
 
 // helpers //////////

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -706,6 +706,20 @@ describe('features/popup-menu', function() {
       }).not.to.throw();
     }));
 
+
+    it('should refocus canvas on close', inject(function(canvas, popupMenu) {
+
+      // given
+      sinon.spy(canvas, 'restoreFocus');
+
+      // when
+      popupMenu.close();
+
+      // then
+      expect(canvas.restoreFocus).to.have.been.calledOnce;
+
+    }));
+
   });
 
 

--- a/test/spec/features/search-pad/SearchPadSpec.js
+++ b/test/spec/features/search-pad/SearchPadSpec.js
@@ -277,6 +277,20 @@ describe('features/searchPad', function() {
       expect(capturedEvents).to.eql([ EVENTS.opened, EVENTS.closed ]);
     }));
 
+
+    it('should refocus canvas on close', inject(function(canvas, searchPad) {
+
+      // given
+      sinon.spy(canvas, 'restoreFocus');
+      searchPad.open();
+
+      // when
+      triggerMouseEvent(canvas.getContainer(), 'click', 0, 0);
+
+      // then
+      expect(canvas.restoreFocus).to.have.been.calledOnce;
+    }));
+
   });
 
 


### PR DESCRIPTION
Keyboard is not implicitly bound and `Canvas` is a focusable element.

This builds foundations to [support cross-browser/application copy and paste](https://github.com/bpmn-io/internal-docs/issues/614) and more general keyboard related UX enhancements.

This change introduces a predictable editing experience, simplifies the keyboard and ensures worry free interoperability with multiple editors and inputs on the page.

### Keyboard binding (https://github.com/bpmn-io/diagram-js/pull/662/commits/b0f9a75fc2cb38a1a973763512821c92550837db)

Keyboard is now implicitly bound to the canvas element (svg). It provides behavior closer to native browser experience.

Previous calls to `keyboard.bind(someElement)` or configuration via `keyboard.bindTo` log a descriptive descriptive error:

![image](https://user-images.githubusercontent.com/58601/185193522-95d1f79a-3cdb-48a0-b70e-1f3b8579b313.png)

### Canvas focusable (https://github.com/bpmn-io/diagram-js/pull/662/commits/c75285be7eb40da0de5a193bfe95f03865c52fd0)

The `Canvas` is now a focusable component, that is recognized accordingly by the browser, with all benefits for UX and interaction. New APIs are provided to allow restoring focus to the canvas.

Components that pull focus from the `Canvas` during modeling must ensure to restore the focus (if intended), via `Canvas#restoreFocus`.

---

Closes https://github.com/bpmn-io/diagram-js/issues/661