### PR TITLE
docs(command): state that `executed` hooks are also part of the transaction

### DIFF
--- a/lib/command/CommandStack.js
+++ b/lib/command/CommandStack.js
@@ -54,7 +54,7 @@ import {
  * got changed during the `execute` and `revert` operations.
  *
  * Command handlers may execute other modeling operations (and thus
- * commands) in their `preExecute` and `postExecute` phases. The command
+ * commands) in their `preExecute(d)` and `postExecute(d)` phases. The command
  * stack will properly group all commands together into a logical unit
  * that may be re- and undone atomically.
  *


### PR DESCRIPTION
This may prevent potential confusion.