### PR TITLE
Fix upgrade issues

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -555,13 +555,6 @@ marker.djs-dragger tspan {
   outline: none;
 }
 
-.djs-popup_header {
-  display: flex;
-  align-items: stretch;
-  line-height: 20px;
-  margin: 12px 12px 10px 12px;
-}
-
 .djs-popup-header {
   display: flex;
   align-items: stretch;

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -514,7 +514,7 @@ marker.djs-dragger tspan {
 /**
  * popup styles
  */
-.djs-popup {
+.djs-popup-backdrop {
   position: fixed;
   width: 100vw;
   height: 100vh;
@@ -527,7 +527,7 @@ marker.djs-dragger tspan {
   border-radius: 2px;
 }
 
-.djs-popup-overlay {
+.djs-popup {
   width: min-content;
   background: var(--popup-background-color);
   overflow: hidden;

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -536,6 +536,7 @@ marker.djs-dragger tspan {
   box-shadow: 0px 2px 10px var(--popup-shadow-color);
   padding-top: 12px;
   min-width: 120px;
+  outline: none;
 }
 
 .djs-popup-search input {

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -534,7 +534,6 @@ marker.djs-dragger tspan {
   position: absolute;
 
   box-shadow: 0px 2px 10px var(--popup-shadow-color);
-  padding-top: 12px;
   min-width: 120px;
   outline: none;
 }
@@ -559,7 +558,7 @@ marker.djs-dragger tspan {
   display: flex;
   align-items: stretch;
   line-height: 20px;
-  margin: 0 12px 10px 12px;
+  margin: 10px 12px 10px 12px;
 }
 
 .djs-popup-header .entry {
@@ -603,7 +602,7 @@ marker.djs-dragger tspan {
 }
 
 .djs-popup-results {
-  margin: 0 3px 7px 12px;
+  margin: 7px 3px 7px 12px;
   list-style: none;
   max-height: 280px;
   overflow: overlay;

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -249,9 +249,9 @@ function PopupMenuWrapper(props) {
 
   const checkClose = useCallback((event) => {
 
-    const overlay = domClosest(event.target, '.djs-popup .djs-popup-overlay', true);
+    const popup = domClosest(event.target, '.djs-popup', true);
 
-    if (overlay) {
+    if (popup) {
       return;
     }
 
@@ -279,7 +279,7 @@ function PopupMenuWrapper(props) {
 
   return html`
     <div
-      class=${ classNames('djs-popup', className) }
+      class="djs-popup-backdrop"
       onClick=${ checkClose }
       onKeydown=${ onKeydown }
       onKeyup=${ onKeyup }
@@ -287,7 +287,7 @@ function PopupMenuWrapper(props) {
       tabIndex="-1"
     >
       <div
-        class="djs-popup-overlay"
+        class=${ classNames('djs-popup', className) }
         ref=${ overlayRef }
         style=${ getOverlayStyle(props) }
       >

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -258,19 +258,17 @@ function PopupMenuWrapper(props) {
     onClose();
   }, [ onClose ]);
 
-  const overlayRef = useRef();
-
   useLayoutEffect(() => {
     if (typeof positionGetter !== 'function') {
       return;
     }
 
-    const overlayEl = overlayRef.current;
-    const position = positionGetter(overlayEl);
+    const popupEl = popupRef.current;
+    const position = positionGetter(popupEl);
 
-    overlayEl.style.left = `${position.x}px`;
-    overlayEl.style.top = `${position.y}px`;
-  }, [ overlayRef.current, positionGetter ]);
+    popupEl.style.left = `${position.x}px`;
+    popupEl.style.top = `${position.y}px`;
+  }, [ popupRef.current, positionGetter ]);
 
   // focus popup initially, on mount
   useLayoutEffect(() => {
@@ -281,15 +279,14 @@ function PopupMenuWrapper(props) {
     <div
       class="djs-popup-backdrop"
       onClick=${ checkClose }
-      onKeydown=${ onKeydown }
-      onKeyup=${ onKeyup }
-      ref=${ popupRef }
-      tabIndex="-1"
     >
       <div
         class=${ classNames('djs-popup', className) }
-        ref=${ overlayRef }
-        style=${ getOverlayStyle(props) }
+        style=${ getPopupStyle(props) }
+        onKeydown=${ onKeydown }
+        onKeyup=${ onKeyup }
+        ref=${ popupRef }
+        tabIndex="-1"
       >
         ${children}
       </div>
@@ -299,7 +296,7 @@ function PopupMenuWrapper(props) {
 
 // helpers //////////////////////
 
-function getOverlayStyle(props) {
+function getPopupStyle(props) {
   return {
     transform: `scale(${props.scale})`,
     width: `${props.width}px`

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -53,7 +53,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
     });
 
     const popup = domQuery(
-      '.djs-popup-overlay', container
+      '.djs-popup', container
     );
 
     const popupBounds = popup.getBoundingClientRect();
@@ -99,7 +99,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
       });
 
       const popupEl = domQuery(
-        '.djs-popup', container
+        '.djs-popup-backdrop', container
       );
 
       // then
@@ -118,7 +118,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
     });
 
     const popup = domQuery(
-      '.djs-popup-overlay', container
+      '.djs-popup', container
     );
 
     // then
@@ -173,7 +173,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
       createPopupMenu({ container, entries, onClose, onSelect });
 
       const popup = domQuery(
-        '.djs-popup-overlay', container
+        '.djs-popup', container
       );
 
       popup.click();

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -99,7 +99,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
       });
 
       const popupEl = domQuery(
-        '.djs-popup-backdrop', container
+        '.djs-popup', container
       );
 
       // then

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -255,13 +255,13 @@ describe('features/popup-menu', function() {
       popupMenu.open({}, 'menu', { x: 100, y: 100 });
 
       var container = popupMenu._current.container;
-      var popup = container.childNodes[0];
 
       // then
       expect(domClasses(container).has('djs-popup-parent')).to.be.true;
+      expect(domQueryAll('.djs-popup-backdrop', container)).to.have.length(1);
       expect(domQueryAll('.djs-popup', container)).to.have.length(1);
-      expect(domClasses(popup).has('djs-popup')).to.be.true;
-      expect(domClasses(popup).has('menu')).to.be.true;
+
+      expect(domClasses(domQuery('.djs-popup', container)).has('menu')).to.be.true;
     }));
 
 
@@ -1072,12 +1072,12 @@ describe('features/popup-menu', function() {
         expect(queryPopup('.popup-menu1')).to.be.null;
         expect(queryPopup('.popup-menu2')).not.to.be.null;
 
-        var popup = container.childNodes[0];
-        expect(domClasses(popup).has('popup-menu2')).to.be.true;
+        var popupBackdropEl = container.childNodes[0];
 
-        var popupOverlay = popup.childNodes[0];
-        expect(popupOverlay.style.left).to.eql('200px');
-        expect(popupOverlay.style.top).to.eql('200px');
+        var popupEl = popupBackdropEl.childNodes[0];
+        expect(popupEl.style.left).to.eql('200px');
+        expect(popupEl.style.top).to.eql('200px');
+        expect(domClasses(popupEl).has('popup-menu2')).to.be.true;
 
         var group = getGroup('default');
 
@@ -1357,7 +1357,7 @@ describe('features/popup-menu', function() {
       // when
       popupMenu.open({}, 'custom-provider', cursorPosition);
 
-      var menu = domQuery('.djs-popup-overlay', popupMenu._current.container);
+      var menu = domQuery('.djs-popup', popupMenu._current.container);
 
       var menuDimensions = {
         width: menu.scrollWidth,
@@ -1384,7 +1384,7 @@ describe('features/popup-menu', function() {
         // when
         popupMenu.open({}, 'custom-provider', { x: 100, y: 150, cursor: cursorPosition });
 
-        var menu = domQuery('.djs-popup-overlay', popupMenu._current.container);
+        var menu = domQuery('.djs-popup', popupMenu._current.container);
 
         // then
         expect(menu.offsetTop).to.equal(10);
@@ -1402,7 +1402,7 @@ describe('features/popup-menu', function() {
       // when
       popupMenu.open({}, 'custom-provider', cursorPosition);
 
-      var menu = domQuery('.djs-popup-overlay', popupMenu._current.container);
+      var menu = domQuery('.djs-popup', popupMenu._current.container);
 
       var menuDimensions = {
         width: menu.scrollWidth,
@@ -1455,7 +1455,7 @@ describe('features/popup-menu', function() {
 
           popupMenu.open({}, 'menu', { x: 100, y: 100 });
 
-          var menu = domQuery('.djs-popup-overlay', popupMenu._current.container);
+          var menu = domQuery('.djs-popup', popupMenu._current.container);
 
           var actualScale = scaleVector(menu) || { x: 1, y: 1 };
 


### PR DESCRIPTION
Testing the diagram-js@11.1.0 integration into bpmn-js I found two quirks that are worth investigating:

* We broke the semantics of the `djs-popup` class, unnecessarily => proposal to revert this via https://github.com/bpmn-io/diagram-js/commit/71f1f1c094fcb72a943c7a2fa8eb568a5487e72a
* We apply inconsistent padding / margin leading to broken UI in search/header-less popups => Fixed via https://github.com/bpmn-io/diagram-js/pull/714/commits/c28fadf21b06613a8b37ec72df104d162fa69ff3

----

#### Screens showcasing UI after padding/margin fixes

![screenshot 6a40eh](https://user-images.githubusercontent.com/58601/203991615-92284d74-65b3-4d01-bc2a-df112192d03c.png)
![screenshot iUAln8](https://user-images.githubusercontent.com/58601/203991619-5d478334-4d9f-4f5d-9b0b-d2d526de5df1.png)
![screenshot zTDADd](https://user-images.githubusercontent.com/58601/203991621-b90d5bb5-1926-4cf3-96ab-4e6b7f349375.png)
