### PR TITLE
feat: support select after replacement

### DIFF
--- a/lib/features/replace/Replace.js
+++ b/lib/features/replace/Replace.js
@@ -13,23 +13,23 @@ var round = Math.round;
  *
  * @param {Modeling} modeling
  */
-export default function Replace(modeling) {
-
+export default function Replace(modeling, eventBus) {
   this._modeling = modeling;
+  this._eventBus = eventBus;
 }
 
-Replace.$inject = [ 'modeling' ];
+Replace.$inject = [ 'modeling', 'eventBus' ];
 
 /**
  * @param {Element} oldElement - Element to be replaced
- * @param {Object}  newElementData - Containing information about the new element,
+ * @param {Object}  attrs - Containing information about the new element,
  *                                   for example the new bounds and type.
- * @param {Object}  options - Custom options that will be attached to the context. It can be used to inject data
+ * @param {Object}  hints -   Custom hints that will be attached to the context. It can be used to inject data
  *                            that is needed in the command chain. For example it could be used in
  *                            eventbus.on('commandStack.shape.replace.postExecute') to change shape attributes after
  *                            shape creation.
  */
-Replace.prototype.replaceElement = function(oldElement, newElementData, options) {
+Replace.prototype.replaceElement = function(oldElement, attrs, hints) {
 
   if (oldElement.waypoints) {
 
@@ -38,22 +38,29 @@ Replace.prototype.replaceElement = function(oldElement, newElementData, options)
   }
 
   var modeling = this._modeling;
+  var eventBus = this._eventBus;
 
-  var width = newElementData.width || oldElement.width,
-      height = newElementData.height || oldElement.height,
-      x = newElementData.x || oldElement.x,
-      y = newElementData.y || oldElement.y,
+  eventBus.fire('replace.start', {
+    element: oldElement,
+    attrs,
+    hints
+  });
+
+  var width = attrs.width || oldElement.width,
+      height = attrs.height || oldElement.height,
+      x = attrs.x || oldElement.x,
+      y = attrs.y || oldElement.y,
       centerX = round(x + width / 2),
       centerY = round(y + height / 2);
 
   // modeling API requires center coordinates,
   // account for that when handling shape bounds
 
-  return modeling.replaceShape(
+  var newElement = modeling.replaceShape(
     oldElement,
     assign(
       {},
-      newElementData,
+      attrs,
       {
         x: centerX,
         y: centerY,
@@ -61,6 +68,14 @@ Replace.prototype.replaceElement = function(oldElement, newElementData, options)
         height: height
       }
     ),
-    options
+    hints
   );
+
+  eventBus.fire('replace.end', {
+    element: oldElement,
+    newElement,
+    hints
+  });
+
+  return newElement;
 };

--- a/lib/features/replace/ReplaceSelectionBehavior.js
+++ b/lib/features/replace/ReplaceSelectionBehavior.js
@@ -1,0 +1,18 @@
+export default function ReplaceSelectionBehavior(selection, eventBus) {
+
+  eventBus.on('replace.end', 500, function(event) {
+    const {
+      newElement,
+      hints = {}
+    } = event;
+
+    if (hints.select === false) {
+      return;
+    }
+
+    selection.select(newElement);
+  });
+
+}
+
+ReplaceSelectionBehavior.$inject = [ 'selection', 'eventBus' ];

--- a/lib/features/replace/index.js
+++ b/lib/features/replace/index.js
@@ -1,6 +1,8 @@
 import Replace from './Replace';
+import ReplaceSelectionBehavior from './ReplaceSelectionBehavior';
 
 export default {
-  __init__: [ 'replace' ],
+  __init__: [ 'replace', 'replaceSelectionBehavior' ],
+  replaceSelectionBehavior: [ 'type', ReplaceSelectionBehavior ],
   replace: [ 'type', Replace ]
 };

--- a/test/spec/features/replace/ReplaceSelectionBehaviorSpec.js
+++ b/test/spec/features/replace/ReplaceSelectionBehaviorSpec.js
@@ -1,0 +1,88 @@
+import {
+  bootstrapDiagram,
+  inject
+} from 'test/TestHelper';
+
+import modelingModule from 'lib/features/modeling';
+import replaceModule from 'lib/features/replace';
+
+
+describe('features/replace - ReplaceSelectionBehavior', function() {
+
+  beforeEach(bootstrapDiagram({
+    modules: [
+      modelingModule,
+      replaceModule
+    ]
+  }));
+
+  var rootShape, parentShape, originalShape;
+
+  beforeEach(inject(function(elementFactory, canvas) {
+
+    rootShape = elementFactory.createRoot({
+      id: 'root'
+    });
+
+    canvas.setRootElement(rootShape);
+
+    parentShape = elementFactory.createShape({
+      id: 'parent',
+      x: 100, y: 100, width: 300, height: 300
+    });
+
+    canvas.addShape(parentShape, rootShape);
+
+    originalShape = elementFactory.createShape({
+      id: 'originalShape',
+      x: 110, y: 110, width: 100, height: 100
+    });
+
+    canvas.addShape(originalShape, parentShape);
+  }));
+
+
+  describe('#replaceElement', function() {
+
+    it('should select after replacement', inject(function(replace, selection) {
+
+      // given
+      var replacement = {
+        id: 'replacement',
+        width: 200,
+        height: 200
+      };
+
+      // when
+      var newShape = replace.replaceElement(originalShape, replacement);
+
+      // then
+      expect(newShape).to.exist;
+
+      // expect added
+      expect(selection.get()).to.eql([ newShape ]);
+    }));
+
+
+    it('should NOT select after replacement if <hints.select === false>', inject(function(replace, selection) {
+
+      // given
+      var replacement = {
+        id: 'replacement',
+        width: 200,
+        height: 200
+      };
+
+      // when
+      var newShape = replace.replaceElement(originalShape, replacement, { select: false });
+
+      // then
+      expect(newShape).to.exist;
+
+      // expect added
+      expect(selection.get()).not.to.include(newShape);
+    }));
+
+  });
+
+});

--- a/test/spec/features/replace/ReplaceSpec.js
+++ b/test/spec/features/replace/ReplaceSpec.js
@@ -10,8 +10,12 @@ import {
   query as domQuery
 } from 'min-dom';
 
+import {
+  pick
+} from 'min-dash';
 
-describe('features/replace', function() {
+
+describe('features/replace - Replace', function() {
 
   beforeEach(bootstrapDiagram({
     modules: [
@@ -65,6 +69,49 @@ describe('features/replace', function() {
 
       // expect added
       expect(elementRegistry.get('replacement')).to.equal(newShape);
+    }));
+
+
+    it('should emit events', inject(function(elementRegistry, replace, eventBus) {
+
+      // given
+      var log = [];
+
+      function capture(eventBus, eventType) {
+        eventBus.on(eventType, function(event) {
+          log.push([ eventType, pick(event, [ 'attrs', 'element', 'hints', 'newElement' ]) ]);
+        });
+      }
+
+      capture(eventBus, 'replace.start');
+      capture(eventBus, 'replace.end');
+
+      var replaceHints = {
+        foo: 'FOO'
+      };
+
+      var replaceAttrs = {
+        id: 'replacement',
+        width: 200,
+        height: 200
+      };
+
+      // when
+      var newElement = replace.replaceElement(originalShape, replaceAttrs, replaceHints);
+
+      // then
+      expect(log).to.eql([
+        [ 'replace.start', {
+          element: originalShape,
+          attrs: replaceAttrs,
+          hints: replaceHints
+        } ],
+        [ 'replace.end', {
+          element: originalShape,
+          newElement: newElement,
+          hints: replaceHints
+        } ]
+      ]);
     }));
 
 


### PR DESCRIPTION
This mirrors existing patterns (cf. auto-place).

Per default replaced elements will be selected, unless explicitly disabled via hint.

----

Idea is to get interaction related logic, where a shared concern, out of downstream libraries (properties panel [element template removal](https://github.com/bpmn-io/bpmn-js-properties-panel/blob/663003e48cdb19942f9d7293e7269562eb8aae97/src/provider/element-templates/util/templateUtil.js#L33), [bpmn replace](https://github.com/bpmn-io/bpmn-js/blob/develop/lib/features/replace/BpmnReplace.js#L290)).