### PR TITLE
Adds additional parameters to EventCallback type

### DIFF
--- a/lib/core/EventBus.d.ts
+++ b/lib/core/EventBus.d.ts
@@ -6,7 +6,7 @@ export type Event = {
   defaultPrevented: boolean;
 };
 
-export type EventCallback<T extends Event> = (event: T) => any | void;
+export type EventCallback<T extends Event> = (event: T, ...additional: any[]) => any | void;
 
 export type EventBusListener = {
   priority: number;

--- a/lib/core/EventBus.spec.ts
+++ b/lib/core/EventBus.spec.ts
@@ -34,6 +34,10 @@ eventBus.on('foo', 2000, callback);
 
 eventBus.on('foo', callback, this);
 
+eventBus.on('foo', (event, additional1, additional2) => {
+  console.log(foo, additional1, additional2);
+});
+
 type FooEvent = {
   foo: string;
 } & Event;
@@ -51,3 +55,7 @@ eventBus.once('foo', callback);
 eventBus.once('foo', 2000, callback);
 
 eventBus.once('foo', callback, this);
+
+eventBus.once('foo', (event, additional1, additional2) => {
+  console.log(foo, additional1, additional2);
+});


### PR DESCRIPTION
Currently the type defines, that the EventCallback can only receive a single parameter `event`. However when firing an event, an arbitrary amount of additional parameters can be passed to the callback.

Closes https://github.com/bpmn-io/diagram-js/issues/758.
