### PR TITLE
Make keyboard friendly enough

### DIFF
--- a/lib/features/keyboard/Keyboard.js
+++ b/lib/features/keyboard/Keyboard.js
@@ -24,7 +24,7 @@ var DEFAULT_PRIORITY = 1000;
 
 /**
  * A keyboard abstraction that may be activated and
- * deactivated by users at will, consuming key events
+ * deactivated by users at will, consuming global key events
  * and triggering diagram actions.
  *
  * For keys pressed down, keyboard fires `keyboard.keydown` event.

--- a/lib/features/keyboard/Keyboard.js
+++ b/lib/features/keyboard/Keyboard.js
@@ -109,6 +109,10 @@ Keyboard.prototype._keyHandler = function(event, type) {
 };
 
 Keyboard.prototype._isEventIgnored = function(event) {
+  if (event.defaultPrevented) {
+    return true;
+  }
+
   return isInput(event.target) && this._isModifiedKeyIgnored(event);
 };
 
@@ -139,8 +143,8 @@ Keyboard.prototype.bind = function(node) {
   this._node = node;
 
   // bind key events
-  domEvent.bind(node, 'keydown', this._keydownHandler, true);
-  domEvent.bind(node, 'keyup', this._keyupHandler, true);
+  domEvent.bind(node, 'keydown', this._keydownHandler);
+  domEvent.bind(node, 'keyup', this._keyupHandler);
 
   this._fire('bind');
 };
@@ -156,8 +160,8 @@ Keyboard.prototype.unbind = function() {
     this._fire('unbind');
 
     // unbind key events
-    domEvent.unbind(node, 'keydown', this._keydownHandler, true);
-    domEvent.unbind(node, 'keyup', this._keyupHandler, true);
+    domEvent.unbind(node, 'keydown', this._keydownHandler);
+    domEvent.unbind(node, 'keyup', this._keyupHandler);
   }
 
   this._node = null;

--- a/test/spec/features/keyboard/KeyboardSpec.js
+++ b/test/spec/features/keyboard/KeyboardSpec.js
@@ -180,39 +180,68 @@ describe('features/keyboard', function() {
     });
 
 
+    it('should ignore propagation stopped events', inject(
       function(keyboard, eventBus) {
 
         // given
-        var eventBusSpy = sinon.spy(eventBus, 'fire');
+        var keyListener = sinon.spy();
 
-        var inputField = document.createElement('input');
-        testDiv.appendChild(inputField);
+        keyboard.bind(testDiv);
+
+        eventBus.on('keyboard.keydown', keyListener);
+        eventBus.on('keyboard.keyup', keyListener);
+
+        var testEl = domify('<div tab-index="-1"></div>');
+
+        testEl.addEventListener('keydown', function(event) {
+          event.stopPropagation();
+        });
+
+        testEl.addEventListener('keyup', function(event) {
+          event.stopPropagation();
+        });
+
+        testDiv.appendChild(testEl);
 
         // when
-        keyboard._keyHandler({ key: TEST_KEY, target: inputField });
-        keyboard._keyHandler({ key: TEST_KEY, shiftKey: true, target: inputField });
+        dispatchKeyboardEvent(testEl, 'keydown');
+        dispatchKeyboardEvent(testEl, 'keyup');
 
         // then
-        expect(eventBusSpy).to.not.be.called;
+        expect(keyListener).not.to.be.called;
       })
     );
 
 
-    it('should not fire modifier event if target is input field', inject(
+    it('should ignore default prevented events', inject(
       function(keyboard, eventBus) {
 
         // given
-        var eventBusSpy = sinon.spy(eventBus, 'fire');
+        var keyListener = sinon.spy();
 
-        var inputField = document.createElement('input');
-        testDiv.appendChild(inputField);
+        keyboard.bind(testDiv);
+
+        eventBus.on('keyboard.keydown', keyListener);
+        eventBus.on('keyboard.keyup', keyListener);
+
+        var testEl = domify('<div tab-index="-1"></div>');
+
+        testEl.addEventListener('keydown', function(event) {
+          event.preventDefault();
+        });
+
+        testEl.addEventListener('keyup', function(event) {
+          event.preventDefault();
+        });
+
+        testDiv.appendChild(testEl);
 
         // when
-        keyboard._keyHandler({ key: TEST_KEY, metaKey: true, target: inputField });
-        keyboard._keyHandler({ key: TEST_KEY, ctrlKey: true, target: inputField });
+        dispatchKeyboardEvent(testEl, 'keydown');
+        dispatchKeyboardEvent(testEl, 'keyup');
 
         // then
-        expect(eventBusSpy).to.not.be.called;
+        expect(keyListener).not.to.be.called;
       })
     );
 
@@ -482,6 +511,7 @@ describe('features/keyboard', function() {
 // helpers //////////
 
 function dispatchKeyboardEvent(target, type) {
-  var event = createKeyEvent('Any', { type: type });
+  var event = createKeyEvent('KeyA', { type });
+
   target.dispatchEvent(event);
 }

--- a/test/spec/features/keyboard/KeyboardSpec.js
+++ b/test/spec/features/keyboard/KeyboardSpec.js
@@ -139,7 +139,47 @@ describe('features/keyboard', function() {
     }));
 
 
-    it('should not fire non-modifier event if target is input field', inject(
+    describe('should ignore input field targets', function() {
+
+      it('non-modifier event', inject(
+        function(keyboard, eventBus) {
+
+          // given
+          var eventBusSpy = sinon.spy(eventBus, 'fire');
+
+          var inputField = document.createElement('input');
+          testDiv.appendChild(inputField);
+
+          // when
+          keyboard._keyHandler({ key: TEST_KEY, target: inputField });
+          keyboard._keyHandler({ key: TEST_KEY, shiftKey: true, target: inputField });
+
+          // then
+          expect(eventBusSpy).to.not.be.called;
+        })
+      );
+
+      it('modifier event', inject(
+        function(keyboard, eventBus) {
+
+          // given
+          var eventBusSpy = sinon.spy(eventBus, 'fire');
+
+          var inputField = document.createElement('input');
+          testDiv.appendChild(inputField);
+
+          // when
+          keyboard._keyHandler({ key: TEST_KEY, metaKey: true, target: inputField });
+          keyboard._keyHandler({ key: TEST_KEY, ctrlKey: true, target: inputField });
+
+          // then
+          expect(eventBusSpy).to.not.be.called;
+        })
+      );
+
+    });
+
+
       function(keyboard, eventBus) {
 
         // given


### PR DESCRIPTION
Ensure we play nice with other UI components up in the component tree; rather than handling keys on capture, handle events on bubble. Ignore events that got their propagation stopped or their default prevented.


A result of this PR is that components downwards in the component tree can use standard DOM facilities to prevent the event from being handled by keyboard:

```
(e)
 |
 * <Some Component> (e.stopPropagation())
 
 * <Keyboard>
```
-----

Closes #707 