### PR TITLE
fix(context-pad): clear hover timeout on close

### DIFF
--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -442,6 +442,8 @@ ContextPad.prototype.close = function() {
     return;
   }
 
+  clearTimeout(this._timeout);
+
   this._overlays.remove(this._overlayId);
 
   this._overlayId = null;

--- a/test/spec/features/context-pad/ContextPadProvider.js
+++ b/test/spec/features/context-pad/ContextPadProvider.js
@@ -5,13 +5,17 @@ import imageC from './resources/c.png';
 import { every } from 'min-dash';
 
 
-export default function ContextPadProvider(contextPad) {
+export default function ContextPadProvider(contextPad, elementRegistry) {
+  this._contextPad = contextPad;
+  this._elementRegistry = elementRegistry;
+
   contextPad.registerProvider(this);
 }
 
-ContextPadProvider.$inject = [ 'contextPad' ];
+ContextPadProvider.$inject = [ 'contextPad', 'elementRegistry' ];
 
 ContextPadProvider.prototype.getContextPadEntries = function(element) {
+  var self = this;
 
   if (element.type === 'A') {
     return {
@@ -47,6 +51,11 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
       'action.hover': {
         className: 'hover',
         action: {
+          click: function(e) {
+            self._contextPad.open(self._elementRegistry.get('s2'));
+
+            return 'action.click';
+          },
           hover: function(e) {
             e.__handled = true;
 

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -838,6 +838,47 @@ describe('features/context-pad', function() {
     }));
 
 
+    it('should not handle hover event', inject(function(canvas, contextPad) {
+
+      // given
+      var shape = canvas.addShape({
+        id: 's1',
+        width: 100, height: 100,
+        x: 10, y: 10,
+        type: 'hover'
+      });
+
+      canvas.addShape({
+        id: 's2',
+        width: 100, height: 100,
+        x: 10, y: 10,
+        type: 'hover'
+      });
+
+      contextPad.open(shape);
+
+      var pad = contextPad.getPad(shape),
+          html = pad.html,
+          target = domQuery('[data-action="action.hover"]', html);
+
+      var event = globalEvent(target, { x: 0, y: 0 });
+
+      // when
+      contextPad.trigger('mouseover', event);
+
+      expect(event.__handled).not.to.exist;
+
+      clock.tick(250);
+
+      contextPad.trigger('click', globalEvent(target, { x: 0, y: 0 }));
+
+      clock.tick(500);
+
+      // then
+      expect(event.__handled).not.to.exist;
+    }));
+
+
     it('should prevent unhandled events', inject(function(canvas, contextPad) {
 
       // given


### PR DESCRIPTION
![brave_FzqvDuhVLx](https://github.com/bpmn-io/diagram-js/assets/7633572/10692a46-c29a-46b3-a628-efd4c7a3e37b)


---

Related to bpmn-io/bpmn-js#2004

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
