### PR TITLE
Centralize `isConnection`, `isLabel` and `isRoot` Checks

### DIFF
--- a/lib/features/bendpoints/BendpointSnapping.js
+++ b/lib/features/bendpoints/BendpointSnapping.js
@@ -8,6 +8,8 @@ import { setSnapped } from '../snapping/SnapUtil';
 
 import { getClosestPointOnConnection } from './BendpointUtil';
 
+import { isConnection } from '../../util/ModelUtil';
+
 /**
  * @typedef {import('../../core/EventBus').default} EventBus
  */
@@ -245,10 +247,3 @@ export default function BendpointSnapping(eventBus) {
 
 
 BendpointSnapping.$inject = [ 'eventBus' ];
-
-
-// helpers //////////////////////
-
-function isConnection(element) {
-  return element && !!element.waypoints;
-}

--- a/lib/features/copy-paste/CopyPaste.js
+++ b/lib/features/copy-paste/CopyPaste.js
@@ -17,6 +17,11 @@ import {
 
 import { eachElement } from '../../util/Elements';
 
+import {
+  isConnection,
+  isLabel
+} from '../../util/ModelUtil';
+
 /**
  * @typedef {import('../../core/Types').ElementLike} Element
  * @typedef {import('../../core/Types').ShapeLike} Shape
@@ -578,14 +583,6 @@ CopyPaste.prototype.createTree = function(elements) {
 
 function isAttacher(element) {
   return !!element.host;
-}
-
-function isConnection(element) {
-  return !!element.waypoints;
-}
-
-function isLabel(element) {
-  return !!element.labelTarget;
 }
 
 function copyWaypoints(element) {

--- a/lib/features/create/Create.js
+++ b/lib/features/create/Create.js
@@ -15,6 +15,11 @@ import {
 
 import { getBBox } from '../../util/Elements';
 
+import {
+  isConnection,
+  isLabel
+} from '../../util/ModelUtil';
+
 /**
  * @typedef {import('../../core/Types').ElementLike} Element
  * @typedef {import('../../core/Types').ShapeLike} Shape
@@ -367,14 +372,6 @@ function ensureConstraints(event) {
   }
 }
 
-function isConnection(element) {
-  return !!element.waypoints;
-}
-
 function isSingleShape(elements) {
-  return elements && elements.length === 1 && !isConnection(elements[0]);
-}
-
-function isLabel(element) {
-  return !!element.labelTarget;
+  return elements && elements.length === 1 && !isConnection(elements[ 0 ]);
 }

--- a/lib/features/modeling/cmd/CreateElementsHandler.js
+++ b/lib/features/modeling/cmd/CreateElementsHandler.js
@@ -14,6 +14,11 @@ import {
   getParents
 } from '../../../util/Elements';
 
+import {
+  isConnection,
+  isLabel
+} from '../../../util/ModelUtil';
+
 /**
  * @typedef {import('../Modeling').default} Modeling
  */
@@ -128,13 +133,3 @@ CreateElementsHandler.prototype.preExecute = function(context) {
 
   context.elements = values(cache);
 };
-
-// helpers //////////
-
-function isConnection(element) {
-  return !!element.waypoints;
-}
-
-function isLabel(element) {
-  return !!element.labelTarget;
-}

--- a/lib/features/modeling/cmd/DeleteShapeHandler.js
+++ b/lib/features/modeling/cmd/DeleteShapeHandler.js
@@ -5,6 +5,8 @@ import {
 
 import { saveClear } from '../../../util/Removal';
 
+import { isConnection } from '../../../util/ModelUtil';
+
 /**
  * @typedef {import('../../../core/Canvas').default} Canvas
  * @typedef {import('../Modeling').default} Modeling
@@ -95,7 +97,3 @@ DeleteShapeHandler.prototype.revert = function(context) {
 
   return shape;
 };
-
-function isConnection(element) {
-  return element.waypoints;
-}

--- a/lib/features/move/MovePreview.js
+++ b/lib/features/move/MovePreview.js
@@ -22,6 +22,8 @@ import {
 
 import { translate } from '../../util/SvgTransformUtil';
 
+import { isConnection } from '../../util/ModelUtil';
+
 /**
  * @typedef {import('../../model/Types').Element} Element
  *
@@ -251,11 +253,4 @@ function removeEdges(elements) {
 
 function haveDifferentParents(elements) {
   return size(groupBy(elements, function(e) { return e.parent && e.parent.id; })) !== 1;
-}
-
-/**
- * Checks if an element is a connection.
- */
-function isConnection(element) {
-  return element.waypoints;
 }

--- a/lib/features/resize/ResizeHandles.js
+++ b/lib/features/resize/ResizeHandles.js
@@ -25,6 +25,8 @@ import {
 
 import { getReferencePoint } from './Resize';
 
+import { isConnection } from '../../util/ModelUtil';
+
 /**
  * @typedef {import('../../model/Types').Element} Element
  *
@@ -210,8 +212,4 @@ function getHandleOffset(direction) {
   }
 
   return offset;
-}
-
-function isConnection(element) {
-  return !!element.waypoints;
 }

--- a/lib/features/snapping/CreateMoveSnapping.js
+++ b/lib/features/snapping/CreateMoveSnapping.js
@@ -13,6 +13,11 @@ import {
   isNumber
 } from 'min-dash';
 
+import {
+  isConnection,
+  isLabel
+} from '../../util/ModelUtil';
+
 /**
  * @typedef {import('../../core/ElementRegistry').default} ElementRegistry
  * @typedef {import('../../core/EventBus').default} EventBus
@@ -200,14 +205,6 @@ CreateMoveSnapping.prototype.getSnapTargets = function(shape, target) {
 
 // helpers //////////
 
-function isConnection(element) {
-  return !!element.waypoints;
-}
-
 function isHidden(element) {
   return !!element.hidden;
-}
-
-function isLabel(element) {
-  return !!element.labelTarget;
 }

--- a/lib/features/snapping/ResizeSnapping.js
+++ b/lib/features/snapping/ResizeSnapping.js
@@ -17,6 +17,11 @@ import {
 
 import { forEach } from 'min-dash';
 
+import {
+  isConnection,
+  isLabel
+} from '../../util/ModelUtil';
+
 /**
  * @typedef {import('../../core/EventBus').default} EventBus
  * @typedef {import('./Snapping').default} Snapping
@@ -157,16 +162,8 @@ function isAttached(element, host) {
   return element.host === host;
 }
 
-function isConnection(element) {
-  return !!element.waypoints;
-}
-
 function isHidden(element) {
   return !!element.hidden;
-}
-
-function isLabel(element) {
-  return !!element.labelTarget;
 }
 
 function isHorizontal(direction) {

--- a/lib/features/space-tool/SpaceTool.js
+++ b/lib/features/space-tool/SpaceTool.js
@@ -20,6 +20,11 @@ import { set as setCursor } from '../../util/Cursor';
 
 import { selfAndAllChildren } from '../../util/Elements';
 
+import {
+  isConnection,
+  isLabel
+} from '../../util/ModelUtil';
+
 /**
  * @typedef {import('../../core/Types').ShapeLike} Shape
  *
@@ -619,12 +624,4 @@ function includes(array, item) {
 
 function isAttacher(element) {
   return !!element.host;
-}
-
-function isConnection(element) {
-  return !!element.waypoints;
-}
-
-function isLabel(element) {
-  return !!element.labelTarget;
 }

--- a/lib/features/space-tool/SpaceToolPreview.js
+++ b/lib/features/space-tool/SpaceToolPreview.js
@@ -19,6 +19,8 @@ import {
   translate
 } from '../../util/SvgTransformUtil';
 
+import { isConnection } from '../../util/ModelUtil';
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/ElementRegistry').default} ElementRegistry
@@ -301,13 +303,3 @@ SpaceToolPreview.$inject = [
   'styles',
   'previewSupport'
 ];
-
-
-// helpers //////////////////////
-
-/**
- * Checks if an element is a connection.
- */
-function isConnection(element) {
-  return element.waypoints;
-}

--- a/lib/layout/LayoutUtil.js
+++ b/lib/layout/LayoutUtil.js
@@ -10,6 +10,8 @@ import {
 
 import intersectPaths from 'path-intersection';
 
+import { isConnection } from '../util/ModelUtil';
+
 /**
  * @typedef {import('../core/Types').ElementLike} Element
  * @typedef {import('../core/Types').ConnectionLike} Connection
@@ -302,8 +304,4 @@ export function filterRedundantWaypoints(waypoints) {
 
 function distance(a, b) {
   return Math.sqrt(Math.pow(a.x - b.x, 2) + Math.pow(a.y - b.y, 2));
-}
-
-function isConnection(element) {
-  return !!element.waypoints;
 }

--- a/lib/model/index.js
+++ b/lib/model/index.js
@@ -242,6 +242,7 @@ var types = {
  *
  * @return {Root}
  */
+
 /**
  * Creates a connection.
  *
@@ -265,6 +266,7 @@ var types = {
  *
  * @return {Connection}
  */
+
 /**
  * Creates a shape.
  *
@@ -288,6 +290,7 @@ var types = {
  *
  * @return {Shape}
  */
+
 /**
  * Creates a label.
  *
@@ -307,6 +310,7 @@ var types = {
  *
  * @param {'label'} type
  * @param {Object} [attrs]
+ *
  * @return {Label}
  */
 export function create(type, attrs) {
@@ -321,6 +325,7 @@ export function create(type, attrs) {
  * Checks whether an object is a model instance.
  *
  * @param {any} obj
+ *
  * @return {boolean}
  */
 export function isModelElement(obj) {

--- a/lib/util/ModelUtil.js
+++ b/lib/util/ModelUtil.js
@@ -1,0 +1,38 @@
+import {
+  has,
+  isNil,
+  isObject
+} from 'min-dash';
+
+/**
+ * Checks whether a value is an instance of Connection.
+ *
+ * @param {any} value
+ *
+ * @return {boolean}
+ */
+export function isConnection(value) {
+  return isObject(value) && has(value, 'waypoints');
+}
+
+/**
+ * Checks whether a value is an instance of Label.
+ *
+ * @param {any} value
+ *
+ * @return {boolean}
+ */
+export function isLabel(value) {
+  return isObject(value) && has(value, 'labelTarget');
+}
+
+/**
+ * Checks whether a value is an instance of Root.
+ *
+ * @param {any} value
+ *
+ * @return {boolean}
+ */
+export function isRoot(value) {
+  return isObject(value) && isNil(value.parent);
+}

--- a/test/spec/features/copy-paste/CopyPasteSpec.js
+++ b/test/spec/features/copy-paste/CopyPasteSpec.js
@@ -19,7 +19,7 @@ import rulesModule from './rules';
 import selectionModule from 'lib/features/selection';
 
 /**
- * @typedef {import('../../model').Base} Base
+ * @typedef {import('../../../../lib/model/Types').Element} Element
  */
 
 var HIGH_PRIORITY = 2000;
@@ -760,11 +760,11 @@ describe('features/copy-paste', function() {
  * Find elements in a tree.
  * Return found elements or false.
  *
- * @param {Array<Base>} elements
+ * @param {Array<Element>} elements
  * @param {Object} tree
  * @param {number} [depth]
  *
- * @return {Array<Base>|false}
+ * @return {Array<Element>|false}
  */
 function findElementsInTree(elements, tree, depth) {
   var foundElements = _findElementsInTree(elements, tree, depth);
@@ -780,11 +780,11 @@ function findElementsInTree(elements, tree, depth) {
  * Find element in a tree.
  * Return found element or false.
  *
- * @param {Base} element
+ * @param {Element} element
  * @param {Object} tree
  * @param {number} [depth]
  *
- * @return {Base|false}
+ * @return {Element|false}
  */
 function findElementInTree(elements, tree, depth) {
   var foundElements = _findElementsInTree(elements, tree, depth);

--- a/test/spec/model/ModelSpec.js
+++ b/test/spec/model/ModelSpec.js
@@ -3,6 +3,11 @@ import {
   isModelElement
 } from 'lib/model';
 
+import {
+  isConnection,
+  isLabel,
+  isRoot
+} from '../../../lib/util/ModelUtil';
 
 describe('model', function() {
 
@@ -21,7 +26,61 @@ describe('model', function() {
       // then
       expect(connection.waypoints).to.equal(waypoints);
 
+      expect(isConnection(connection)).to.be.true;
       expect(isModelElement(connection)).to.be.true;
+    });
+
+
+    it('should create label', function() {
+
+      // given
+      var shape = create('shape', {
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 100
+      });
+
+      var x = 10, y = 20, width = 100, height = 100;
+
+      // when
+      var label = create('label', {
+        x: x,
+        y: y,
+        width: width,
+        height: height,
+        labelTarget: shape
+      });
+
+      // then
+      expect(label.labelTarget).to.equal(shape);
+
+      expect(isLabel(label)).to.be.true;
+      expect(isModelElement(label)).to.be.true;
+    });
+
+
+    it('should create root', function() {
+
+      // given
+      var x = 10, y = 20, width = 100, height = 100;
+
+      // when
+      var root = create('root', {
+        x: x,
+        y: y,
+        width: width,
+        height: height
+      });
+
+      // then
+      expect(root.x).to.equal(x);
+      expect(root.y).to.equal(y);
+      expect(root.width).to.equal(width);
+      expect(root.height).to.equal(height);
+
+      expect(isRoot(root)).to.be.true;
+      expect(isModelElement(root)).to.be.true;
     });
 
 


### PR DESCRIPTION
* export `isConnection`, `isLabel` and `isRoot` checks from `ModelUtil` and test
* use these checks
* checks will be usable by bpmn-js, too

---

Required by https://github.com/bpmn-io/bpmn-js/pull/1903
Related to https://github.com/bpmn-io/bpmn-js/issues/1901