### PR TITLE
fix: remove physical keyboard bindings

### DIFF
--- a/lib/features/keyboard/KeyboardBindings.js
+++ b/lib/features/keyboard/KeyboardBindings.js
@@ -4,15 +4,22 @@ import {
   isCopy,
   isPaste,
   isUndo,
-  isRedo
+  isRedo,
+  KEYS_COPY,
+  KEYS_PASTE,
+  KEYS_UNDO,
+  KEYS_REDO
 } from './KeyboardUtil';
 
-var LOW_PRIORITY = 500;
+export {
+  KEYS_COPY,
+  KEYS_PASTE,
+  KEYS_UNDO,
+  KEYS_REDO
+};
 
-export var KEYS_COPY = [ 'c', 'C', 'KeyC' ];
-export var KEYS_PASTE = [ 'v', 'V', 'KeyV' ];
-export var KEYS_REDO = [ 'y', 'Y', 'KeyY' ];
-export var KEYS_UNDO = [ 'z', 'Z', 'KeyZ' ];
+
+var LOW_PRIORITY = 500;
 
 
 /**

--- a/lib/features/keyboard/KeyboardUtil.js
+++ b/lib/features/keyboard/KeyboardUtil.js
@@ -1,9 +1,9 @@
 import { isArray } from 'min-dash';
 
-var KEYS_COPY = [ 'c', 'C', 'KeyC' ];
-var KEYS_PASTE = [ 'v', 'V', 'KeyV' ];
-var KEYS_REDO = [ 'y', 'Y', 'KeyY' ];
-var KEYS_UNDO = [ 'z', 'Z', 'KeyZ' ];
+export var KEYS_COPY = [ 'c', 'C' ];
+export var KEYS_PASTE = [ 'v', 'V' ];
+export var KEYS_REDO = [ 'y', 'Y' ];
+export var KEYS_UNDO = [ 'z', 'Z' ];
 
 /**
  * Returns true if event was triggered with any modifier

--- a/test/spec/features/keyboard/CopySpec.js
+++ b/test/spec/features/keyboard/CopySpec.js
@@ -14,7 +14,7 @@ import editorActionsModule from 'lib/features/editor-actions';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
 
-var KEYS_COPY = [ 'c', 'C', 'KeyC' ];
+var KEYS_COPY = [ 'c', 'C' ];
 
 
 describe('features/keyboard - copy', function() {

--- a/test/spec/features/keyboard/PasteSpec.js
+++ b/test/spec/features/keyboard/PasteSpec.js
@@ -14,7 +14,7 @@ import editorActionsModule from 'lib/features/editor-actions';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
 
-var KEYS_PASTE = [ 'v', 'V', 'KeyV' ];
+var KEYS_PASTE = [ 'v', 'V' ];
 
 
 describe('features/keyboard - paste', function() {

--- a/test/spec/features/keyboard/RedoSpec.js
+++ b/test/spec/features/keyboard/RedoSpec.js
@@ -13,8 +13,8 @@ import keyboardModule from 'lib/features/keyboard';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
 
-var KEYS_REDO = [ 'y', 'Y', 'KeyY' ];
-var KEYS_UNDO = [ 'z', 'Z', 'KeyZ' ];
+var KEYS_REDO = [ 'y', 'Y' ];
+var KEYS_UNDO = [ 'z', 'Z' ];
 
 
 describe('features/keyboard - redo', function() {

--- a/test/spec/features/keyboard/UndoSpec.js
+++ b/test/spec/features/keyboard/UndoSpec.js
@@ -13,7 +13,7 @@ import keyboardModule from 'lib/features/keyboard';
 
 import { createKeyEvent } from 'test/util/KeyEvents';
 
-var KEYS_UNDO = [ 'z', 'Z', 'KeyZ' ];
+var KEYS_UNDO = [ 'z', 'Z' ];
 
 
 describe('features/keyboard - undo', function() {


### PR DESCRIPTION
This restores a the pre 11.0.0 behavior.

Related to https://github.com/bpmn-io/bpmn-js/issues/1842