### PR TITLE
feat(palette): allow trigger with entry id

### DIFF
--- a/lib/features/palette/Palette.js
+++ b/lib/features/palette/Palette.js
@@ -285,9 +285,7 @@ Palette.prototype._update = function() {
  * @param  {Event} event
  */
 Palette.prototype.trigger = function(action, event, autoActivate) {
-  var entries = this._entries,
-      entry,
-      handler,
+  var entry,
       originalEvent,
       button = event.delegateTarget || event.target;
 
@@ -295,7 +293,18 @@ Palette.prototype.trigger = function(action, event, autoActivate) {
     return event.preventDefault();
   }
 
-  entry = entries[domAttr(button, 'data-action')];
+  entry = domAttr(button, 'data-action');
+  originalEvent = event.originalEvent || event;
+
+  return this.triggerEntry(entry, action, originalEvent, autoActivate);
+};
+
+Palette.prototype.triggerEntry = function(entryId, action, event, autoActivate) {
+  var entries = this._entries,
+      entry,
+      handler;
+
+  entry = entries[entryId];
 
   // when user clicks on the palette and not on an action
   if (!entry) {
@@ -304,16 +313,14 @@ Palette.prototype.trigger = function(action, event, autoActivate) {
 
   handler = entry.action;
 
-  originalEvent = event.originalEvent || event;
-
   // simple action (via callback function)
   if (isFunction(handler)) {
     if (action === 'click') {
-      handler(originalEvent, autoActivate);
+      return handler(event, autoActivate);
     }
   } else {
     if (handler[action]) {
-      handler[action](originalEvent, autoActivate);
+      return handler[action](event, autoActivate);
     }
   }
 

--- a/test/spec/features/palette/PaletteSpec.js
+++ b/test/spec/features/palette/PaletteSpec.js
@@ -4,6 +4,10 @@ import {
   inject
 } from 'test/TestHelper';
 
+import {
+  createEvent as globalEvent
+} from '../../../util/MockEvents';
+
 import paletteModule from 'lib/features/palette';
 
 import {
@@ -686,6 +690,112 @@ describe('features/palette', function() {
       expect(injected).not.to.exist;
     }));
 
+  });
+
+
+  describe('event handling', function() {
+
+    const paletteProvider = {
+      getPaletteEntries: function() {
+        return {
+          'entry-1': {
+            label: 'My Entry',
+            action: function(e) {
+              e.__handled = true;
+            }
+          },
+          'entry-2': {
+            label: 'My Entry',
+            action: {
+              click: function(e) {
+                e.__handled = true;
+              },
+              dragstart: function(e) {
+                e.__handled = true;
+              }
+            }
+          }
+        };
+      }
+    };
+
+    beforeEach(bootstrapDiagram({ modules: [ paletteModule ] }));
+
+    beforeEach(inject(function(palette) {
+      palette.registerProvider(800, paletteProvider);
+    }));
+
+
+    it('should handle click event', inject(function(palette) {
+
+      // given
+      var target = domQuery('.djs-palette [data-action="entry-1"]');
+      var event = globalEvent(target, { x: 0, y: 0 });
+
+      // when
+      palette.trigger('click', event);
+
+      // then
+      expect(event.__handled).to.be.true;
+    }));
+
+
+    it('should prevent unhandled events', inject(function(palette) {
+
+      // given
+      var target = domQuery('.djs-palette [data-action="entry-1"]');
+      var event = globalEvent(target, { x: 0, y: 0 });
+
+      // when
+      palette.trigger('dragstart', event);
+
+      // then
+      expect(event.defaultPrevented).to.be.true;
+    }));
+
+
+    it('should handle drag event', inject(function(palette) {
+
+      // given
+      var target = domQuery('.djs-palette [data-action="entry-2"]');
+      var event = globalEvent(target, { x: 0, y: 0 });
+
+      // when
+      palette.trigger('dragstart', event);
+
+      // then
+      expect(event.__handled).to.be.true;
+    }));
+
+
+    it('should gracefully handle non-existing entry', inject(function(palette) {
+
+      // given
+      var target = domQuery('.djs-palette [data-action=""]');
+      var event = globalEvent(target, { x: 0, y: 0 });
+
+      // when
+      var result = palette.triggerEntry('NON_EXISTING_ENTRY', 'dragstart', event);
+
+      // then
+      expect(event.__handled).not.to.exist;
+      expect(result).not.to.exist;
+    }));
+
+
+    it('should gracefully handle non-existing action', inject(function(palette) {
+
+      // given
+      var target = domQuery('.djs-palette [data-action="entry-1"]');
+      var event = globalEvent(target, { x: 0, y: 0 });
+
+      // when
+      var result = palette.triggerEntry('entry-1', 'NON_EXISTING_ACTION', event);
+
+      // then
+      expect(event.__handled).not.to.exist;
+      expect(result).not.to.exist;
+    }));
   });
 
 });


### PR DESCRIPTION
In order to support https://github.com/bpmn-io/bpmn-js/issues/1814; similar to how we did for context pad https://github.com/bpmn-io/diagram-js/pull/719

I added some general test cases for `#trigger` similar to the ones we have for context pad since we didn't have these for palette