### PR TITLE
fix: correct type definitions

### DIFF
--- a/lib/core/EventBus.spec.ts
+++ b/lib/core/EventBus.spec.ts
@@ -35,7 +35,7 @@ eventBus.on('foo', 2000, callback);
 eventBus.on('foo', callback, this);
 
 eventBus.on('foo', (event, additional1, additional2) => {
-  console.log(foo, additional1, additional2);
+  console.log('foo', additional1, additional2);
 });
 
 type FooEvent = {
@@ -57,5 +57,5 @@ eventBus.once('foo', 2000, callback);
 eventBus.once('foo', callback, this);
 
 eventBus.once('foo', (event, additional1, additional2) => {
-  console.log(foo, additional1, additional2);
+  console.log('foo', additional1, additional2);
 });


### PR DESCRIPTION
This fixes our type check that otherwise complains (rightfully) that `foo` is not defined.