### PR TITLE
Correctly listen for <Escape> to cancel dragging

### DIFF
--- a/lib/features/dragging/Dragging.js
+++ b/lib/features/dragging/Dragging.js
@@ -284,7 +284,7 @@ export default function Dragging(eventBus, canvas, selection, elementRegistry) {
 
   function checkCancel(event) {
 
-    if (isKey('Escape')) {
+    if (isKey('Escape', event)) {
       preventDefault(event);
 
       cancel();

--- a/test/spec/features/dragging/DraggingSpec.js
+++ b/test/spec/features/dragging/DraggingSpec.js
@@ -12,6 +12,8 @@ import zoomScrollModule from 'lib/navigation/zoomscroll';
 import createModule from 'lib/features/create';
 import modelingModule from 'lib/features/modeling';
 
+import { createKeyEvent } from 'test/util/KeyEvents';
+
 import { classes as svgClasses } from 'tiny-svg';
 
 
@@ -424,6 +426,30 @@ describe('features/dragging - Dragging', function() {
     ));
 
   });
+
+});
+
+
+describe('features/dragging - keyboard integration', function() {
+
+  beforeEach(bootstrapDiagram({
+    modules: [
+      dragModule
+    ]
+  }));
+
+
+  it('should cancel on <Escape>', inject(function(dragging) {
+
+    // given
+    dragging.init(canvasEvent({ x: 10, y: 10 }), 'foo');
+
+    // when
+    document.dispatchEvent(createKeyEvent('Escape', { type: 'keyup' }));
+
+    // then
+    expect(dragging.context()).not.to.exist;
+  }));
 
 });
 


### PR DESCRIPTION
Corrects a regression introduced with https://github.com/bpmn-io/diagram-js/pull/681/files#diff-ea53e0ed1128baaadcc175076dc701fd054fe6888b90ec144a17a786dbbca707.