### PR TITLE
deps: update to path-intersection@3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "min-dash": "^4.1.0",
         "min-dom": "^4.1.0",
         "object-refs": "^0.3.0",
-        "path-intersection": "^2.2.1",
+        "path-intersection": "^3.0.0",
         "tiny-svg": "^3.0.1"
       },
       "devDependencies": {
@@ -6514,8 +6514,12 @@
       }
     },
     "node_modules/path-intersection": {
-      "version": "2.2.1",
-      "license": "MIT"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-3.0.0.tgz",
+      "integrity": "sha512-Rdnfb33F9+qadWe3ZyzDpw3KSXQhsK1MByL44QzSDIQtMAujd0zFx9f+kt4SaQp1JOoXl5pl5K28EoEuAEgarA==",
+      "engines": {
+        "node": ">= 14.20"
+      }
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -13124,7 +13128,9 @@
       "dev": true
     },
     "path-intersection": {
-      "version": "2.2.1"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-3.0.0.tgz",
+      "integrity": "sha512-Rdnfb33F9+qadWe3ZyzDpw3KSXQhsK1MByL44QzSDIQtMAujd0zFx9f+kt4SaQp1JOoXl5pl5K28EoEuAEgarA=="
     },
     "path-is-absolute": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "min-dash": "^4.1.0",
     "min-dom": "^4.1.0",
     "object-refs": "^0.3.0",
-    "path-intersection": "^2.2.1",
+    "path-intersection": "^3.0.0",
     "tiny-svg": "^3.0.1"
   }
 }


### PR DESCRIPTION
This bumps to `path-intersection@3` which exposes proper module exports.

I regard this change as _non-breaking_ as diagram-js is meant to be bundled through modern module bundlers anyway. 