### PR TITLE
Use ES2018 syntax

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,5 @@
 {
-  "extends": "plugin:bpmn-io/es6",
-  "env": {
-    "browser": true
-  },
+  "extends": "plugin:bpmn-io/browser",
   "rules": {
     "no-restricted-imports": [ "error", {
       "name": "inherits",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ _**Note:** Yet to be released changes appear here._
 
 ### Breaking Changes
 
-* Migrated to ES2018 syntax. [Read the blog post with details and a migration guide](https://bpmn.io/blog/posts/2022-core-libraries-migrated-to-es2018.html).
+* Migrated to ES2018 syntax. [Read the blog post with details and a migration guide](https://bpmn.io/blog/posts/2022-migration-to-es2018.html).
 
 ## 8.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+## 9.0.0
+
+* `FEAT`: use ES2018 syntax ([#674](https://github.com/bpmn-io/bpmn-js/pull/674))
+
+### Breaking Changes
+
+* Migrated to ES2018 syntax. [Read the blog post with details and a migration guide](https://bpmn.io/blog/posts/2022-core-libraries-migrated-to-es2018.html).
+
 ## 8.9.0
 
 * `FEAT`: expose result of editor action execution ([#660](https://github.com/bpmn-io/diagram-js/pull/660))

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 var path = require('path');
 
 var coverage = process.env.COVERAGE;

--- a/lib/command/CommandStack.js
+++ b/lib/command/CommandStack.js
@@ -147,7 +147,7 @@ CommandStack.prototype.execute = function(command, context) {
 
   this._currentExecution.trigger = 'execute';
 
-  var action = { command: command, context: context };
+  const action = { command: command, context: context };
 
   this._pushAction(action);
   this._internalExecute(action);
@@ -177,11 +177,11 @@ CommandStack.prototype.execute = function(command, context) {
  */
 CommandStack.prototype.canExecute = function(command, context) {
 
-  var action = { command: command, context: context };
+  const action = { command: command, context: context };
 
-  var handler = this._getHandler(command);
+  const handler = this._getHandler(command);
 
-  var result = this._fire(command, 'canExecute', action);
+  let result = this._fire(command, 'canExecute', action);
 
   // handler#canExecute will only be called if no listener
   // decided on a result already
@@ -216,7 +216,7 @@ CommandStack.prototype.clear = function(emit) {
  * Undo last command(s)
  */
 CommandStack.prototype.undo = function() {
-  var action = this._getUndoAction(),
+  let action = this._getUndoAction(),
       next;
 
   if (action) {
@@ -244,7 +244,7 @@ CommandStack.prototype.undo = function() {
  * Redo last command(s)
  */
 CommandStack.prototype.redo = function() {
-  var action = this._getRedoAction(),
+  let action = this._getRedoAction(),
       next;
 
   if (action) {
@@ -292,7 +292,7 @@ CommandStack.prototype.registerHandler = function(command, handlerCls) {
     throw new Error('command and handlerCls must be defined');
   }
 
-  var handler = this._injector.instantiate(handlerCls);
+  const handler = this._injector.instantiate(handlerCls);
   this.register(command, handler);
 };
 
@@ -319,24 +319,22 @@ CommandStack.prototype._getUndoAction = function() {
 // internal functionality //////////////////////
 
 CommandStack.prototype._internalUndo = function(action) {
-  var self = this;
+  const command = action.command,
+        context = action.context;
 
-  var command = action.command,
-      context = action.context;
-
-  var handler = this._getHandler(command);
+  const handler = this._getHandler(command);
 
   // guard against illegal nested command stack invocations
-  this._atomicDo(function() {
-    self._fire(command, 'revert', action);
+  this._atomicDo(() => {
+    this._fire(command, 'revert', action);
 
     if (handler.revert) {
-      self._markDirty(handler.revert(context));
+      this._markDirty(handler.revert(context));
     }
 
-    self._revertedAction(action);
+    this._revertedAction(action);
 
-    self._fire(command, 'reverted', action);
+    this._fire(command, 'reverted', action);
   });
 };
 
@@ -347,12 +345,12 @@ CommandStack.prototype._fire = function(command, qualifier, event) {
     qualifier = null;
   }
 
-  var names = qualifier ? [ command + '.' + qualifier, qualifier ] : [ command ],
-      i, name, result;
+  const names = qualifier ? [ command + '.' + qualifier, qualifier ] : [ command ];
+  let result;
 
   event = this._eventBus.createEvent(event);
 
-  for (i = 0; (name = names[i]); i++) {
+  for (const name of names) {
     result = this._eventBus.fire('commandStack.' + name, event);
 
     if (event.cancelBubble) {
@@ -369,7 +367,7 @@ CommandStack.prototype._createId = function() {
 
 CommandStack.prototype._atomicDo = function(fn) {
 
-  var execution = this._currentExecution;
+  const execution = this._currentExecution;
 
   execution.atomic = true;
 
@@ -381,12 +379,10 @@ CommandStack.prototype._atomicDo = function(fn) {
 };
 
 CommandStack.prototype._internalExecute = function(action, redo) {
-  var self = this;
+  const command = action.command,
+        context = action.context;
 
-  var command = action.command,
-      context = action.context;
-
-  var handler = this._getHandler(command);
+  const handler = this._getHandler(command);
 
   if (!handler) {
     throw new Error('no command handler registered for <' + command + '>');
@@ -405,20 +401,20 @@ CommandStack.prototype._internalExecute = function(action, redo) {
   }
 
   // guard against illegal nested command stack invocations
-  this._atomicDo(function() {
+  this._atomicDo(() => {
 
-    self._fire(command, 'execute', action);
+    this._fire(command, 'execute', action);
 
     if (handler.execute) {
 
       // actual execute + mark return results as dirty
-      self._markDirty(handler.execute(context));
+      this._markDirty(handler.execute(context));
     }
 
     // log to stack
-    self._executedAction(action, redo);
+    this._executedAction(action, redo);
 
-    self._fire(command, 'executed', action);
+    this._fire(command, 'executed', action);
   });
 
   if (!redo) {
@@ -437,10 +433,10 @@ CommandStack.prototype._internalExecute = function(action, redo) {
 
 CommandStack.prototype._pushAction = function(action) {
 
-  var execution = this._currentExecution,
-      actions = execution.actions;
+  const execution = this._currentExecution,
+        actions = execution.actions;
 
-  var baseAction = actions[0];
+  const baseAction = actions[0];
 
   if (execution.atomic) {
     throw new Error('illegal invocation in <execute> or <revert> phase (action: ' + action.command + ')');
@@ -455,10 +451,10 @@ CommandStack.prototype._pushAction = function(action) {
 
 
 CommandStack.prototype._popAction = function() {
-  var execution = this._currentExecution,
-      trigger = execution.trigger,
-      actions = execution.actions,
-      dirty = execution.dirty;
+  const execution = this._currentExecution,
+        trigger = execution.trigger,
+        actions = execution.actions,
+        dirty = execution.dirty;
 
   actions.pop();
 
@@ -475,7 +471,7 @@ CommandStack.prototype._popAction = function() {
 
 
 CommandStack.prototype._markDirty = function(elements) {
-  var execution = this._currentExecution;
+  const execution = this._currentExecution;
 
   if (!elements) {
     return;
@@ -488,7 +484,7 @@ CommandStack.prototype._markDirty = function(elements) {
 
 
 CommandStack.prototype._executedAction = function(action, redo) {
-  var stackIdx = ++this._stackIdx;
+  const stackIdx = ++this._stackIdx;
 
   if (!redo) {
     this._stack.splice(stackIdx, this._stack.length, action);

--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -65,12 +65,12 @@ function createContainer(options) {
 
   options = assign({}, { width: '100%', height: '100%' }, options);
 
-  var container = options.container || document.body;
+  const container = options.container || document.body;
 
   // create a <div> around the svg element with the respective size
   // this way we can always get the correct container size
   // (this is impossible for <svg> elements at the moment)
-  var parent = document.createElement('div');
+  const parent = document.createElement('div');
   parent.setAttribute('class', 'djs-container');
 
   assignStyle(parent, {
@@ -86,10 +86,10 @@ function createContainer(options) {
 }
 
 function createGroup(parent, cls, childIndex) {
-  var group = svgCreate('g');
+  const group = svgCreate('g');
   svgClasses(group).add(cls);
 
-  var index = childIndex !== undefined ? childIndex : parent.childNodes.length - 1;
+  const index = childIndex !== undefined ? childIndex : parent.childNodes.length - 1;
 
   // must ensure second argument is node or _null_
   // cf. https://developer.mozilla.org/en-US/docs/Web/API/Node/insertBefore
@@ -98,14 +98,14 @@ function createGroup(parent, cls, childIndex) {
   return group;
 }
 
-var BASE_LAYER = 'base';
+const BASE_LAYER = 'base';
 
 // render plane contents behind utility layers
-var PLANE_LAYER_INDEX = 0;
-var UTILITY_LAYER_INDEX = 1;
+const PLANE_LAYER_INDEX = 0;
+const UTILITY_LAYER_INDEX = 1;
 
 
-var REQUIRED_MODEL_ATTRS = {
+const REQUIRED_MODEL_ATTRS = {
   shape: [ 'x', 'y', 'width', 'height' ],
   connection: [ 'waypoints' ]
 };
@@ -160,17 +160,17 @@ Canvas.$inject = [
  */
 Canvas.prototype._init = function(config) {
 
-  var eventBus = this._eventBus;
+  const eventBus = this._eventBus;
 
   // html container
-  var container = this._container = createContainer(config);
+  const container = this._container = createContainer(config);
 
-  var svg = this._svg = svgCreate('svg');
+  const svg = this._svg = svgCreate('svg');
   svgAttr(svg, { width: '100%', height: '100%' });
 
   svgAppend(container, svg);
 
-  var viewport = this._viewport = createGroup(svg, 'viewport');
+  const viewport = this._viewport = createGroup(svg, 'viewport');
 
   // debounce canvas.viewbox.changed events
   // for smoother diagram interaction
@@ -221,7 +221,7 @@ Canvas.prototype._destroy = function(emit) {
     viewport: this._viewport
   });
 
-  var parent = this._container.parentNode;
+  const parent = this._container.parentNode;
 
   if (parent) {
     parent.removeChild(this._container);
@@ -237,18 +237,16 @@ Canvas.prototype._destroy = function(emit) {
 
 Canvas.prototype._clear = function() {
 
-  var self = this;
-
-  var allElements = this._elementRegistry.getAll();
+  const allElements = this._elementRegistry.getAll();
 
   // remove all elements
-  allElements.forEach(function(element) {
-    var type = getType(element);
+  allElements.forEach(element => {
+    const type = getType(element);
 
     if (type === 'root') {
-      self.removeRootElement(element);
+      this.removeRootElement(element);
     } else {
-      self._removeElement(element, type);
+      this._removeElement(element, type);
     }
   });
 
@@ -291,7 +289,7 @@ Canvas.prototype.getLayer = function(name, index) {
     throw new Error('must specify a name');
   }
 
-  var layer = this._layers[name];
+  let layer = this._layers[name];
 
   if (!layer) {
     layer = this._layers[name] = this._createLayer(name, index);
@@ -339,7 +337,7 @@ Canvas.prototype._createLayer = function(name, index) {
     index = UTILITY_LAYER_INDEX;
   }
 
-  var childIndex = this._getChildIndex(index);
+  const childIndex = this._getChildIndex(index);
 
   return {
     group: createGroup(this._viewport, 'layer-' + name, childIndex),
@@ -361,21 +359,21 @@ Canvas.prototype.showLayer = function(name) {
     throw new Error('must specify a name');
   }
 
-  var layer = this._layers[name];
+  const layer = this._layers[name];
 
   if (!layer) {
     throw new Error('layer <' + name + '> does not exist');
   }
 
-  var viewport = this._viewport;
-  var group = layer.group;
-  var index = layer.index;
+  const viewport = this._viewport;
+  const group = layer.group;
+  const index = layer.index;
 
   if (layer.visible) {
     return group;
   }
 
-  var childIndex = this._getChildIndex(index);
+  const childIndex = this._getChildIndex(index);
 
   viewport.insertBefore(group, viewport.childNodes[childIndex] || null);
 
@@ -396,13 +394,13 @@ Canvas.prototype.hideLayer = function(name) {
     throw new Error('must specify a name');
   }
 
-  var layer = this._layers[name];
+  const layer = this._layers[name];
 
   if (!layer) {
     throw new Error('layer <' + name + '> does not exist');
   }
 
-  var group = layer.group;
+  const group = layer.group;
 
   if (!layer.visible) {
     return group;
@@ -418,7 +416,7 @@ Canvas.prototype.hideLayer = function(name) {
 
 Canvas.prototype._removeLayer = function(name) {
 
-  var layer = this._layers[name];
+  const layer = this._layers[name];
 
   if (layer) {
     delete this._layers[name];
@@ -433,7 +431,7 @@ Canvas.prototype._removeLayer = function(name) {
  * @returns {SVGElement|null}
  */
 Canvas.prototype.getActiveLayer = function() {
-  var plane = this._findPlaneForRoot(this.getRootElement());
+  const plane = this._findPlaneForRoot(this.getRootElement());
 
   if (!plane) {
     return null;
@@ -459,7 +457,7 @@ Canvas.prototype.findRoot = function(element) {
     return;
   }
 
-  var plane = this._findPlaneForRoot(
+  const plane = this._findPlaneForRoot(
     findRoot(element)
   ) || {};
 
@@ -498,7 +496,7 @@ Canvas.prototype.getContainer = function() {
 // markers //////////////////////
 
 Canvas.prototype._updateMarker = function(element, marker, add) {
-  var container;
+  let container;
 
   if (!element.id) {
     element = this._elementRegistry.get(element);
@@ -546,7 +544,7 @@ Canvas.prototype._updateMarker = function(element, marker, add) {
  * @example
  * canvas.addMarker('foo', 'some-marker');
  *
- * var fooGfx = canvas.getGraphics('foo');
+ * const fooGfx = canvas.getGraphics('foo');
  *
  * fooGfx; // <g class="... some-marker"> ... </g>
  *
@@ -582,7 +580,7 @@ Canvas.prototype.hasMarker = function(element, marker) {
     element = this._elementRegistry.get(element);
   }
 
-  var gfx = this.getGraphics(element);
+  const gfx = this.getGraphics(element);
 
   return svgClasses(gfx).has(marker);
 };
@@ -620,7 +618,7 @@ Canvas.prototype.toggleMarker = function(element, marker) {
  * @returns {Object|djs.model.Root|null} rootElement.
  */
 Canvas.prototype.getRootElement = function() {
-  var rootElement = this._rootElement;
+  const rootElement = this._rootElement;
 
   // can return null if root elements are present but none was set yet
   if (rootElement || this._planes.length) {
@@ -639,7 +637,7 @@ Canvas.prototype.getRootElement = function() {
  */
 
 Canvas.prototype.addRootElement = function(rootElement) {
-  var idx = this._rootsIdx++;
+  const idx = this._rootsIdx++;
 
   if (!rootElement) {
     rootElement = {
@@ -649,11 +647,11 @@ Canvas.prototype.addRootElement = function(rootElement) {
     };
   }
 
-  var layerName = rootElement.layer = 'root-' + idx;
+  const layerName = rootElement.layer = 'root-' + idx;
 
   this._ensureValid('root', rootElement);
 
-  var layer = this.getLayer(layerName, PLANE_LAYER_INDEX);
+  const layer = this.getLayer(layerName, PLANE_LAYER_INDEX);
 
   this.hideLayer(layerName);
 
@@ -680,7 +678,7 @@ Canvas.prototype.removeRootElement = function(rootElement) {
     rootElement = this._elementRegistry.get(rootElement);
   }
 
-  var plane = this._findPlaneForRoot(rootElement);
+  const plane = this._findPlaneForRoot(rootElement);
 
   if (!plane) {
     return;
@@ -726,7 +724,7 @@ Canvas.prototype.setRootElement = function(rootElement, override) {
     return;
   }
 
-  var plane;
+  let plane;
 
   if (!rootElement) {
     throw new Error('rootElement required');
@@ -746,8 +744,8 @@ Canvas.prototype.setRootElement = function(rootElement, override) {
 
 
 Canvas.prototype._removeRoot = function(element) {
-  var elementRegistry = this._elementRegistry,
-      eventBus = this._eventBus;
+  const elementRegistry = this._elementRegistry,
+        eventBus = this._eventBus;
 
   // simulate element remove event sequence
   eventBus.fire('root.remove', { element: element });
@@ -758,8 +756,8 @@ Canvas.prototype._removeRoot = function(element) {
 
 
 Canvas.prototype._addRoot = function(element, gfx) {
-  var elementRegistry = this._elementRegistry,
-      eventBus = this._eventBus;
+  const elementRegistry = this._elementRegistry,
+        eventBus = this._eventBus;
 
   // resemble element add event sequence
   eventBus.fire('root.add', { element: element });
@@ -772,7 +770,7 @@ Canvas.prototype._addRoot = function(element, gfx) {
 
 Canvas.prototype._setRoot = function(rootElement, layer) {
 
-  var currentRoot = this._rootElement;
+  const currentRoot = this._rootElement;
 
   if (currentRoot) {
 
@@ -812,9 +810,9 @@ Canvas.prototype._ensureValid = function(type, element) {
     throw new Error('element <' + element.id + '> already exists');
   }
 
-  var requiredAttrs = REQUIRED_MODEL_ATTRS[type];
+  const requiredAttrs = REQUIRED_MODEL_ATTRS[type];
 
-  var valid = every(requiredAttrs, function(attr) {
+  const valid = every(requiredAttrs, function(attr) {
     return typeof element[attr] !== 'undefined';
   });
 
@@ -853,8 +851,8 @@ Canvas.prototype._addElement = function(type, element, parent, parentIndex) {
 
   parent = parent || this.getRootElement();
 
-  var eventBus = this._eventBus,
-      graphicsFactory = this._graphicsFactory;
+  const eventBus = this._eventBus,
+        graphicsFactory = this._graphicsFactory;
 
   this._ensureValid(type, element);
 
@@ -863,7 +861,7 @@ Canvas.prototype._addElement = function(type, element, parent, parentIndex) {
   this._setParent(element, parent, parentIndex);
 
   // create graphics
-  var gfx = graphicsFactory.create(type, element, parentIndex);
+  const gfx = graphicsFactory.create(type, element, parentIndex);
 
   this._elementRegistry.add(element, gfx);
 
@@ -907,9 +905,9 @@ Canvas.prototype.addConnection = function(connection, parent, parentIndex) {
  */
 Canvas.prototype._removeElement = function(element, type) {
 
-  var elementRegistry = this._elementRegistry,
-      graphicsFactory = this._graphicsFactory,
-      eventBus = this._eventBus;
+  const elementRegistry = this._elementRegistry,
+        graphicsFactory = this._graphicsFactory,
+        eventBus = this._eventBus;
 
   element = elementRegistry.get(element.id || element);
 
@@ -1058,7 +1056,7 @@ Canvas.prototype._viewboxChanged = function() {
  * // sets the visible area of the diagram to (100|100) -> (600|100)
  * // and and scales it according to the diagram width
  *
- * var viewbox = canvas.viewbox(); // pass `false` to force recomputing the box.
+ * const viewbox = canvas.viewbox(); // pass `false` to force recomputing the box.
  *
  * console.log(viewbox);
  * // {
@@ -1072,7 +1070,7 @@ Canvas.prototype._viewboxChanged = function() {
  * // if the current diagram is zoomed and scrolled, you may reset it to the
  * // default zoom via this method, too:
  *
- * var zoomedAndScrolledViewbox = canvas.viewbox();
+ * const zoomedAndScrolledViewbox = canvas.viewbox();
  *
  * canvas.viewbox({
  *   x: 0,
@@ -1095,9 +1093,9 @@ Canvas.prototype.viewbox = function(box) {
     return this._cachedViewbox;
   }
 
-  var viewport = this._viewport,
-      innerBox,
-      outerBox = this.getSize(),
+  const viewport = this._viewport,
+        outerBox = this.getSize();
+  let innerBox,
       matrix,
       activeLayer,
       transform,
@@ -1141,7 +1139,7 @@ Canvas.prototype.viewbox = function(box) {
     this._changeViewbox(function() {
       scale = Math.min(outerBox.width / box.width, outerBox.height / box.height);
 
-      var matrix = this._svg.createSVGMatrix()
+      const matrix = this._svg.createSVGMatrix()
         .scale(scale)
         .translate(-box.x, -box.y);
 
@@ -1163,8 +1161,8 @@ Canvas.prototype.viewbox = function(box) {
  */
 Canvas.prototype.scroll = function(delta) {
 
-  var node = this._viewport;
-  var matrix = node.getCTM();
+  const node = this._viewport;
+  let matrix = node.getCTM();
 
   if (delta) {
     this._changeViewbox(function() {
@@ -1188,14 +1186,14 @@ Canvas.prototype.scroll = function(delta) {
  *
  */
 Canvas.prototype.scrollToElement = function(element, padding) {
-  var defaultPadding = 100;
+  let defaultPadding = 100;
 
   if (typeof element === 'string') {
     element = this._elementRegistry.get(element);
   }
 
   // set to correct rootElement
-  var rootElement = this.findRoot(element);
+  const rootElement = this.findRoot(element);
 
   if (rootElement !== this.getRootElement()) {
     this.setRootElement(rootElement);
@@ -1215,11 +1213,11 @@ Canvas.prototype.scrollToElement = function(element, padding) {
     left: padding.left || defaultPadding
   };
 
-  var elementBounds = getBoundingBox(element),
-      elementTrbl = asTRBL(elementBounds),
-      viewboxBounds = this.viewbox(),
-      zoom = this.zoom(),
-      dx, dy;
+  const elementBounds = getBoundingBox(element),
+        elementTrbl = asTRBL(elementBounds),
+        viewboxBounds = this.viewbox(),
+        zoom = this.zoom();
+  let dx, dy;
 
   // shrink viewboxBounds with padding
   viewboxBounds.y += padding.top / zoom;
@@ -1227,9 +1225,9 @@ Canvas.prototype.scrollToElement = function(element, padding) {
   viewboxBounds.width -= (padding.right + padding.left) / zoom;
   viewboxBounds.height -= (padding.bottom + padding.top) / zoom;
 
-  var viewboxTrbl = asTRBL(viewboxBounds);
+  const viewboxTrbl = asTRBL(viewboxBounds);
 
-  var canFit = elementBounds.width < viewboxBounds.width && elementBounds.height < viewboxBounds.height;
+  const canFit = elementBounds.width < viewboxBounds.width && elementBounds.height < viewboxBounds.height;
 
   if (!canFit) {
 
@@ -1239,10 +1237,10 @@ Canvas.prototype.scrollToElement = function(element, padding) {
 
   } else {
 
-    var dRight = Math.max(0, elementTrbl.right - viewboxTrbl.right),
-        dLeft = Math.min(0, elementTrbl.left - viewboxTrbl.left),
-        dBottom = Math.max(0, elementTrbl.bottom - viewboxTrbl.bottom),
-        dTop = Math.min(0, elementTrbl.top - viewboxTrbl.top);
+    const dRight = Math.max(0, elementTrbl.right - viewboxTrbl.right),
+          dLeft = Math.min(0, elementTrbl.left - viewboxTrbl.left),
+          dBottom = Math.max(0, elementTrbl.bottom - viewboxTrbl.bottom),
+          dTop = Math.min(0, elementTrbl.top - viewboxTrbl.top);
 
     dx = dRight || dLeft;
     dy = dBottom || dTop;
@@ -1275,7 +1273,7 @@ Canvas.prototype.zoom = function(newScale, center) {
     return this._fitViewport(center);
   }
 
-  var outer,
+  let outer,
       matrix;
 
   this._changeViewbox(function() {
@@ -1296,16 +1294,16 @@ Canvas.prototype.zoom = function(newScale, center) {
 };
 
 function setCTM(node, m) {
-  var mstr = 'matrix(' + m.a + ',' + m.b + ',' + m.c + ',' + m.d + ',' + m.e + ',' + m.f + ')';
+  const mstr = 'matrix(' + m.a + ',' + m.b + ',' + m.c + ',' + m.d + ',' + m.e + ',' + m.f + ')';
   node.setAttribute('transform', mstr);
 }
 
 Canvas.prototype._fitViewport = function(center) {
 
-  var vbox = this.viewbox(),
-      outer = vbox.outer,
-      inner = vbox.inner,
-      newScale,
+  const vbox = this.viewbox(),
+        outer = vbox.outer,
+        inner = vbox.inner;
+  let newScale,
       newViewbox;
 
   // display the complete diagram without zooming in.
@@ -1346,13 +1344,13 @@ Canvas.prototype._fitViewport = function(center) {
 
 Canvas.prototype._setZoom = function(scale, center) {
 
-  var svg = this._svg,
-      viewport = this._viewport;
+  const svg = this._svg,
+        viewport = this._viewport;
 
-  var matrix = svg.createSVGMatrix();
-  var point = svg.createSVGPoint();
+  const matrix = svg.createSVGMatrix();
+  const point = svg.createSVGPoint();
 
-  var centerPoint,
+  let centerPoint,
       originalPoint,
       currentMatrix,
       scaleMatrix,
@@ -1360,7 +1358,7 @@ Canvas.prototype._setZoom = function(scale, center) {
 
   currentMatrix = viewport.getCTM();
 
-  var currentScale = currentMatrix.a;
+  const currentScale = currentMatrix.a;
 
   if (center) {
     centerPoint = assign(point, center);
@@ -1409,13 +1407,13 @@ Canvas.prototype.getSize = function() {
  * @return {Bounds} the absolute bounding box
  */
 Canvas.prototype.getAbsoluteBBox = function(element) {
-  var vbox = this.viewbox();
-  var bbox;
+  const vbox = this.viewbox();
+  let bbox;
 
   // connection
   // use svg bbox
   if (element.waypoints) {
-    var gfx = this.getGraphics(element);
+    const gfx = this.getGraphics(element);
 
     bbox = gfx.getBBox();
   }
@@ -1426,11 +1424,11 @@ Canvas.prototype.getAbsoluteBBox = function(element) {
     bbox = element;
   }
 
-  var x = bbox.x * vbox.scale - vbox.x * vbox.scale;
-  var y = bbox.y * vbox.scale - vbox.y * vbox.scale;
+  const x = bbox.x * vbox.scale - vbox.x * vbox.scale;
+  const y = bbox.y * vbox.scale - vbox.y * vbox.scale;
 
-  var width = bbox.width * vbox.scale;
-  var height = bbox.height * vbox.scale;
+  const width = bbox.width * vbox.scale;
+  const height = bbox.height * vbox.scale;
 
   return {
     x: x,

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "babel-plugin-istanbul": "^6.1.1",
         "chai": "^4.2.0",
         "eslint": "^8.22.0",
-        "eslint-plugin-bpmn-io": "^0.14.1",
+        "eslint-plugin-bpmn-io": "^0.15.1",
         "eslint-plugin-import": "^2.26.0",
         "jquery": "^3.5.1",
         "karma": "^6.4.0",
@@ -137,39 +137,6 @@
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/eslint-parser": {
-      "version": "7.18.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-scope": "^5.1.1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@babel/eslint-parser/node_modules/semver": {
       "version": "6.3.0",
       "dev": true,
       "license": "ISC",
@@ -351,20 +318,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.18.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/template": {
@@ -2428,280 +2381,16 @@
       }
     },
     "node_modules/eslint-plugin-bpmn-io": {
-      "version": "0.14.1",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-bpmn-io/-/eslint-plugin-bpmn-io-0.15.1.tgz",
+      "integrity": "sha512-J0eN4rzyNTER6dpW8EbiDZ6uhvOZXmvvmWABB4t2fQtUHyHZ0zd3gLMtYWZI0yMurVxpr7KWOzo7Yokz5QDILg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.18.10",
-        "@babel/eslint-parser": "^7.18.9",
-        "@babel/plugin-syntax-jsx": "^7.18.6",
         "eslint-plugin-mocha": "^10.1.0",
         "eslint-plugin-react": "^7.30.1"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/compat-data": {
-      "version": "7.18.8",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/core": {
-      "version": "7.18.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.18.10",
-        "@babel/helper-compilation-targets": "^7.18.9",
-        "@babel/helper-module-transforms": "^7.18.9",
-        "@babel/helpers": "^7.18.9",
-        "@babel/parser": "^7.18.10",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.18.10",
-        "@babel/types": "^7.18.10",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/generator": {
-      "version": "7.18.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.18.10",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "jsesc": "^2.5.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/helper-compilation-targets": {
-      "version": "7.18.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.18.8",
-        "@babel/helper-validator-option": "^7.18.6",
-        "browserslist": "^4.20.2",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/helper-environment-visitor": {
-      "version": "7.18.9",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/helper-function-name": {
-      "version": "7.18.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.18.6",
-        "@babel/types": "^7.18.9"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/helper-hoist-variables": {
-      "version": "7.18.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/helper-module-imports": {
-      "version": "7.18.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/helper-module-transforms": {
-      "version": "7.18.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-simple-access": "^7.18.6",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "@babel/template": "^7.18.6",
-        "@babel/traverse": "^7.18.9",
-        "@babel/types": "^7.18.9"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/helper-simple-access": {
-      "version": "7.18.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.18.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/helper-validator-option": {
-      "version": "7.18.6",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/helpers": {
-      "version": "7.18.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.18.6",
-        "@babel/traverse": "^7.18.9",
-        "@babel/types": "^7.18.9"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/parser": {
-      "version": "7.18.11",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/template": {
-      "version": "7.18.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.18.6",
-        "@babel/parser": "^7.18.10",
-        "@babel/types": "^7.18.10"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/traverse": {
-      "version": "7.18.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.18.10",
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-function-name": "^7.18.9",
-        "@babel/helper-hoist-variables": "^7.18.6",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.18.11",
-        "@babel/types": "^7.18.10",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/types": {
-      "version": "7.18.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.18.10",
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/convert-source-map": {
-      "version": "1.8.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/json5": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/semver": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
+        "eslint": "^8.0.0"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -8154,25 +7843,6 @@
         }
       }
     },
-    "@babel/eslint-parser": {
-      "version": "7.18.9",
-      "dev": true,
-      "requires": {
-        "eslint-scope": "^5.1.1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "2.1.0",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "dev": true
-        }
-      }
-    },
     "@babel/generator": {
       "version": "7.18.12",
       "dev": true,
@@ -8280,13 +7950,6 @@
     "@babel/parser": {
       "version": "7.17.3",
       "dev": true
-    },
-    "@babel/plugin-syntax-jsx": {
-      "version": "7.18.6",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.18.6"
-      }
     },
     "@babel/template": {
       "version": "7.18.10",
@@ -9820,184 +9483,13 @@
       }
     },
     "eslint-plugin-bpmn-io": {
-      "version": "0.14.1",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-bpmn-io/-/eslint-plugin-bpmn-io-0.15.1.tgz",
+      "integrity": "sha512-J0eN4rzyNTER6dpW8EbiDZ6uhvOZXmvvmWABB4t2fQtUHyHZ0zd3gLMtYWZI0yMurVxpr7KWOzo7Yokz5QDILg==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.18.10",
-        "@babel/eslint-parser": "^7.18.9",
-        "@babel/plugin-syntax-jsx": "^7.18.6",
         "eslint-plugin-mocha": "^10.1.0",
         "eslint-plugin-react": "^7.30.1"
-      },
-      "dependencies": {
-        "@babel/compat-data": {
-          "version": "7.18.8",
-          "dev": true
-        },
-        "@babel/core": {
-          "version": "7.18.10",
-          "dev": true,
-          "requires": {
-            "@ampproject/remapping": "^2.1.0",
-            "@babel/code-frame": "^7.18.6",
-            "@babel/generator": "^7.18.10",
-            "@babel/helper-compilation-targets": "^7.18.9",
-            "@babel/helper-module-transforms": "^7.18.9",
-            "@babel/helpers": "^7.18.9",
-            "@babel/parser": "^7.18.10",
-            "@babel/template": "^7.18.10",
-            "@babel/traverse": "^7.18.10",
-            "@babel/types": "^7.18.10",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.2",
-            "json5": "^2.2.1",
-            "semver": "^6.3.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.18.12",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.18.10",
-            "@jridgewell/gen-mapping": "^0.3.2",
-            "jsesc": "^2.5.1"
-          }
-        },
-        "@babel/helper-compilation-targets": {
-          "version": "7.18.9",
-          "dev": true,
-          "requires": {
-            "@babel/compat-data": "^7.18.8",
-            "@babel/helper-validator-option": "^7.18.6",
-            "browserslist": "^4.20.2",
-            "semver": "^6.3.0"
-          }
-        },
-        "@babel/helper-environment-visitor": {
-          "version": "7.18.9",
-          "dev": true
-        },
-        "@babel/helper-function-name": {
-          "version": "7.18.9",
-          "dev": true,
-          "requires": {
-            "@babel/template": "^7.18.6",
-            "@babel/types": "^7.18.9"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.18.6",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.18.6"
-          }
-        },
-        "@babel/helper-module-imports": {
-          "version": "7.18.6",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.18.6"
-          }
-        },
-        "@babel/helper-module-transforms": {
-          "version": "7.18.9",
-          "dev": true,
-          "requires": {
-            "@babel/helper-environment-visitor": "^7.18.9",
-            "@babel/helper-module-imports": "^7.18.6",
-            "@babel/helper-simple-access": "^7.18.6",
-            "@babel/helper-split-export-declaration": "^7.18.6",
-            "@babel/helper-validator-identifier": "^7.18.6",
-            "@babel/template": "^7.18.6",
-            "@babel/traverse": "^7.18.9",
-            "@babel/types": "^7.18.9"
-          }
-        },
-        "@babel/helper-simple-access": {
-          "version": "7.18.6",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.18.6"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.18.6",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.18.6"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.18.6",
-          "dev": true
-        },
-        "@babel/helper-validator-option": {
-          "version": "7.18.6",
-          "dev": true
-        },
-        "@babel/helpers": {
-          "version": "7.18.9",
-          "dev": true,
-          "requires": {
-            "@babel/template": "^7.18.6",
-            "@babel/traverse": "^7.18.9",
-            "@babel/types": "^7.18.9"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.18.11",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.18.10",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.18.6",
-            "@babel/parser": "^7.18.10",
-            "@babel/types": "^7.18.10"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.18.11",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.18.6",
-            "@babel/generator": "^7.18.10",
-            "@babel/helper-environment-visitor": "^7.18.9",
-            "@babel/helper-function-name": "^7.18.9",
-            "@babel/helper-hoist-variables": "^7.18.6",
-            "@babel/helper-split-export-declaration": "^7.18.6",
-            "@babel/parser": "^7.18.11",
-            "@babel/types": "^7.18.10",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.18.10",
-          "dev": true,
-          "requires": {
-            "@babel/helper-string-parser": "^7.18.10",
-            "@babel/helper-validator-identifier": "^7.18.6",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "convert-source-map": {
-          "version": "1.8.0",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.1"
-          }
-        },
-        "json5": {
-          "version": "2.2.1",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "dev": true
-        }
       }
     },
     "eslint-plugin-import": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "css.escape": "^1.5.1",
-        "didi": "^8.0.1",
+        "didi": "^9.0.0",
         "hammerjs": "^2.0.1",
         "inherits-browser": "0.0.1",
         "min-dash": "^3.5.2",
@@ -2049,8 +2049,9 @@
       "license": "MIT"
     },
     "node_modules/didi": {
-      "version": "8.0.1",
-      "license": "MIT"
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
+      "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w=="
     },
     "node_modules/diff": {
       "version": "5.0.0",
@@ -9109,7 +9110,9 @@
       "dev": true
     },
     "didi": {
-      "version": "8.0.1"
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
+      "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w=="
     },
     "diff": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-plugin-istanbul": "^6.1.1",
     "chai": "^4.2.0",
     "eslint": "^8.22.0",
-    "eslint-plugin-bpmn-io": "^0.14.1",
+    "eslint-plugin-bpmn-io": "^0.15.1",
     "eslint-plugin-import": "^2.26.0",
     "jquery": "^3.5.1",
     "karma": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "css.escape": "^1.5.1",
-    "didi": "^8.0.1",
+    "didi": "^9.0.0",
     "hammerjs": "^2.0.1",
     "inherits-browser": "0.0.1",
     "min-dash": "^3.5.2",


### PR DESCRIPTION
# Breaking Changes

* Migrated to ES2018 syntax. [Read the blog post with details and a migration guide](https://bpmn.io/blog/posts/2022-core-libraries-migrated-to-es2018.html).

---

Requires https://github.com/bpmn-io/bpmn.io/pull/147