### PR TITLE
Fixup remove container close

### DIFF
--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -47,7 +47,8 @@ var DEFAULT_PRIORITY = 1000;
 export default function PopupMenu(config, eventBus, canvas) {
   this._eventBus = eventBus;
   this._canvas = canvas;
-  this._current = {};
+
+  this._current = null;
 
   var scale = isDefined(config && config.scale) ? config.scale : {
     min: 1,
@@ -60,7 +61,7 @@ export default function PopupMenu(config, eventBus, canvas) {
 
 
   eventBus.on('diagram.destroy', () => {
-    this._destroy();
+    this.close();
   });
 
   eventBus.on('element.changed', event => {
@@ -209,11 +210,15 @@ PopupMenu.prototype.close = function() {
 
   this.reset();
 
-  this._current.container = null;
+  this._current = null;
 };
 
 PopupMenu.prototype.reset = function() {
-  render(null, this._current.container);
+  const container = this._current.container;
+
+  render(null, container);
+
+  domRemove(container);
 };
 
 PopupMenu.prototype._emit = function(event, payload) {
@@ -248,11 +253,6 @@ PopupMenu.prototype._bindAutoClose = function() {
 */
 PopupMenu.prototype._unbindAutoClose = function() {
   this._eventBus.off(CLOSE_EVENTS, this.close, this);
-};
-
-
-PopupMenu.prototype._destroy = function() {
-  this._current.container && domRemove(this._current.container);
 };
 
 
@@ -475,7 +475,7 @@ PopupMenu.prototype._getHeaderEntries = function(element, providers) {
  * @return {boolean} true if open
  */
 PopupMenu.prototype.isOpen = function() {
-  return !!this._current.container;
+  return !!this._current;
 };
 
 

--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -111,19 +111,20 @@ PopupMenu.prototype._render = function() {
   const onClose = result => this.close(result);
   const onSelect = (event, entry) => this.trigger(event, entry);
 
-  render(html`
-    <${PopupMenuComponent}
-      onClose=${ onClose }
-      onSelect=${ onSelect }
-      position=${ position }
-      className=${ className }
-      entries=${ entriesArray }
-      headerEntries=${ headerEntriesArray }
-      scale=${ scale }
-      ...${{ ...options }}
-    />
-  `,
-  this._current.container
+  render(
+    html`
+      <${PopupMenuComponent}
+        onClose=${ onClose }
+        onSelect=${ onSelect }
+        position=${ position }
+        className=${ className }
+        entries=${ entriesArray }
+        headerEntries=${ headerEntriesArray }
+        scale=${ scale }
+        ...${{ ...options }}
+      />
+    `,
+    this._current.container
   );
 };
 
@@ -153,6 +154,7 @@ PopupMenu.prototype.open = function(element, providerId, position, options) {
   if (this.isOpen()) {
     this.close();
   }
+
   const {
     entries,
     headerEntries
@@ -173,8 +175,6 @@ PopupMenu.prototype.open = function(element, providerId, position, options) {
   this._bindAutoClose();
 
   this._render();
-
-
 };
 
 

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -254,14 +254,14 @@ describe('features/popup-menu', function() {
       // when
       popupMenu.open({}, 'menu', { x: 100, y: 100 });
 
-      var container = popupMenu._current.container;
+      var container = getPopupContainer();
 
       // then
       expect(domClasses(container).has('djs-popup-parent')).to.be.true;
-      expect(domQueryAll('.djs-popup-backdrop', container)).to.have.length(1);
-      expect(domQueryAll('.djs-popup', container)).to.have.length(1);
+      expect(queryPopupAll('.djs-popup-backdrop')).to.have.length(1);
+      expect(queryPopupAll('.djs-popup')).to.have.length(1);
 
-      expect(domClasses(domQuery('.djs-popup', container)).has('menu')).to.be.true;
+      expect(domClasses(queryPopup('.djs-popup')).has('menu')).to.be.true;
     }));
 
 
@@ -270,7 +270,7 @@ describe('features/popup-menu', function() {
       // when
       popupMenu.open({}, 'menu', { x: 100, y: 100 });
 
-      var container = popupMenu._current.container;
+      var container = getPopupContainer();
 
       // then
       expect(getComputedStyle(container).visibility).not.to.eql('hidden');
@@ -453,8 +453,7 @@ describe('features/popup-menu', function() {
         // when
         popupMenu.open({}, 'group-menu', { x: 100, y: 100 });
 
-        const container = getPopupContainer(popupMenu);
-        const entryHeaders = domQueryAll('.entry-header', container);
+        const entryHeaders = queryPopupAll('.entry-header');
 
         // then
         expect(entryHeaders).to.have.lengthOf(2);
@@ -563,7 +562,7 @@ describe('features/popup-menu', function() {
 
       // given
       var closeSpy = sinon.spy();
-      var container = popupMenu._current.container;
+      var container = getPopupContainer();
 
       eventBus.on('popupMenu.close', closeSpy);
 
@@ -1379,7 +1378,7 @@ describe('features/popup-menu', function() {
       // when
       popupMenu.open({}, 'custom-provider', cursorPosition);
 
-      var menu = domQuery('.djs-popup', popupMenu._current.container);
+      var menu = queryPopup('.djs-popup');
 
       var menuDimensions = {
         width: menu.scrollWidth,
@@ -1406,7 +1405,7 @@ describe('features/popup-menu', function() {
         // when
         popupMenu.open({}, 'custom-provider', { x: 100, y: 150, cursor: cursorPosition });
 
-        var menu = domQuery('.djs-popup', popupMenu._current.container);
+        var menu = queryPopup('.djs-popup');
 
         // then
         expect(menu.offsetTop).to.equal(10);
@@ -1424,7 +1423,7 @@ describe('features/popup-menu', function() {
       // when
       popupMenu.open({}, 'custom-provider', cursorPosition);
 
-      var menu = domQuery('.djs-popup', popupMenu._current.container);
+      var menu = queryPopup('.djs-popup');
 
       var menuDimensions = {
         width: menu.scrollWidth,
@@ -1477,7 +1476,7 @@ describe('features/popup-menu', function() {
 
           popupMenu.open({}, 'menu', { x: 100, y: 100 });
 
-          var menu = domQuery('.djs-popup', popupMenu._current.container);
+          var menu = queryPopup('.djs-popup');
 
           var actualScale = scaleVector(menu) || { x: 1, y: 1 };
 
@@ -1788,7 +1787,11 @@ function queryPopupAll(selector) {
 
 function getPopupContainer() {
   return getDiagramJS().invoke(function(popupMenu) {
-    return popupMenu._current.container;
+    const current = popupMenu._current;
+
+    expect(current, 'expect popupMenu to be open').to.exist;
+
+    return current.container;
   });
 }
 

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -440,7 +440,6 @@ describe('features/popup-menu', function() {
       it('should display group name if provided', inject(function(popupMenu) {
 
         // given
-        var container = getPopupContainer(popupMenu);
         popupMenu.registerProvider('group-menu', {
           getEntries: function() {
             return [
@@ -454,6 +453,7 @@ describe('features/popup-menu', function() {
         // when
         popupMenu.open({}, 'group-menu', { x: 100, y: 100 });
 
+        const container = getPopupContainer(popupMenu);
         const entryHeaders = domQueryAll('.entry-header', container);
 
         // then
@@ -556,6 +556,28 @@ describe('features/popup-menu', function() {
       expect(open).to.be.false;
 
       expect(closeSpy).to.have.been.calledOnce;
+    }));
+
+
+    it('should remove container', inject(function(popupMenu, eventBus) {
+
+      // given
+      var closeSpy = sinon.spy();
+      var container = popupMenu._current.container;
+
+      eventBus.on('popupMenu.close', closeSpy);
+
+      // assume
+      expect(container.parentNode).to.exist;
+
+      // when
+      popupMenu.close();
+
+      // then
+      expect(popupMenu.isOpen()).to.be.false;
+
+      expect(closeSpy).to.have.been.calledOnce;
+      expect(container.parentNode).not.to.exist;
     }));
 
 


### PR DESCRIPTION
`diagram-js@11` does not properly remove popup menu containers. As a result more and more pile up in the DOM (attached to the body).

This PR , specifically (https://github.com/bpmn-io/diagram-js/pull/715/commits/da2035a7950fee66ebcff52dab426c34f5d5ddd1) ensures that they are attached only for the time where the popup menu is actually opened.