### PR TITLE
fix: revert `djs-dragging` CSS class changes

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -40,7 +40,6 @@
   --context-pad-entry-hover-background-color: var(--color-grey-225-10-95);
 
   --element-dragger-color: var(--color-blue-205-100-50);
-  --element-dragging-color: var(--color-grey-225-10-75);
   --element-hover-outline-fill-color: var(--color-blue-205-100-45);
   --element-selected-outline-stroke-color: var(--color-blue-205-100-50);
   --element-selected-outline-secondary-stroke-color: var(--color-blue-205-100-70);
@@ -283,38 +282,8 @@ marker.djs-dragger tspan {
 
 .djs-dragging,
 .djs-dragging > * {
+  opacity: 0.3 !important;
   pointer-events: none !important;
-}
-
-.djs-dragging .djs-context-pad,
-.djs-dragging .djs-outline {
-  display: none !important;
-}
-
-.djs-dragging * {
-  fill: none !important;
-  stroke: var(--element-dragging-color) !important;
-}
-
-.djs-dragging tspan,
-.djs-dragging text {
-  fill: var(--element-dragging-color) !important;
-  stroke: none !important;
-}
-
-marker.djs-dragging circle,
-marker.djs-dragging path,
-marker.djs-dragging polygon,
-marker.djs-dragging polyline,
-marker.djs-dragging rect {
-  fill: var(--element-dragging-color) !important;
-  stroke: none !important;
-}
-
-marker.djs-dragging text,
-marker.djs-dragging tspan {
-  fill: none !important;
-  stroke: var(--element-dragging-color) !important;
 }
 
 /**


### PR DESCRIPTION
Changing `djs-dragging` CSS class had unintended side effects due to class being used for other elements, too. I'll properly address this with https://github.com/bpmn-io/diagram-js/tree/fix-djs-dragging-2 but for now let's just roll back the changes.

---

Related to https://github.com/bpmn-io/bpmn-js/issues/2002
Related to https://github.com/bpmn-io/bpmn-js/issues/2010

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
