### PR TITLE
Add dedicated undo/redo keyboard utilities

### DIFF
--- a/lib/features/keyboard/KeyboardBindings.js
+++ b/lib/features/keyboard/KeyboardBindings.js
@@ -9,11 +9,12 @@ import {
 
 var LOW_PRIORITY = 500;
 
-export var KEYCODE_C = 67;
-export var KEYCODE_V = 86;
-export var KEYCODE_Y = 89;
-export var KEYCODE_Z = 90;
+var KEYCODE_C = 67;
+var KEYCODE_V = 86;
+var KEYCODE_Y = 89;
+var KEYCODE_Z = 90;
 
+// TODO(nikku): remove in future diagram-js version
 export var KEYS_COPY = [ 'c', 'C', KEYCODE_C ];
 export var KEYS_PASTE = [ 'v', 'V', KEYCODE_V ];
 export var KEYS_REDO = [ 'y', 'Y', KEYCODE_Y ];

--- a/test/spec/features/keyboard/KeyboardBindingsSpec.js
+++ b/test/spec/features/keyboard/KeyboardBindingsSpec.js
@@ -1,0 +1,18 @@
+import {
+  KEYS_UNDO,
+  KEYS_REDO,
+  KEYS_COPY,
+  KEYS_PASTE
+} from 'lib/features/keyboard/KeyboardBindings';
+
+
+describe('features/keyboard - KeyboardBindings', function() {
+
+  it('should provide legacy KEYS_* exports', function() {
+    expect(KEYS_UNDO).to.exist;
+    expect(KEYS_REDO).to.exist;
+    expect(KEYS_COPY).to.exist;
+    expect(KEYS_PASTE).to.exist;
+  });
+
+});


### PR DESCRIPTION
The way folks in the bpmn-io sphere may now test keyboard events against common behaviors is now greatly simplified:

```javascript
import {
  isUndo,
  isRedo,
  isPaste
} from 'diagram-js/lib/features/keyboard/KeyboardUtil';

document.addEventListener('keydown', function(event) {
  if (isUndo(event)) {
    // event is regarded as an UNDO event by bpmn-io tools.
  }
});
```

As a breaking change we stop exporting some basic utilities in `KeyboardBindings` (exporting from actual feature modules is an anti-pattern anyway) with more to be removed in future major  upgrades. The remaining ones are continued to be used in downstream libraries (mainly form-js).

----


Non-breaking changes backported to:

* 7.x - https://github.com/bpmn-io/diagram-js/pull/663
* 8.x - https://github.com/bpmn-io/diagram-js/pull/664