### PR TITLE
docs: reorder external projects alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Some libraries / applications built on top of diagram-js:
 
 #### External
 
-* [Node Sequencer](https://github.com/philippfromme/node-sequencer) - A Node-Based Sequencer for the Web ([Demo](https://philippfromme.github.io/node-sequencer-demo/))
-* [chor-js](https://github.com/bptlab/chor-js) - A BPMN 2.0 Choreography diagram viewer and editor ([Demo](https://bpt-lab.org/chor-js-demo/))
-* [postit-js](https://github.com/pinussilvestrus/postit-js) - Create Post-it boards on a canvas editor ([Demo](https://postit-js-demo.netlify.app/))
-* [Object Diagram Modeler](https://github.com/timKraeuter/object-diagram-modeler) - An object diagram viewer and editor ([Demo](https://timkraeuter.com/object-diagram-modeler/))
 * [archimate-js](https://github.com/archimodel/archimate-js) - An ArchiMate diagram viewer and editor ([Demo](https://archimodel.net))
+* [chor-js](https://github.com/bptlab/chor-js) - A BPMN 2.0 Choreography diagram viewer and editor ([Demo](https://bpt-lab.org/chor-js-demo/))
+* [Node Sequencer](https://github.com/philippfromme/node-sequencer) - A Node-Based Sequencer for the Web ([Demo](https://philippfromme.github.io/node-sequencer-demo/))
+* [Object Diagram Modeler](https://github.com/timKraeuter/object-diagram-modeler) - An object diagram viewer and editor ([Demo](https://timkraeuter.com/object-diagram-modeler/))
+* [postit-js](https://github.com/pinussilvestrus/postit-js) - Create Post-it boards on a canvas editor ([Demo](https://postit-js-demo.netlify.app/))
 
 ## Resources
 


### PR DESCRIPTION
No other ordering was intended in the first place.