### PR TITLE
refactor: replace npm module `css.escape` with native API

### DIFF
--- a/lib/util/EscapeUtil.js
+++ b/lib/util/EscapeUtil.js
@@ -1,6 +1,10 @@
-export {
-  default as escapeCSS
-} from 'css.escape';
+/**
+ * @param {string} str 
+ * @returns {string}
+ */
+export function escapeCSS(str) {
+  return CSS.escape(str);
+}
 
 var HTML_ESCAPE_MAP = {
   '&': '&amp;',

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.2",
         "clsx": "^1.2.1",
-        "css.escape": "^1.5.1",
         "didi": "^9.0.0",
         "hammerjs": "^2.0.1",
         "inherits-browser": "^0.1.0",
@@ -1985,10 +1984,6 @@
       "engines": {
         "node": ">=4.8"
       }
-    },
-    "node_modules/css.escape": {
-      "version": "1.5.1",
-      "license": "MIT"
     },
     "node_modules/custom-event": {
       "version": "1.0.1",
@@ -9085,9 +9080,6 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
-    },
-    "css.escape": {
-      "version": "1.5.1"
     },
     "custom-event": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
   "dependencies": {
     "@bpmn-io/diagram-js-ui": "^0.2.2",
     "clsx": "^1.2.1",
-    "css.escape": "^1.5.1",
     "didi": "^9.0.0",
     "hammerjs": "^2.0.1",
     "inherits-browser": "^0.1.0",


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js/issues/1850