### PR TITLE
chore: add Seata Saga designer as an external project

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Some libraries / applications built on top of diagram-js:
 
 #### External
 
+* [Apache Seata Saga Designer](https://github.com/apache/incubator-seata/tree/2.x/saga/seata-saga-statemachine-designer) - A visual orchestration tool for Seata Saga transaction ([Demo](https://seata.apache.org/saga-designer/))
 * [archimate-js](https://github.com/archimodel/archimate-js) - An ArchiMate diagram viewer and editor ([Demo](https://archimodel.net))
 * [chor-js](https://github.com/bptlab/chor-js) - A BPMN 2.0 Choreography diagram viewer and editor ([Demo](https://bpt-lab.org/chor-js-demo/))
 * [Node Sequencer](https://github.com/philippfromme/node-sequencer) - A Node-Based Sequencer for the Web ([Demo](https://philippfromme.github.io/node-sequencer-demo/))


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
Hi, @nikku

Thanks for your great work. [Apache Seata (Incubator)](https://github.com/apache/incubator-seata) is a distributed transaction framework. And recently, we have used diagram-js as the backbone to refactor our new version of Saga Designer (a visual tool to orchestrate Saga pattern transaction).

This PR aims to provide an external link in the README.