### PR TITLE
chore: make `main` the default branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -17,7 +17,7 @@ Steps to reproduce the behavior:
 1. do this
 2. do that
 
-If possible, try to build [a test case](https://github.com/bpmn-io/diagram-js/tree/master/test/spec) that reproduces your problem.
+If possible, try to build [a test case](https://github.com/bpmn-io/diagram-js/tree/main/test/spec) that reproduces your problem.
 
 
 ### Expected Behavior

--- a/.github/workflows/CODE_SCANNING.yml
+++ b/.github/workflows/CODE_SCANNING.yml
@@ -2,9 +2,9 @@ name: "Code Scanning"
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ main, develop ]
     paths-ignore:
       - '**/*.md'
 

--- a/.github/workflows/MERGE_MASTER_TO_DEVELOP.yml
+++ b/.github/workflows/MERGE_MASTER_TO_DEVELOP.yml
@@ -1,11 +1,11 @@
-name: MERGE_MASTER_TO_DEVELOP
+name: MERGE_MAIN_TO_DEVELOP
 on:
   push:
     branches:
-    - "master"
+    - "main"
 
 jobs:
-  Merge_master_to_develop:
+  Merge_main_to_develop:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -16,11 +16,11 @@ jobs:
       with:
         ref: develop
         fetch-depth: 0
-    - name: Merge master to develop and push
+    - name: Merge main to develop and push
       run: |
         git config user.name '${{ secrets.BPMN_IO_USERNAME }}'
         git config user.email '${{ secrets.BPMN_IO_EMAIL }}'
-        git merge -m 'Merge master to develop' --no-edit origin/master
+        git merge -m 'Merge main to develop' --no-edit origin/main
         git push
 
     - name: Notify failure on Slack

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Some libraries / applications built on top of diagram-js:
 
 * [Issues](https://github.com/bpmn-io/diagram-js/issues)
 * [Changelog](./CHANGELOG.md)
-* [Contributing Guide](https://github.com/bpmn-io/diagram-js/blob/master/.github/CONTRIBUTING.md)
+* [Contributing Guide](.github/CONTRIBUTING.md)
 * [Examples](https://github.com/bpmn-io/diagram-js-examples)
 
 


### PR DESCRIPTION
This makes `main` the default branch. To be updated in the repository once this PR receives a :heavy_check_mark: 