### PR TITLE
feat: add TypeScript declarations for translate functions

### DIFF
--- a/lib/i18n/translate/translate.d.ts
+++ b/lib/i18n/translate/translate.d.ts
@@ -1,0 +1,5 @@
+export type Replacements = {
+  [key: string]: string;
+};
+
+export type TranslateFunction = (template: string, replacements?: Replacements) => string;

--- a/lib/i18n/translate/translate.js
+++ b/lib/i18n/translate/translate.js
@@ -1,4 +1,8 @@
 /**
+ * @typedef {import('./').Replacements} Replacements
+ */
+
+/**
  * A simple translation stub to be used for multi-language support
  * in diagrams. Can be easily replaced with a more sophisticated
  * solution.
@@ -12,7 +16,7 @@
  * }
  *
  * @param {string} template to interpolate
- * @param {Object} [replacements] a map with substitutes
+ * @param {Replacements} [replacements] a map with substitutes
  *
  * @return {string} the translated string
  */

--- a/lib/i18n/translate/translate.spec.ts
+++ b/lib/i18n/translate/translate.spec.ts
@@ -1,0 +1,11 @@
+import { TranslateFunction } from './translate';
+
+const translate: TranslateFunction = (template, replacements) => {
+  for (let replacement in replacements) {
+    console.log(replacement, replacements[ replacement ]);
+  }
+
+  return template;
+};
+
+translate('foo {{bar}}', { bar: 'baz' });


### PR DESCRIPTION
Translate is used quite extensively in bpmn-js, therefore I added types.
