### PR TITLE
fix(canvas): `scrollToElement` accepts root elements

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -1253,6 +1253,11 @@ Canvas.prototype.scrollToElement = function(element, padding) {
     this.setRootElement(rootElement);
   }
 
+  // element is rootElement, do not change viewport
+  if (rootElement === element) {
+    return;
+  }
+
   if (!padding) {
     padding = {};
   }

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -1451,6 +1451,21 @@ describe('Canvas', function() {
       expect(canvas.getRootElement()).to.equal(shapeRoot);
     }));
 
+
+    it('accepts root elements as argument', inject(function(canvas) {
+
+      // given
+      var shapeRoot = canvas.addRootElement({ id: 'root' });
+      canvas.setRootElement(canvas.addRootElement(null));
+
+      // when
+      canvas.scrollToElement(shapeRoot);
+
+      // then
+      expect(canvas.getRootElement()).to.equal(shapeRoot);
+
+    }));
+
   });
 
 


### PR DESCRIPTION
related to https://github.com/camunda/camunda-modeler/issues/3758

![Recording 2023-08-21 at 14 08 54](https://github.com/bpmn-io/diagram-js/assets/21984219/8457906a-af03-4719-a7aa-298bae6ca096)


<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
