### PR TITLE
deps: bump to didi@8.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1919,9 +1919,9 @@
       "dev": true
     },
     "didi": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.0.tgz",
-      "integrity": "sha512-PwqTBaYzzfJSyxvpXPcTWF6nDdCKx2mFAU5eup1ZSb5wbaAS9a/HiKdtcAUdie/VMLHoFI50jkYZcA+bhUOugw=="
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.1.tgz",
+      "integrity": "sha512-7oXiXbp8DHE3FfQsVBkc2pwePo3Jy2uyGS9trAeBmfxiZAP4WV23LWokRpMmyl3hlu8OEAsyMxx19i5P6TVaJQ=="
     },
     "diff": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "css.escape": "^1.5.1",
-    "didi": "^8.0.0",
+    "didi": "^8.0.1",
     "hammerjs": "^2.0.1",
     "inherits-browser": "0.0.1",
     "min-dash": "^3.5.2",

--- a/test/spec/DiagramSpec.js
+++ b/test/spec/DiagramSpec.js
@@ -45,6 +45,20 @@ describe('Diagram', function() {
     });
 
 
+    it('should throw inspectable errors', function() {
+
+      expect(function() {
+        new Diagram({
+          modules: {
+            __init__: [
+              function(foo) {}
+            ]
+          }
+        });
+      }).to.throw(/No provider for "foo"!/);
+    });
+
+
     describe('should expose diagram services', function() {
 
 


### PR DESCRIPTION
Improves error reporting; previous 8.x release would use `AggregateError` which has poor inspection support across systems. That did effectively hide the cause of initialization errors.