### PR TITLE
fix(popup): reposition if under axis

### DIFF
--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -341,6 +341,11 @@ PopupMenu.prototype._ensureVisible = function(container, position) {
     top = position.y - containerBounds.height;
   }
 
+  // underAxis
+  if (position.y < documentBounds.top) {
+    top = position.y + containerBounds.height;
+  }
+
   return {
     x: left,
     y: top

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -1653,6 +1653,29 @@ describe('features/popup-menu', function() {
     }));
 
 
+    it('should open within bounds bellow', inject(function(popupMenu) {
+
+      // given
+      var documentBounds = document.documentElement.getBoundingClientRect();
+
+      const y = - 5;
+      var cursorPosition = { x: documentBounds.left + 100, y: documentBounds.top + y };
+
+      // when
+      popupMenu.open({}, 'custom-provider', cursorPosition);
+
+      var menu = queryPopup('.djs-popup');
+
+      var menuDimensions = {
+        width: menu.scrollWidth,
+        height: menu.scrollHeight
+      };
+
+      // then
+      expect(menu.offsetTop).to.be.closeTo(y + menuDimensions.height, 3);
+    }));
+
+
     it('should open within bounds above (limited client rect height)', inject(
 
       function(popupMenu) {


### PR DESCRIPTION
Related to https://github.com/camunda/improved-canvas/pull/9

Currently, we don't consider that the popup menu can open upwards. I considered doing this in the actual extension but it leads to flaky positioning. And opening downwards is a bpmn-js concern, not diagram-js. So it's fair to also consider this case imo

Before:

https://github.com/bpmn-io/diagram-js/assets/25825387/9b632855-2cd9-4f1b-bd80-2415f7e1b92e

After:

https://github.com/bpmn-io/diagram-js/assets/25825387/6b01cdac-545a-4fc5-862d-0cf552530932
