### PR TITLE
feat(zoom-scroll): add zoom by cmd + wheel on mac

### DIFF
--- a/lib/navigation/zoomscroll/ZoomScroll.js
+++ b/lib/navigation/zoomscroll/ZoomScroll.js
@@ -13,6 +13,10 @@ import {
 } from '../../util/Math';
 
 import {
+  isMac
+} from '../../util/Platform';
+
+import {
   bind
 } from 'min-dash';
 
@@ -123,7 +127,7 @@ ZoomScroll.prototype._handleWheel = function handleWheel(event) {
   // pinch to zoom is mapped to wheel + ctrlKey = true
   // in modern browsers (!)
 
-  var isZoom = event.ctrlKey;
+  var isZoom = event.ctrlKey || (isMac() && event.metaKey);
 
   var isHorizontalScroll = event.shiftKey;
 


### PR DESCRIPTION
This PR adds support for zooming using cmd on the mac platform

It is clear that zooming with ctrl + wheel is most likely a side effect, since event.ctrlKey is also a directive for pinch zoom. but since there is a feature, why not create a more pleasant UX on Mac
