### PR TITLE
fix(popupMenu): include entry id in `popupMenu.trigger`

### DIFF
--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -532,7 +532,7 @@ PopupMenu.prototype.trigger = function(event, entry, action = 'click') {
     let element = domClosest(event.delegateTarget || event.target, '.entry', true);
     let entryId = domAttr(element, DATA_REF);
 
-    entry = this._getEntry(entryId);
+    entry = { id: entryId, ...this._getEntry(entryId) };
   }
 
   const handler = entry.action;

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -820,7 +820,7 @@ describe('features/popup-menu', function() {
       // then
       expect(triggerSpy).to.have.been.calledOnce;
       expect(triggerSpy.getCall(0).args[1]).to.eql({
-        entry: popupMenu._getEntry('1'),
+        entry: { ...popupMenu._getEntry('1'), id: '1' },
         event
       });
     }));


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js-tracking/issues/21

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
