### PR TITLE
fix: prevent canvas scrolling inside popup menu

### DIFF
--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -240,7 +240,7 @@ PopupMenu.prototype._createContainer = function(config) {
   var canvas = this._canvas,
       parent = canvas.getContainer();
 
-  const container = domify(`<div class="djs-popup-parent" data-popup=${config.provider}></div>`);
+  const container = domify(`<div class="djs-popup-parent djs-scrollable" data-popup=${config.provider}></div>`);
 
   parent.appendChild(container);
 


### PR DESCRIPTION
This ensures the popup menu is not accidentally canvas scrolled on mouse wheel.

Closes https://github.com/bpmn-io/diagram-js/issues/729