### PR TITLE
refactor: separate export default from function declaration

### DIFF
--- a/lib/Diagram.js
+++ b/lib/Diagram.js
@@ -2,6 +2,8 @@ import { Injector } from 'didi';
 
 import CoreModule from './core';
 
+export default Diagram;
+
 /**
  * @typedef {import('didi').InjectionContext} InjectionContext
  * @typedef {import('didi').LocalsMap} LocalsMap
@@ -99,7 +101,7 @@ function createInjector(options) {
  * @param {DiagramOptions} [options]
  * @param {Injector} [injector] An (optional) injector to bootstrap the diagram with.
  */
-export default function Diagram(options, injector) {
+export function Diagram(options, injector) {
 
   this._injector = injector = injector || createInjector(options);
 

--- a/lib/command/CommandInterceptor.js
+++ b/lib/command/CommandInterceptor.js
@@ -6,6 +6,8 @@ import {
   isObject
 } from 'min-dash';
 
+export default CommandInterceptor;
+
 /**
  * @typedef {import('../core/Types').ElementLike} ElementLike
  * @typedef {import('../core/EventBus').default} EventBus
@@ -42,7 +44,7 @@ var DEFAULT_PRIORITY = 1000;
  *
  * @param {EventBus} eventBus
  */
-export default function CommandInterceptor(eventBus) {
+export function CommandInterceptor(eventBus) {
 
   /**
    * @type {EventBus}

--- a/lib/command/CommandStack.js
+++ b/lib/command/CommandStack.js
@@ -3,6 +3,8 @@ import {
   isArray
 } from 'min-dash';
 
+export default CommandStack;
+
 /**
  * @typedef {import('didi').Injector} Injector
  *
@@ -107,7 +109,7 @@ import {
  * @param {EventBus} eventBus
  * @param {Injector} injector
  */
-export default function CommandStack(eventBus, injector) {
+export function CommandStack(eventBus, injector) {
 
   /**
    * A map of all registered command handlers.

--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -37,6 +37,8 @@ import {
 import { createMatrix as createMatrix } from 'tiny-svg';
 
 
+export default Canvas;
+
 /**
  * @typedef {import('./Types').ConnectionLike} ConnectionLike
  * @typedef {import('./Types').RootLike} RootLike
@@ -163,7 +165,7 @@ const REQUIRED_MODEL_ATTRS = {
  * @param {GraphicsFactory} graphicsFactory
  * @param {ElementRegistry} elementRegistry
  */
-export default function Canvas(config, eventBus, graphicsFactory, elementRegistry) {
+export function Canvas(config, eventBus, graphicsFactory, elementRegistry) {
   this._eventBus = eventBus;
   this._elementRegistry = elementRegistry;
   this._graphicsFactory = graphicsFactory;

--- a/lib/core/ElementFactory.js
+++ b/lib/core/ElementFactory.js
@@ -4,6 +4,8 @@ import {
 
 import { assign } from 'min-dash';
 
+export default ElementFactory;
+
 /**
  * @typedef {import('../model/Types').Element} Element
  * @typedef {import('../model/Types').Connection} Connection
@@ -20,7 +22,7 @@ import { assign } from 'min-dash';
  * @template {Root} [V=Root]
  * @template {Shape} [W=Shape]
  */
-export default function ElementFactory() {
+export function ElementFactory() {
   this._uid = 12;
 }
 

--- a/lib/core/ElementRegistry.js
+++ b/lib/core/ElementRegistry.js
@@ -2,6 +2,8 @@ var ELEMENT_ID = 'data-element-id';
 
 import { attr as svgAttr } from 'tiny-svg';
 
+export default ElementRegistry;
+
 /**
  * @typedef {import('./Types').ElementLike} ElementLike
  *
@@ -19,7 +21,7 @@ import { attr as svgAttr } from 'tiny-svg';
  *
  * @param {EventBus} eventBus
  */
-export default function ElementRegistry(eventBus) {
+export function ElementRegistry(eventBus) {
 
   /**
    * @type { {

--- a/lib/core/EventBus.js
+++ b/lib/core/EventBus.js
@@ -12,6 +12,8 @@ var DEFAULT_PRIORITY = 1000;
 
 var slice = Array.prototype.slice;
 
+export default EventBus;
+
 /**
  * @typedef { {
  *   stopPropagation(): void;
@@ -119,7 +121,7 @@ var slice = Array.prototype.slice;
  * console.log(sum); // 3
  * ```
  */
-export default function EventBus() {
+export function EventBus() {
 
   /**
    * @type { Record<string, EventBusListener> }

--- a/lib/core/GraphicsFactory.js
+++ b/lib/core/GraphicsFactory.js
@@ -24,6 +24,8 @@ import {
   isFrameElement
 } from '../util/Elements';
 
+export default GraphicsFactory;
+
 /**
  * @typedef {import('./Types').ConnectionLike} ConnectionLike
  * @typedef {import('./Types').ElementLike} ElementLike
@@ -39,7 +41,7 @@ import {
  * @param {EventBus} eventBus
  * @param {ElementRegistry} elementRegistry
  */
-export default function GraphicsFactory(eventBus, elementRegistry) {
+export function GraphicsFactory(eventBus, elementRegistry) {
   this._eventBus = eventBus;
   this._elementRegistry = elementRegistry;
 }

--- a/lib/draw/BaseRenderer.js
+++ b/lib/draw/BaseRenderer.js
@@ -1,5 +1,7 @@
 var DEFAULT_RENDER_PRIORITY = 1000;
 
+export default BaseRenderer;
+
 /**
  * @typedef {import('../core/Types').ElementLike} Element
  * @typedef {import('../core/Types').ConnectionLike} Connection
@@ -14,7 +16,7 @@ var DEFAULT_RENDER_PRIORITY = 1000;
  * @param {EventBus} eventBus
  * @param {number} [renderPriority=1000]
  */
-export default function BaseRenderer(eventBus, renderPriority) {
+export function BaseRenderer(eventBus, renderPriority) {
   var self = this;
 
   renderPriority = renderPriority || DEFAULT_RENDER_PRIORITY;

--- a/lib/draw/DefaultRenderer.js
+++ b/lib/draw/DefaultRenderer.js
@@ -19,6 +19,8 @@ import {
   isFrameElement
 } from '../util/Elements';
 
+export default DefaultRenderer;
+
 /**
  * @typedef {import('../core/EventBus').default} EventBus
  * @typedef {import('./Styles').default} Styles
@@ -34,7 +36,7 @@ var DEFAULT_RENDER_PRIORITY = 1;
  * @param {EventBus} eventBus
  * @param {Styles} styles
  */
-export default function DefaultRenderer(eventBus, styles) {
+export function DefaultRenderer(eventBus, styles) {
 
   BaseRenderer.call(this, eventBus, DEFAULT_RENDER_PRIORITY);
 

--- a/lib/draw/Styles.js
+++ b/lib/draw/Styles.js
@@ -5,10 +5,12 @@ import {
 } from 'min-dash';
 
 
+export default Styles;
+
 /**
  * A component that manages shape styles
  */
-export default function Styles() {
+export function Styles() {
 
   var defaultTraits = {
 

--- a/lib/features/align-elements/AlignElements.js
+++ b/lib/features/align-elements/AlignElements.js
@@ -5,6 +5,8 @@ import {
   sortBy
 } from 'min-dash';
 
+export default AlignElements;
+
 /**
  * @typedef {import('../../model/Types').Element} Element
  *
@@ -51,7 +53,7 @@ var ALIGNMENT_SORTING = {
  * @param {Modeling} modeling
  * @param {Rules} rules
  */
-export default function AlignElements(modeling, rules) {
+export function AlignElements(modeling, rules) {
   this._modeling = modeling;
   this._rules = rules;
 }

--- a/lib/features/attach-support/AttachSupport.js
+++ b/lib/features/attach-support/AttachSupport.js
@@ -15,6 +15,8 @@ import inherits from 'inherits-browser';
 
 import CommandInterceptor from '../../command/CommandInterceptor';
 
+export default AttachSupport;
+
 /**
  * @typedef {import('didi').Injector} Injector
  *
@@ -47,7 +49,7 @@ var MARKER_ATTACH = 'attach-ok';
  * @param {Rules} rules
  * @param {Modeling} modeling
  */
-export default function AttachSupport(injector, eventBus, canvas, rules, modeling) {
+export function AttachSupport(injector, eventBus, canvas, rules, modeling) {
 
   CommandInterceptor.call(this, eventBus);
 

--- a/lib/features/auto-place/AutoPlace.js
+++ b/lib/features/auto-place/AutoPlace.js
@@ -5,6 +5,8 @@ import {
 
 import { DEFAULT_DISTANCE } from './AutoPlaceUtil';
 
+export default AutoPlace;
+
 /**
  * @typedef {import('../../core/Types').ShapeLike} Shape
  *
@@ -26,7 +28,7 @@ var LOW_PRIORITY = 100;
  * @param {Modeling} modeling
  * @param {Canvas} canvas
  */
-export default function AutoPlace(eventBus, modeling, canvas) {
+export function AutoPlace(eventBus, modeling, canvas) {
 
   eventBus.on('autoPlace', LOW_PRIORITY, function(context) {
     var shape = context.shape,

--- a/lib/features/auto-place/AutoPlaceSelectionBehavior.js
+++ b/lib/features/auto-place/AutoPlaceSelectionBehavior.js
@@ -1,3 +1,5 @@
+export default AutoPlaceSelectionBehavior;
+
 /**
  * @typedef {import('../../core/EventBus').default} EventBus
  * @typedef {import('../selection/Selection').default} Selection
@@ -9,7 +11,7 @@
  * @param {EventBus} eventBus
  * @param {Selection} selection
  */
-export default function AutoPlaceSelectionBehavior(eventBus, selection) {
+export function AutoPlaceSelectionBehavior(eventBus, selection) {
 
   eventBus.on('autoPlace.end', 500, function(e) {
     selection.select(e.shape);

--- a/lib/features/auto-resize/AutoResize.js
+++ b/lib/features/auto-resize/AutoResize.js
@@ -21,6 +21,8 @@ import {
 
 import CommandInterceptor from '../../command/CommandInterceptor';
 
+export default AutoResize;
+
 /**
  * @typedef {import('../../model/Types').Element} Element
  * @typedef {import('../../model/Types').Shape} Shape
@@ -44,7 +46,7 @@ import CommandInterceptor from '../../command/CommandInterceptor';
  * @param {Modeling} modeling
  * @param {Rules} rules
  */
-export default function AutoResize(eventBus, elementRegistry, modeling, rules) {
+export function AutoResize(eventBus, elementRegistry, modeling, rules) {
 
   CommandInterceptor.call(this, eventBus);
 

--- a/lib/features/auto-resize/AutoResizeProvider.js
+++ b/lib/features/auto-resize/AutoResizeProvider.js
@@ -2,6 +2,8 @@ import RuleProvider from '../rules/RuleProvider';
 
 import inherits from 'inherits-browser';
 
+export default AutoResizeProvider;
+
 /**
  * @typedef {import('../../model/Types').Shape} Shape
  *
@@ -13,7 +15,7 @@ import inherits from 'inherits-browser';
  *
  * @param {EventBus} eventBus
  */
-export default function AutoResizeProvider(eventBus) {
+export function AutoResizeProvider(eventBus) {
 
   RuleProvider.call(this, eventBus);
 

--- a/lib/features/auto-scroll/AutoScroll.js
+++ b/lib/features/auto-scroll/AutoScroll.js
@@ -4,6 +4,8 @@ import {
   toPoint
 } from '../../util/Event';
 
+export default AutoScroll;
+
 /**
  * @typedef {import('../../util/Types').Point} Point
  *
@@ -29,7 +31,7 @@ import {
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
  */
-export default function AutoScroll(config, eventBus, canvas) {
+export function AutoScroll(config, eventBus, canvas) {
 
   this._canvas = canvas;
 

--- a/lib/features/bendpoints/BendpointMove.js
+++ b/lib/features/bendpoints/BendpointMove.js
@@ -1,5 +1,7 @@
 import { filterRedundantWaypoints } from '../../layout/LayoutUtil';
 
+export default BendpointMove;
+
 /**
  * @typedef {import('didi').Injector} Injector
  *
@@ -27,7 +29,7 @@ var RECONNECT_START = 'reconnectStart',
  * @param {Rules} rules
  * @param {Modeling} modeling
  */
-export default function BendpointMove(injector, eventBus, canvas, dragging, rules, modeling) {
+export function BendpointMove(injector, eventBus, canvas, dragging, rules, modeling) {
   this._injector = injector;
 
   this.start = function(event, connection, bendpointIndex, insert) {

--- a/lib/features/bendpoints/BendpointMovePreview.js
+++ b/lib/features/bendpoints/BendpointMovePreview.js
@@ -9,6 +9,8 @@ import { translate } from '../../util/SvgTransformUtil';
 
 import { isReverse } from './BendpointMove';
 
+export default BendpointMovePreview;
+
 /**
  * @typedef {import('didi').Injector} Injector
  *
@@ -37,7 +39,7 @@ var HIGH_PRIORITY = 1100;
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
  */
-export default function BendpointMovePreview(bendpointMove, injector, eventBus, canvas) {
+export function BendpointMovePreview(bendpointMove, injector, eventBus, canvas) {
   this._injector = injector;
 
   var connectionPreview = injector.get('connectionPreview', false);

--- a/lib/features/bendpoints/BendpointSnapping.js
+++ b/lib/features/bendpoints/BendpointSnapping.js
@@ -10,6 +10,8 @@ import { getClosestPointOnConnection } from './BendpointUtil';
 
 import { isConnection } from '../../util/ModelUtil';
 
+export default BendpointSnapping;
+
 /**
  * @typedef {import('../../core/EventBus').default} EventBus
  */
@@ -21,7 +23,7 @@ var TOLERANCE = 10;
 /**
  * @param {EventBus} eventBus
  */
-export default function BendpointSnapping(eventBus) {
+export function BendpointSnapping(eventBus) {
 
   function snapTo(values, value) {
 

--- a/lib/features/bendpoints/Bendpoints.js
+++ b/lib/features/bendpoints/Bendpoints.js
@@ -40,6 +40,8 @@ import {
   translate
 } from '../../util/SvgTransformUtil';
 
+export default Bendpoints;
+
 /**
  * @typedef {import('../bendpoints/BendpointMove').default} BendpointMove
  * @typedef {import('../../core/Canvas').default} Canvas
@@ -57,7 +59,7 @@ import {
  * @param {BendpointMove} bendpointMove
  * @param {ConnectionSegmentMove} connectionSegmentMove
  */
-export default function Bendpoints(
+export function Bendpoints(
     eventBus, canvas, interactionEvents,
     bendpointMove, connectionSegmentMove) {
 

--- a/lib/features/bendpoints/ConnectionSegmentMove.js
+++ b/lib/features/bendpoints/ConnectionSegmentMove.js
@@ -25,6 +25,8 @@ import {
   translate
 } from '../../util/SvgTransformUtil';
 
+export default ConnectionSegmentMove;
+
 /**
  * @typedef {import('../../model/Types').Shape} Shape
  *
@@ -103,7 +105,7 @@ function getDocking(point, referenceElement, moveAxis) {
  * @param {GraphicsFactory} graphicsFactory
  * @param {Modeling} modeling
  */
-export default function ConnectionSegmentMove(
+export function ConnectionSegmentMove(
     injector, eventBus, canvas,
     dragging, graphicsFactory, modeling) {
 

--- a/lib/features/change-support/ChangeSupport.js
+++ b/lib/features/change-support/ChangeSupport.js
@@ -2,6 +2,8 @@ import {
   getType as getElementType
 } from '../../util/Elements';
 
+export default ChangeSupport;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/ElementRegistry').default} ElementRegistry
@@ -21,7 +23,7 @@ import {
  * @param {ElementRegistry} elementRegistry
  * @param {GraphicsFactory} graphicsFactory
  */
-export default function ChangeSupport(
+export function ChangeSupport(
     eventBus, canvas, elementRegistry,
     graphicsFactory) {
 

--- a/lib/features/clipboard/Clipboard.js
+++ b/lib/features/clipboard/Clipboard.js
@@ -1,7 +1,9 @@
+export default Clipboard;
+
 /**
  * A clip board stub
  */
-export default function Clipboard() {}
+export function Clipboard() {}
 
 
 Clipboard.prototype.get = function() {

--- a/lib/features/connect/Connect.js
+++ b/lib/features/connect/Connect.js
@@ -7,6 +7,8 @@ import {
   isObject
 } from 'min-dash';
 
+export default Connect;
+
 /**
  * @typedef {import('../../model/Types').Element} Element
  *
@@ -24,7 +26,7 @@ import {
  * @param {Modeling} modeling
  * @param {Rules} rules
  */
-export default function Connect(eventBus, dragging, modeling, rules) {
+export function Connect(eventBus, dragging, modeling, rules) {
 
   // rules
 

--- a/lib/features/connect/ConnectPreview.js
+++ b/lib/features/connect/ConnectPreview.js
@@ -1,5 +1,7 @@
 import { isReverse } from './Connect';
 
+export default ConnectPreview;
+
 /**
  * @typedef {import('didi').Injector} Injector
  *
@@ -20,7 +22,7 @@ var MARKER_OK = 'connect-ok',
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
  */
-export default function ConnectPreview(injector, eventBus, canvas) {
+export function ConnectPreview(injector, eventBus, canvas) {
   var connectionPreview = injector.get('connectionPreview', false);
 
   connectionPreview && eventBus.on('connect.move', function(event) {

--- a/lib/features/connection-preview/ConnectionPreview.js
+++ b/lib/features/connection-preview/ConnectionPreview.js
@@ -20,6 +20,8 @@ import {
   createLine
 } from '../../util/RenderUtil';
 
+export default ConnectionPreview;
+
 /**
  * @typedef {import('../../model/Types').Element} Element
  * @typedef {import('../../model/Types').Connection} Connection
@@ -45,7 +47,7 @@ var MARKER_CONNECTION_PREVIEW = 'djs-dragger';
  * @param {GraphicsFactory} graphicsFactory
  * @param {ElementFactory} elementFactory
  */
-export default function ConnectionPreview(
+export function ConnectionPreview(
     injector,
     canvas,
     graphicsFactory,

--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -26,6 +26,8 @@ import {
 import { isConnection } from '../../util/ModelUtil';
 
 
+export default ContextPad;
+
 /**
  * @typedef {import('../../model/Types').Element} Element
  *
@@ -69,7 +71,7 @@ var HOVER_DELAY = 300;
  * @param {EventBus} eventBus
  * @param {Overlays} overlays
  */
-export default function ContextPad(canvas, config, eventBus, overlays) {
+export function ContextPad(canvas, config, eventBus, overlays) {
 
   this._canvas = canvas;
   this._eventBus = eventBus;

--- a/lib/features/copy-paste/CopyPaste.js
+++ b/lib/features/copy-paste/CopyPaste.js
@@ -22,6 +22,8 @@ import {
   isLabel
 } from '../../util/ModelUtil';
 
+export default CopyPaste;
+
 /**
  * @typedef {import('../../core/Types').ElementLike} Element
  * @typedef {import('../../core/Types').ShapeLike} Shape
@@ -74,7 +76,7 @@ import {
  * @param {Mouse} mouse
  * @param {Rules} rules
  */
-export default function CopyPaste(
+export function CopyPaste(
     canvas,
     create,
     clipboard,

--- a/lib/features/create/Create.js
+++ b/lib/features/create/Create.js
@@ -20,6 +20,8 @@ import {
   isLabel
 } from '../../util/ModelUtil';
 
+export default Create;
+
 /**
  * @typedef {import('../../core/Types').ElementLike} Element
  * @typedef {import('../../core/Types').ShapeLike} Shape
@@ -47,7 +49,7 @@ var HIGH_PRIORITY = 2000;
  * @param {Modeling} modeling
  * @param {Rules} rules
  */
-export default function Create(
+export function Create(
     canvas,
     dragging,
     eventBus,

--- a/lib/features/create/CreateConnectPreview.js
+++ b/lib/features/create/CreateConnectPreview.js
@@ -1,5 +1,7 @@
 var LOW_PRIORITY = 740;
 
+export default CreateConnectPreview;
+
 /**
  * @typedef {import('didi').Injector} Injector
  *
@@ -12,7 +14,7 @@ var LOW_PRIORITY = 740;
  * @param {Injector} injector
  * @param {EventBus} eventBus
  */
-export default function CreateConnectPreview(injector, eventBus) {
+export function CreateConnectPreview(injector, eventBus) {
   var connectionPreview = injector.get('connectionPreview', false);
 
   eventBus.on('create.move', LOW_PRIORITY, function(event) {

--- a/lib/features/create/CreatePreview.js
+++ b/lib/features/create/CreatePreview.js
@@ -11,6 +11,8 @@ import {
   remove as svgRemove
 } from 'tiny-svg';
 
+export default CreatePreview;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/EventBus').default} EventBus
@@ -28,7 +30,7 @@ var LOW_PRIORITY = 750;
  * @param {PreviewSupport} previewSupport
  * @param {Styles} styles
  */
-export default function CreatePreview(
+export function CreatePreview(
     canvas,
     eventBus,
     graphicsFactory,

--- a/lib/features/distribute-elements/DistributeElements.js
+++ b/lib/features/distribute-elements/DistributeElements.js
@@ -4,6 +4,8 @@ import {
   isArray
 } from 'min-dash';
 
+export default DistributeElements;
+
 /**
  * @typedef {import('../../model/Types').Element} Element
  *
@@ -39,7 +41,7 @@ var THRESHOLD = 5;
  * @param {Modeling} modeling
  * @param {Rules} rules
  */
-export default function DistributeElements(modeling, rules) {
+export function DistributeElements(modeling, rules) {
   this._modeling = modeling;
 
   this._filters = [];

--- a/lib/features/dragging/Dragging.js
+++ b/lib/features/dragging/Dragging.js
@@ -27,6 +27,8 @@ import {
 
 import { isKey } from '../keyboard/KeyboardUtil';
 
+export default Dragging;
+
 /**
  * @typedef {import('../../util/Types').Point} Point
  *
@@ -139,7 +141,7 @@ function getLength(point) {
  * @param {Selection} selection
  * @param {ElementRegistry} elementRegistry
  */
-export default function Dragging(eventBus, canvas, selection, elementRegistry) {
+export function Dragging(eventBus, canvas, selection, elementRegistry) {
 
   var defaultOptions = {
     threshold: 5,

--- a/lib/features/editor-actions/EditorActions.js
+++ b/lib/features/editor-actions/EditorActions.js
@@ -3,6 +3,8 @@ import {
   isArray
 } from 'min-dash';
 
+export default EditorActions;
+
 /**
  * @typedef {import('didi').Injector} Injector
  *
@@ -33,7 +35,7 @@ var NOT_REGISTERED_ERROR = 'is not a registered action',
  * @param {EventBus} eventBus
  * @param {Injector} injector
  */
-export default function EditorActions(eventBus, injector) {
+export function EditorActions(eventBus, injector) {
 
   // initialize actions
   this._actions = {};

--- a/lib/features/global-connect/GlobalConnect.js
+++ b/lib/features/global-connect/GlobalConnect.js
@@ -1,6 +1,8 @@
 var MARKER_OK = 'connect-ok',
     MARKER_NOT_OK = 'connect-not-ok';
 
+export default GlobalConnect;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../connect/Connect').default} Connect
@@ -25,7 +27,7 @@ var MARKER_OK = 'connect-ok',
  * @param {Rules} rules
  * @param {Mouse} mouse
  */
-export default function GlobalConnect(
+export function GlobalConnect(
     eventBus, dragging, connect,
     canvas, toolManager, rules,
     mouse) {

--- a/lib/features/grid-snapping/GridSnapping.js
+++ b/lib/features/grid-snapping/GridSnapping.js
@@ -15,6 +15,8 @@ import {
   quantize
 } from './GridUtil';
 
+export default GridSnapping;
+
 /**
  * @typedef {import('../../core/ElementRegistry').default} ElementRegistry
  * @typedef {import('../../core/EventBus').default} EventBus
@@ -31,7 +33,7 @@ var LOW_PRIORITY = 800;
  * @param {EventBus} eventBus
  * @param {Object} config
  */
-export default function GridSnapping(elementRegistry, eventBus, config) {
+export function GridSnapping(elementRegistry, eventBus, config) {
 
   var active = !config || config.active !== false;
 

--- a/lib/features/grid-snapping/behavior/ResizeBehavior.js
+++ b/lib/features/grid-snapping/behavior/ResizeBehavior.js
@@ -7,6 +7,8 @@ import {
   isString
 } from 'min-dash';
 
+export default ResizeBehavior;
+
 /**
  * @typedef {import('../../../model/Types').Shape} Shape
  *
@@ -22,7 +24,7 @@ import {
  * @param {EventBus} eventBus
  * @param {GridSnapping} gridSnapping
  */
-export default function ResizeBehavior(eventBus, gridSnapping) {
+export function ResizeBehavior(eventBus, gridSnapping) {
   CommandInterceptor.call(this, eventBus);
 
   this._gridSnapping = gridSnapping;

--- a/lib/features/grid-snapping/behavior/SpaceToolBehavior.js
+++ b/lib/features/grid-snapping/behavior/SpaceToolBehavior.js
@@ -1,3 +1,5 @@
+export default SpaceToolBehavior;
+
 /**
  * @typedef {import('../../../core/EventBus').default} EventBus
  * @typedef {import('../../grid-snapping/GridSnapping').default} GridSnapping
@@ -11,7 +13,7 @@ var HIGH_PRIORITY = 2000;
  * @param {EventBus} eventBus
  * @param {GridSnapping} gridSnapping
  */
-export default function SpaceToolBehavior(eventBus, gridSnapping) {
+export function SpaceToolBehavior(eventBus, gridSnapping) {
   eventBus.on([
     'spaceTool.move',
     'spaceTool.end'

--- a/lib/features/hand-tool/HandTool.js
+++ b/lib/features/hand-tool/HandTool.js
@@ -4,6 +4,8 @@ import {
 
 import { isKey } from '../../features/keyboard/KeyboardUtil';
 
+export default HandTool;
+
 /**
  * @typedef {import('didi').Injector} Injector
  *
@@ -25,7 +27,7 @@ var HAND_CURSOR = 'grab';
  * @param {ToolManager} toolManager
  * @param {Mouse} mouse
  */
-export default function HandTool(
+export function HandTool(
     eventBus, canvas, dragging,
     injector, toolManager, mouse) {
 

--- a/lib/features/hover-fix/HoverFix.js
+++ b/lib/features/hover-fix/HoverFix.js
@@ -6,6 +6,8 @@ import {
   toPoint
 } from '../../util/Event';
 
+export default HoverFix;
+
 /**
  * @typedef {import('didi').Injector} Injector
  *
@@ -31,7 +33,7 @@ var HIGH_PRIORITY = 1500;
  * @param {EventBus} eventBus
  * @param {Injector} injector
  */
-export default function HoverFix(elementRegistry, eventBus, injector) {
+export function HoverFix(elementRegistry, eventBus, injector) {
 
   var self = this;
 

--- a/lib/features/interaction-events/InteractionEvents.js
+++ b/lib/features/interaction-events/InteractionEvents.js
@@ -26,6 +26,8 @@ import {
   updateLine
 } from '../../util/RenderUtil';
 
+export default InteractionEvents;
+
 /**
  * @typedef {import('../../model/Types').Element} Element
  *
@@ -68,7 +70,7 @@ var LOW_PRIORITY = 500;
  * @param {ElementRegistry} elementRegistry
  * @param {Styles} styles
  */
-export default function InteractionEvents(eventBus, elementRegistry, styles) {
+export function InteractionEvents(eventBus, elementRegistry, styles) {
 
   var self = this;
 

--- a/lib/features/keyboard-move-selection/KeyboardMoveSelection.js
+++ b/lib/features/keyboard-move-selection/KeyboardMoveSelection.js
@@ -2,6 +2,8 @@ import {
   assign
 } from 'min-dash';
 
+export default KeyboardMoveSelection;
+
 /**
  * @typedef {import('../keyboard/Keyboard').default} Keyboard
  * @typedef {import('../modeling/Modeling').default} Modeling
@@ -73,7 +75,7 @@ var DIRECTIONS_DELTA = {
  * @param {Rules} rules
  * @param {Selection} selection
  */
-export default function KeyboardMoveSelection(
+export function KeyboardMoveSelection(
     config,
     keyboard,
     modeling,

--- a/lib/features/keyboard/Keyboard.js
+++ b/lib/features/keyboard/Keyboard.js
@@ -15,6 +15,8 @@ import {
   isShift
 } from './KeyboardUtil';
 
+export default Keyboard;
+
 /**
  * @typedef {import('../../core/EventBus').default} EventBus
  *
@@ -53,7 +55,7 @@ var DEFAULT_PRIORITY = 1000;
  * @param {EventTarget} [config.bindTo]
  * @param {EventBus} eventBus
  */
-export default function Keyboard(config, eventBus) {
+export function Keyboard(config, eventBus) {
   var self = this;
 
   this._config = config || {};

--- a/lib/features/keyboard/KeyboardBindings.js
+++ b/lib/features/keyboard/KeyboardBindings.js
@@ -11,6 +11,8 @@ import {
   KEYS_REDO
 } from './KeyboardUtil';
 
+export default KeyboardBindings;
+
 /**
  * @typedef {import('../editor-actions/EditorActions').default} EditorActions
  * @typedef {import('../../core/EventBus').default} EventBus
@@ -37,7 +39,7 @@ var LOW_PRIORITY = 500;
  * @param {EventBus} eventBus
  * @param {Keyboard} keyboard
  */
-export default function KeyboardBindings(eventBus, keyboard) {
+export function KeyboardBindings(eventBus, keyboard) {
 
   var self = this;
 

--- a/lib/features/label-support/LabelSupport.js
+++ b/lib/features/label-support/LabelSupport.js
@@ -17,6 +17,8 @@ import { saveClear } from '../../util/Removal';
 
 import CommandInterceptor from '../../command/CommandInterceptor';
 
+export default LabelSupport;
+
 /**
  * @typedef {import('../../model/Types').Element} Element
  *
@@ -34,7 +36,7 @@ import CommandInterceptor from '../../command/CommandInterceptor';
  * @param {EventBus} eventBus
  * @param {Modeling} modeling
  */
-export default function LabelSupport(injector, eventBus, modeling) {
+export function LabelSupport(injector, eventBus, modeling) {
 
   CommandInterceptor.call(this, eventBus);
 

--- a/lib/features/lasso-tool/LassoTool.js
+++ b/lib/features/lasso-tool/LassoTool.js
@@ -13,6 +13,8 @@ import {
   remove as svgRemove
 } from 'tiny-svg';
 
+export default LassoTool;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../dragging/Dragging').default} Dragging
@@ -36,7 +38,7 @@ var LASSO_TOOL_CURSOR = 'crosshair';
  * @param {ToolManager} toolManager
  * @param {Mouse} mouse
  */
-export default function LassoTool(
+export function LassoTool(
     eventBus, canvas, dragging,
     elementRegistry, selection, toolManager,
     mouse) {

--- a/lib/features/modeling/Modeling.js
+++ b/lib/features/modeling/Modeling.js
@@ -28,6 +28,8 @@ import UpdateWaypointsHandler from './cmd/UpdateWaypointsHandler';
 
 import { isModelElement } from '../../model';
 
+export default Modeling;
+
 /**
  * @typedef {import('../../model/Types').Element} Element
  * @typedef {import('../../model/Types').Connection} Connection
@@ -97,7 +99,7 @@ import { isModelElement } from '../../model';
  * @param {ElementFactory} elementFactory
  * @param {CommandStack} commandStack
  */
-export default function Modeling(eventBus, elementFactory, commandStack) {
+export function Modeling(eventBus, elementFactory, commandStack) {
   this._eventBus = eventBus;
   this._elementFactory = elementFactory;
   this._commandStack = commandStack;

--- a/lib/features/modeling/cmd/AlignElementsHandler.js
+++ b/lib/features/modeling/cmd/AlignElementsHandler.js
@@ -1,5 +1,7 @@
 import { forEach, isDefined } from 'min-dash';
 
+export default AlignElements;
+
 /**
  * @typedef {import('../../../core/Canvas').default} Canvas
  * @typedef {import('../Modeling').default} Modeling
@@ -11,7 +13,7 @@ import { forEach, isDefined } from 'min-dash';
  * @param {Modeling} modeling
  * @param {Canvas} canvas
  */
-export default function AlignElements(modeling, canvas) {
+export function AlignElements(modeling, canvas) {
   this._modeling = modeling;
   this._canvas = canvas;
 }

--- a/lib/features/modeling/cmd/AppendShapeHandler.js
+++ b/lib/features/modeling/cmd/AppendShapeHandler.js
@@ -1,5 +1,7 @@
 import { some } from 'min-dash';
 
+export default AppendShapeHandler;
+
 /**
  * @typedef {import('../../../model/Types').Element} Element
  * @typedef {import('../../../model/Types').Parent} Parent
@@ -16,7 +18,7 @@ import { some } from 'min-dash';
  *
  * @param {Modeling} modeling
  */
-export default function AppendShapeHandler(modeling) {
+export function AppendShapeHandler(modeling) {
   this._modeling = modeling;
 }
 

--- a/lib/features/modeling/cmd/CreateConnectionHandler.js
+++ b/lib/features/modeling/cmd/CreateConnectionHandler.js
@@ -1,3 +1,5 @@
+export default CreateConnectionHandler;
+
 /**
  * @typedef {import('../../../model/Types').Element} Element
  * @typedef {import('../../../model/Types').Shape} Shape
@@ -14,7 +16,7 @@
  * @param {Canvas} canvas
  * @param {Layouter} layouter
  */
-export default function CreateConnectionHandler(canvas, layouter) {
+export function CreateConnectionHandler(canvas, layouter) {
   this._canvas = canvas;
   this._layouter = layouter;
 }

--- a/lib/features/modeling/cmd/CreateElementsHandler.js
+++ b/lib/features/modeling/cmd/CreateElementsHandler.js
@@ -19,6 +19,8 @@ import {
   isLabel
 } from '../../../util/ModelUtil';
 
+export default CreateElementsHandler;
+
 /**
  * @typedef {import('../Modeling').default} Modeling
  */
@@ -28,7 +30,7 @@ var round = Math.round;
 /**
  * @param {Modeling} modeling
  */
-export default function CreateElementsHandler(modeling) {
+export function CreateElementsHandler(modeling) {
   this._modeling = modeling;
 }
 

--- a/lib/features/modeling/cmd/CreateLabelHandler.js
+++ b/lib/features/modeling/cmd/CreateLabelHandler.js
@@ -2,6 +2,8 @@ import inherits from 'inherits-browser';
 
 import CreateShapeHandler from './CreateShapeHandler';
 
+export default CreateLabelHandler;
+
 /**
  * @typedef {import('../../../core/Canvas').default} Canvas
  *
@@ -16,7 +18,7 @@ import CreateShapeHandler from './CreateShapeHandler';
  *
  * @param {Canvas} canvas
  */
-export default function CreateLabelHandler(canvas) {
+export function CreateLabelHandler(canvas) {
   CreateShapeHandler.call(this, canvas);
 }
 

--- a/lib/features/modeling/cmd/CreateShapeHandler.js
+++ b/lib/features/modeling/cmd/CreateShapeHandler.js
@@ -1,5 +1,7 @@
 import { assign } from 'min-dash';
 
+export default CreateShapeHandler;
+
 /**
  * @typedef {import('../../../model/Types').Element} Element
  * @typedef {import('../../../util/Types').Point} Point
@@ -15,7 +17,7 @@ var round = Math.round;
  *
  * @param {Canvas} canvas
  */
-export default function CreateShapeHandler(canvas) {
+export function CreateShapeHandler(canvas) {
   this._canvas = canvas;
 }
 

--- a/lib/features/modeling/cmd/DeleteConnectionHandler.js
+++ b/lib/features/modeling/cmd/DeleteConnectionHandler.js
@@ -5,6 +5,8 @@ import {
 
 import { saveClear } from '../../../util/Removal';
 
+export default DeleteConnectionHandler;
+
 /**
  * @typedef {import('../../../core/Canvas').default} Canvas
  * @typedef {import('../Modeling').default} Modeling
@@ -13,7 +15,7 @@ import { saveClear } from '../../../util/Removal';
 /**
  * A handler that implements reversible deletion of Connections.
  */
-export default function DeleteConnectionHandler(canvas, modeling) {
+export function DeleteConnectionHandler(canvas, modeling) {
   this._canvas = canvas;
   this._modeling = modeling;
 }

--- a/lib/features/modeling/cmd/DeleteElementsHandler.js
+++ b/lib/features/modeling/cmd/DeleteElementsHandler.js
@@ -1,5 +1,7 @@
 import { forEach } from 'min-dash';
 
+export default DeleteElementsHandler;
+
 /**
  * @typedef {import('../../../core/ElementRegistry').default} ElementRegistry
  * @typedef {import('../Modeling').default} Modeling
@@ -9,7 +11,7 @@ import { forEach } from 'min-dash';
  * @param {Modeling} modeling
  * @param {ElementRegistry} elementRegistry
  */
-export default function DeleteElementsHandler(modeling, elementRegistry) {
+export function DeleteElementsHandler(modeling, elementRegistry) {
   this._modeling = modeling;
   this._elementRegistry = elementRegistry;
 }

--- a/lib/features/modeling/cmd/DeleteShapeHandler.js
+++ b/lib/features/modeling/cmd/DeleteShapeHandler.js
@@ -7,6 +7,8 @@ import { saveClear } from '../../../util/Removal';
 
 import { isConnection } from '../../../util/ModelUtil';
 
+export default DeleteShapeHandler;
+
 /**
  * @typedef {import('../../../core/Canvas').default} Canvas
  * @typedef {import('../Modeling').default} Modeling
@@ -18,7 +20,7 @@ import { isConnection } from '../../../util/ModelUtil';
  * @param {Canvas} canvas
  * @param {Modeling} modeling
  */
-export default function DeleteShapeHandler(canvas, modeling) {
+export function DeleteShapeHandler(canvas, modeling) {
   this._canvas = canvas;
   this._modeling = modeling;
 }

--- a/lib/features/modeling/cmd/DistributeElementsHandler.js
+++ b/lib/features/modeling/cmd/DistributeElementsHandler.js
@@ -3,6 +3,8 @@ import {
   sortBy
 } from 'min-dash';
 
+export default DistributeElements;
+
 /**
  * @typedef {import('../Modeling').default} Modeling
  */
@@ -12,7 +14,7 @@ import {
  *
  * @param {Modeling} modeling
  */
-export default function DistributeElements(modeling) {
+export function DistributeElements(modeling) {
   this._modeling = modeling;
 }
 

--- a/lib/features/modeling/cmd/LayoutConnectionHandler.js
+++ b/lib/features/modeling/cmd/LayoutConnectionHandler.js
@@ -1,5 +1,7 @@
 import { assign } from 'min-dash';
 
+export default LayoutConnectionHandler;
+
 /**
  * @typedef {import('../../../core/Canvas').default} Canvas
  * @typedef {import('../../../layout/BaseLayouter').default} Layouter
@@ -11,7 +13,7 @@ import { assign } from 'min-dash';
  * @param {Layouter} layouter
  * @param {Canvas} canvas
  */
-export default function LayoutConnectionHandler(layouter, canvas) {
+export function LayoutConnectionHandler(layouter, canvas) {
   this._layouter = layouter;
   this._canvas = canvas;
 }

--- a/lib/features/modeling/cmd/MoveConnectionHandler.js
+++ b/lib/features/modeling/cmd/MoveConnectionHandler.js
@@ -7,13 +7,15 @@ import {
 } from '../../../util/Collections';
 
 
+export default MoveConnectionHandler;
+
 /**
  * A handler that implements reversible moving of connections.
  *
  * The handler differs from the layout connection handler in a sense
  * that it preserves the connection layout.
  */
-export default function MoveConnectionHandler() { }
+export function MoveConnectionHandler() { }
 
 
 MoveConnectionHandler.prototype.execute = function(context) {

--- a/lib/features/modeling/cmd/MoveElementsHandler.js
+++ b/lib/features/modeling/cmd/MoveElementsHandler.js
@@ -1,5 +1,7 @@
 import MoveHelper from './helper/MoveHelper';
 
+export default MoveElementsHandler;
+
 /**
  * @typedef {import('../Modeling').default} Modeling
  */
@@ -9,7 +11,7 @@ import MoveHelper from './helper/MoveHelper';
  *
  * @param {Modeling} modeling
  */
-export default function MoveElementsHandler(modeling) {
+export function MoveElementsHandler(modeling) {
   this._helper = new MoveHelper(modeling);
 }
 

--- a/lib/features/modeling/cmd/MoveShapeHandler.js
+++ b/lib/features/modeling/cmd/MoveShapeHandler.js
@@ -16,6 +16,8 @@ import {
   getMovedTargetAnchor
 } from './helper/AnchorsHelper';
 
+export default MoveShapeHandler;
+
 /**
  * @typedef {import('../Modeling').default} Modeling
  */
@@ -25,7 +27,7 @@ import {
  *
  * @param {Modeling} modeling
  */
-export default function MoveShapeHandler(modeling) {
+export function MoveShapeHandler(modeling) {
   this._modeling = modeling;
 
   this._helper = new MoveHelper(modeling);

--- a/lib/features/modeling/cmd/ReconnectConnectionHandler.js
+++ b/lib/features/modeling/cmd/ReconnectConnectionHandler.js
@@ -1,5 +1,7 @@
 import { isArray } from 'min-dash';
 
+export default ReconnectConnectionHandler;
+
 /**
  * @typedef {import('../Modeling').default} Modeling
  */
@@ -9,7 +11,7 @@ import { isArray } from 'min-dash';
  *
  * @param {Modeling} modeling
  */
-export default function ReconnectConnectionHandler(modeling) {
+export function ReconnectConnectionHandler(modeling) {
   this._modeling = modeling;
 }
 

--- a/lib/features/modeling/cmd/ReplaceShapeHandler.js
+++ b/lib/features/modeling/cmd/ReplaceShapeHandler.js
@@ -5,6 +5,8 @@ import {
   getResizedTargetAnchor
 } from './helper/AnchorsHelper';
 
+export default ReplaceShapeHandler;
+
 /**
  * @typedef {import('../../model/Types').Shape} Shape
  *
@@ -22,7 +24,7 @@ import {
  * @param {Modeling} modeling
  * @param {Rules} rules
  */
-export default function ReplaceShapeHandler(modeling, rules) {
+export function ReplaceShapeHandler(modeling, rules) {
   this._modeling = modeling;
   this._rules = rules;
 }

--- a/lib/features/modeling/cmd/ResizeShapeHandler.js
+++ b/lib/features/modeling/cmd/ResizeShapeHandler.js
@@ -8,6 +8,8 @@ import {
   getResizedTargetAnchor
 } from './helper/AnchorsHelper';
 
+export default ResizeShapeHandler;
+
 /**
  * @typedef {import('../Modeling').default} Modeling
  */
@@ -17,7 +19,7 @@ import {
  *
  * @param {Modeling} modeling
  */
-export default function ResizeShapeHandler(modeling) {
+export function ResizeShapeHandler(modeling) {
   this._modeling = modeling;
 }
 

--- a/lib/features/modeling/cmd/SpaceToolHandler.js
+++ b/lib/features/modeling/cmd/SpaceToolHandler.js
@@ -16,6 +16,8 @@ import {
   getResizedTargetAnchor
 } from './helper/AnchorsHelper';
 
+export default SpaceToolHandler;
+
 /**
  * @typedef {import('../Modeling').default} Modeling
  */
@@ -25,7 +27,7 @@ import {
  *
  * @param {Modeling} modeling
  */
-export default function SpaceToolHandler(modeling) {
+export function SpaceToolHandler(modeling) {
   this._modeling = modeling;
 }
 

--- a/lib/features/modeling/cmd/ToggleShapeCollapseHandler.js
+++ b/lib/features/modeling/cmd/ToggleShapeCollapseHandler.js
@@ -3,6 +3,8 @@ import {
   forEach
 } from 'min-dash';
 
+export default ToggleShapeCollapseHandler;
+
 /**
  * @typedef {import('../../model/Types').Shape} Shape
  *
@@ -15,7 +17,7 @@ import {
  *
  * @param {Modeling} modeling
  */
-export default function ToggleShapeCollapseHandler(modeling) {
+export function ToggleShapeCollapseHandler(modeling) {
   this._modeling = modeling;
 }
 

--- a/lib/features/modeling/cmd/UpdateAttachmentHandler.js
+++ b/lib/features/modeling/cmd/UpdateAttachmentHandler.js
@@ -3,6 +3,8 @@ import {
   remove as collectionRemove
 } from '../../../util/Collections';
 
+export default UpdateAttachmentHandler;
+
 /**
  * @typedef {import('../Modeling').default} Modeling
  */
@@ -12,7 +14,7 @@ import {
  *
  * @param {Modeling} modeling
  */
-export default function UpdateAttachmentHandler(modeling) {
+export function UpdateAttachmentHandler(modeling) {
   this._modeling = modeling;
 }
 

--- a/lib/features/modeling/cmd/helper/MoveHelper.js
+++ b/lib/features/modeling/cmd/helper/MoveHelper.js
@@ -9,6 +9,8 @@ import {
 
 import MoveClosure from './MoveClosure';
 
+export default MoveHelper;
+
 /**
  * @typedef {import('../../../../core/Types').ElementLike} Element
  * @typedef {import('../../../../core/Types').ShapeLike} Shape
@@ -24,7 +26,7 @@ import MoveClosure from './MoveClosure';
  *
  * @param {Modeling} modeling
  */
-export default function MoveHelper(modeling) {
+export function MoveHelper(modeling) {
   this._modeling = modeling;
 }
 

--- a/lib/features/mouse/Mouse.js
+++ b/lib/features/mouse/Mouse.js
@@ -1,3 +1,5 @@
+export default Mouse;
+
 /**
  * @typedef {import('../../core/EventBus').default} EventBus
  */
@@ -5,7 +7,7 @@
 /**
  * @param {EventBus} eventBus
  */
-export default function Mouse(eventBus) {
+export function Mouse(eventBus) {
   var self = this;
 
   this._lastMoveEvent = null;

--- a/lib/features/move/Move.js
+++ b/lib/features/move/Move.js
@@ -9,6 +9,8 @@ import {
   classes as svgClasses
 } from 'tiny-svg';
 
+export default MoveEvents;
+
 /**
  * @typedef {import('../../core/Types').ElementLike} Element
  * @typedef {import('../../core/Types').ShapeLike} Shape
@@ -48,7 +50,7 @@ function mid(element) {
  * @param {Selection} selection
  * @param {Rules} rules
  */
-export default function MoveEvents(
+export function MoveEvents(
     eventBus, dragging, modeling,
     selection, rules) {
 

--- a/lib/features/move/MovePreview.js
+++ b/lib/features/move/MovePreview.js
@@ -24,6 +24,8 @@ import { translate } from '../../util/SvgTransformUtil';
 
 import { isConnection } from '../../util/ModelUtil';
 
+export default MovePreview;
+
 /**
  * @typedef {import('../../model/Types').Element} Element
  *
@@ -50,7 +52,7 @@ var MARKER_DRAGGING = 'djs-dragging',
  * @param {Styles} styles
  * @param {PreviewSupport} previewSupport
  */
-export default function MovePreview(
+export function MovePreview(
     eventBus, canvas, styles, previewSupport) {
 
   function getVisualDragShapes(shapes) {

--- a/lib/features/ordering/OrderingProvider.js
+++ b/lib/features/ordering/OrderingProvider.js
@@ -2,6 +2,8 @@ import inherits from 'inherits-browser';
 
 import CommandInterceptor from '../../command/CommandInterceptor';
 
+export default OrderingProvider;
+
 /**
  * @typedef {import('../../core/Types').ElementLike} Element
  * @typedef {import('../../core/Types').ShapeLike} Shape
@@ -38,7 +40,7 @@ import CommandInterceptor from '../../command/CommandInterceptor';
  *
  * @param {EventBus} eventBus
  */
-export default function OrderingProvider(eventBus) {
+export function OrderingProvider(eventBus) {
 
   CommandInterceptor.call(this, eventBus);
 

--- a/lib/features/outline/Outline.js
+++ b/lib/features/outline/Outline.js
@@ -20,6 +20,8 @@ import {
 
 var DEFAULT_PRIORITY = 1000;
 
+export default Outline;
+
 /**
  * @typedef {import('../../model/Types').Element} Element
  *
@@ -36,7 +38,7 @@ var DEFAULT_PRIORITY = 1000;
  * @param {EventBus} eventBus
  * @param {Styles} styles
  */
-export default function Outline(eventBus, styles) {
+export function Outline(eventBus, styles) {
 
   this._eventBus = eventBus;
 

--- a/lib/features/overlays/Overlays.js
+++ b/lib/features/overlays/Overlays.js
@@ -30,6 +30,8 @@ var ids = new Ids('ov');
 
 var LOW_PRIORITY = 500;
 
+export default Overlays;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/ElementRegistry').default} ElementRegistry
@@ -153,7 +155,7 @@ var LOW_PRIORITY = 500;
  * @param {Canvas} canvas
  * @param {ElementRegistry} elementRegistry
  */
-export default function Overlays(config, eventBus, canvas, elementRegistry) {
+export function Overlays(config, eventBus, canvas, elementRegistry) {
   this._eventBus = eventBus;
   this._canvas = canvas;
   this._elementRegistry = elementRegistry;

--- a/lib/features/palette/Palette.js
+++ b/lib/features/palette/Palette.js
@@ -19,6 +19,8 @@ import {
   escapeCSS
 } from '../../util/EscapeUtil';
 
+export default Palette;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/EventBus').default} EventBus
@@ -45,7 +47,7 @@ var DEFAULT_PRIORITY = 1000;
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
  */
-export default function Palette(eventBus, canvas) {
+export function Palette(eventBus, canvas) {
 
   this._eventBus = eventBus;
   this._canvas = canvas;

--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -19,6 +19,8 @@ import {
 
 import PopupMenuComponent from './PopupMenuComponent';
 
+export default PopupMenu;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/EventBus').default} EventBus
@@ -60,7 +62,7 @@ var DEFAULT_PRIORITY = 1000;
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
  */
-export default function PopupMenu(config, eventBus, canvas) {
+export function PopupMenu(config, eventBus, canvas) {
   this._eventBus = eventBus;
   this._canvas = canvas;
 

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -17,6 +17,8 @@ import PopupMenuList from './PopupMenuList';
 import classNames from 'clsx';
 import { isDefined, isFunction } from 'min-dash';
 
+export default PopupMenuComponent;
+
 /**
  * @typedef {import('./PopupMenuProvider').PopupMenuEntry} PopupMenuEntry
  * @typedef {import('./PopupMenuProvider').PopupMenuHeaderEntry} PopupMenuHeaderEntry
@@ -40,7 +42,7 @@ import { isDefined, isFunction } from 'min-dash';
  * @param {PopupMenuEmptyPlaceholder} [props.emptyPlaceholder]
  * @param {number} [props.width]
  */
-export default function PopupMenuComponent(props) {
+export function PopupMenuComponent(props) {
   const {
     onClose,
     onSelect,

--- a/lib/features/popup-menu/PopupMenuItem.js
+++ b/lib/features/popup-menu/PopupMenuItem.js
@@ -4,6 +4,8 @@ import {
   html
 } from '../../ui';
 
+export default PopupMenuItem;
+
 /**
  * @typedef {import('./PopupMenuProvider').PopupMenuEntry} PopupMenuEntry
  */
@@ -19,7 +21,7 @@ import {
  * @param {(event: MouseEvent) => void} props.onMouseLeave
  * @param {(event: MouseEvent, entry?: PopupMenuEntry, action?: string) => void} props.onAction
  */
-export default function PopupMenuItem(props) {
+export function PopupMenuItem(props) {
   const {
     entry,
     selected,

--- a/lib/features/popup-menu/PopupMenuList.js
+++ b/lib/features/popup-menu/PopupMenuList.js
@@ -7,6 +7,8 @@ import {
 
 import PopupMenuItem from './PopupMenuItem';
 
+export default PopupMenuList;
+
 /**
  * @typedef {import('./PopupMenuProvider').PopupMenuEntry} PopupMenuEntry
  */
@@ -19,7 +21,7 @@ import PopupMenuItem from './PopupMenuItem';
  * @param {PopupMenuEntry} props.selectedEntry
  * @param {(entry: PopupMenuEntry | null) => void} props.setSelectedEntry
  */
-export default function PopupMenuList(props) {
+export function PopupMenuList(props) {
   const {
     selectedEntry,
     setSelectedEntry,

--- a/lib/features/preview-support/PreviewSupport.js
+++ b/lib/features/preview-support/PreviewSupport.js
@@ -15,6 +15,8 @@ import { query as domQuery } from 'min-dom';
 
 import { getVisual } from '../../util/GraphicsUtil';
 
+export default PreviewSupport;
+
 /**
  * @typedef {import('../../core/Types').ElementLike} Element
  * @typedef {import('../../core/Types').ShapeLike} Shape
@@ -51,7 +53,7 @@ var NODES_CAN_HAVE_MARKER = [
  * @param {Canvas} canvas
  * @param {Styles} styles
  */
-export default function PreviewSupport(elementRegistry, eventBus, canvas, styles) {
+export function PreviewSupport(elementRegistry, eventBus, canvas, styles) {
   this._elementRegistry = elementRegistry;
   this._canvas = canvas;
   this._styles = styles;

--- a/lib/features/replace/Replace.js
+++ b/lib/features/replace/Replace.js
@@ -2,6 +2,8 @@ import {
   assign
 } from 'min-dash';
 
+export default Replace;
+
 /**
  * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
  * @typedef {import('../modeling/Modeling').default} Modeling
@@ -17,7 +19,7 @@ var round = Math.round;
  * @param {Modeling} modeling
  * @param {EventBus} eventBus
  */
-export default function Replace(modeling, eventBus) {
+export function Replace(modeling, eventBus) {
   this._modeling = modeling;
   this._eventBus = eventBus;
 }

--- a/lib/features/resize/Resize.js
+++ b/lib/features/resize/Resize.js
@@ -16,6 +16,8 @@ import {
   roundBounds
 } from '../../layout/LayoutUtil';
 
+export default Resize;
+
 /**
  * @typedef {import('../../core/Types').ShapeLike} Shape
  *
@@ -73,7 +75,7 @@ var DEFAULT_MIN_WIDTH = 10;
  * @param {Modeling} modeling
  * @param {Dragging} dragging
  */
-export default function Resize(eventBus, rules, modeling, dragging) {
+export function Resize(eventBus, rules, modeling, dragging) {
 
   this._dragging = dragging;
   this._rules = rules;

--- a/lib/features/resize/ResizeHandles.js
+++ b/lib/features/resize/ResizeHandles.js
@@ -27,6 +27,8 @@ import { getReferencePoint } from './Resize';
 
 import { isConnection } from '../../util/ModelUtil';
 
+export default ResizeHandles;
+
 /**
  * @typedef {import('../../model/Types').Element} Element
  *
@@ -53,7 +55,7 @@ var directions = [ 'n', 'w', 's', 'e', 'nw', 'ne', 'se', 'sw' ];
  * @param {Selection} selection
  * @param {Resize} resize
  */
-export default function ResizeHandles(eventBus, canvas, selection, resize) {
+export function ResizeHandles(eventBus, canvas, selection, resize) {
 
   this._resize = resize;
   this._canvas = canvas;

--- a/lib/features/resize/ResizePreview.js
+++ b/lib/features/resize/ResizePreview.js
@@ -9,6 +9,8 @@ import {
   classes as svgClasses
 } from 'tiny-svg';
 
+export default ResizePreview;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/EventBus').default} EventBus
@@ -22,7 +24,7 @@ import {
  * @param {Canvas} canvas
  * @param {PreviewSupport} previewSupport
  */
-export default function ResizePreview(eventBus, canvas, previewSupport) {
+export function ResizePreview(eventBus, canvas, previewSupport) {
 
   /**
    * Update resizer frame.

--- a/lib/features/root-elements/RootElementsBehavior.js
+++ b/lib/features/root-elements/RootElementsBehavior.js
@@ -2,6 +2,8 @@ import inherits from 'inherits-browser';
 
 import CommandInterceptor from '../../command/CommandInterceptor';
 
+export default RootElementsBehavior;
+
 /**
  * @typedef {import('didi').Injector} Injector
  *
@@ -15,7 +17,7 @@ import CommandInterceptor from '../../command/CommandInterceptor';
  * @param {Canvas} canvas
  * @param {Injector} injector
  */
-export default function RootElementsBehavior(canvas, injector) {
+export function RootElementsBehavior(canvas, injector) {
 
   injector.invoke(CommandInterceptor, this);
 

--- a/lib/features/rules/RuleProvider.js
+++ b/lib/features/rules/RuleProvider.js
@@ -2,6 +2,8 @@ import inherits from 'inherits-browser';
 
 import CommandInterceptor from '../../command/CommandInterceptor';
 
+export default RuleProvider;
+
 /**
  * @typedef {import('../../core/EventBus').default} EventBus
  */
@@ -16,7 +18,7 @@ import CommandInterceptor from '../../command/CommandInterceptor';
  *
  * @param {EventBus} eventBus
  */
-export default function RuleProvider(eventBus) {
+export function RuleProvider(eventBus) {
   CommandInterceptor.call(this, eventBus);
 
   this.init();

--- a/lib/features/rules/Rules.js
+++ b/lib/features/rules/Rules.js
@@ -1,3 +1,5 @@
+export default Rules;
+
 /**
  * @typedef {import('didi').Injector} Injector
  */
@@ -16,7 +18,7 @@
  *
  * @param {Injector} injector
  */
-export default function Rules(injector) {
+export function Rules(injector) {
   this._commandStack = injector.get('commandStack', false);
 }
 

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -18,6 +18,8 @@ import {
 
 import { isKey } from '../keyboard/KeyboardUtil';
 
+export default SearchPad;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/EventBus').default} EventBus
@@ -41,7 +43,7 @@ import { isKey } from '../keyboard/KeyboardUtil';
  * @param {Overlays} overlays
  * @param {Selection} selection
  */
-export default function SearchPad(canvas, eventBus, overlays, selection) {
+export function SearchPad(canvas, eventBus, overlays, selection) {
   this._open = false;
   this._results = [];
   this._eventMaps = [];

--- a/lib/features/selection/Selection.js
+++ b/lib/features/selection/Selection.js
@@ -3,6 +3,8 @@ import {
   forEach
 } from 'min-dash';
 
+export default Selection;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/EventBus').default} EventBus
@@ -15,7 +17,7 @@ import {
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
  */
-export default function Selection(eventBus, canvas) {
+export function Selection(eventBus, canvas) {
 
   this._eventBus = eventBus;
   this._canvas = canvas;

--- a/lib/features/selection/SelectionBehavior.js
+++ b/lib/features/selection/SelectionBehavior.js
@@ -8,6 +8,8 @@ import {
   isArray
 } from 'min-dash';
 
+export default SelectionBehavior;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/ElementRegistry').default} ElementRegistry
@@ -21,7 +23,7 @@ import {
  * @param {Canvas} canvas
  * @param {ElementRegistry} elementRegistry
  */
-export default function SelectionBehavior(eventBus, selection, canvas, elementRegistry) {
+export function SelectionBehavior(eventBus, selection, canvas, elementRegistry) {
 
   // Select elements on create
   eventBus.on('create.end', 500, function(event) {

--- a/lib/features/selection/SelectionVisuals.js
+++ b/lib/features/selection/SelectionVisuals.js
@@ -13,6 +13,8 @@ import {
 
 import { getBBox } from '../../util/Elements';
 
+export default SelectionVisuals;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/EventBus').default} EventBus
@@ -37,7 +39,7 @@ var SELECTION_OUTLINE_PADDING = 6;
  * @param {EventBus} eventBus
  * @param {Selection} selection
  */
-export default function SelectionVisuals(canvas, eventBus, selection) {
+export function SelectionVisuals(canvas, eventBus, selection) {
   this._canvas = canvas;
 
   var self = this;

--- a/lib/features/snapping/CreateMoveSnapping.js
+++ b/lib/features/snapping/CreateMoveSnapping.js
@@ -18,6 +18,8 @@ import {
   isLabel
 } from '../../util/ModelUtil';
 
+export default CreateMoveSnapping;
+
 /**
  * @typedef {import('../../core/ElementRegistry').default} ElementRegistry
  * @typedef {import('../../core/EventBus').default} EventBus
@@ -34,7 +36,7 @@ var HIGHER_PRIORITY = 1250;
  * @param {EventBus} eventBus
  * @param {Snapping} snapping
  */
-export default function CreateMoveSnapping(elementRegistry, eventBus, snapping) {
+export function CreateMoveSnapping(elementRegistry, eventBus, snapping) {
   var self = this;
 
   this._elementRegistry = elementRegistry;

--- a/lib/features/snapping/ResizeSnapping.js
+++ b/lib/features/snapping/ResizeSnapping.js
@@ -22,6 +22,8 @@ import {
   isLabel
 } from '../../util/ModelUtil';
 
+export default ResizeSnapping;
+
 /**
  * @typedef {import('../../core/EventBus').default} EventBus
  * @typedef {import('./Snapping').default} Snapping
@@ -36,7 +38,7 @@ var HIGHER_PRIORITY = 1250;
  * @param {EventBus} eventBus
  * @param {Snapping} snapping
  */
-export default function ResizeSnapping(eventBus, snapping) {
+export function ResizeSnapping(eventBus, snapping) {
   var self = this;
 
   eventBus.on([ 'resize.start' ], function(event) {

--- a/lib/features/snapping/SnapContext.js
+++ b/lib/features/snapping/SnapContext.js
@@ -6,6 +6,8 @@ import {
   snapTo
 } from './SnapUtil';
 
+export default SnapContext;
+
 /**
  * @typedef {import('../../model/Types').Element} Element
  *
@@ -21,7 +23,7 @@ import {
  * mappings of drop targets (to identify the snapping)
  * to computed snap points.
  */
-export default function SnapContext() {
+export function SnapContext() {
 
   /**
    * @type {Record<string, SnapPoints>}

--- a/lib/features/snapping/Snapping.js
+++ b/lib/features/snapping/Snapping.js
@@ -18,6 +18,8 @@ import {
   create as svgCreate
 } from 'tiny-svg';
 
+export default Snapping;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  *
@@ -36,7 +38,7 @@ export var SNAP_LINE_HIDE_DELAY = 1000;
  *
  * @param {Canvas} canvas
  */
-export default function Snapping(canvas) {
+export function Snapping(canvas) {
   this._canvas = canvas;
 
   // delay hide by 1000 seconds since last snap

--- a/lib/features/space-tool/SpaceTool.js
+++ b/lib/features/space-tool/SpaceTool.js
@@ -28,6 +28,8 @@ import {
   isLabel
 } from '../../util/ModelUtil';
 
+export default SpaceTool;
+
 /**
  * @typedef {import('../../core/Types').ShapeLike} Shape
  *
@@ -84,7 +86,7 @@ var PADDING = 20;
  * @param {ToolManager} toolManager
  * @param {Mouse} mouse
  */
-export default function SpaceTool(
+export function SpaceTool(
     canvas, dragging, eventBus,
     modeling, rules, toolManager,
     mouse) {

--- a/lib/features/space-tool/SpaceToolPreview.js
+++ b/lib/features/space-tool/SpaceToolPreview.js
@@ -21,6 +21,8 @@ import {
 
 import { isConnection } from '../../util/ModelUtil';
 
+export default SpaceToolPreview;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/ElementRegistry').default} ElementRegistry
@@ -39,7 +41,7 @@ var max = Math.max;
  * @param {Canvas} canvas
  * @param {Styles} styles
  */
-export default function SpaceToolPreview(
+export function SpaceToolPreview(
     eventBus, elementRegistry, canvas,
     styles, previewSupport) {
 

--- a/lib/features/tool-manager/ToolManager.js
+++ b/lib/features/tool-manager/ToolManager.js
@@ -6,6 +6,8 @@ import {
   closest as domClosest
 } from 'min-dom';
 
+export default ToolManager;
+
 /**
  * @typedef {import('../dragging/Dragging').default} Dragging
  * @typedef {import('../../core/EventBus').default} EventBus
@@ -22,7 +24,7 @@ var LOW_PRIORITY = 250;
  * @param {EventBus} eventBus
  * @param {Dragging} dragging
  */
-export default function ToolManager(eventBus, dragging) {
+export function ToolManager(eventBus, dragging) {
   this._eventBus = eventBus;
   this._dragging = dragging;
 

--- a/lib/features/tooltips/Tooltips.js
+++ b/lib/features/tooltips/Tooltips.js
@@ -15,6 +15,8 @@ import {
 
 import Ids from '../../util/IdGenerator';
 
+export default Tooltips;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/EventBus').default} EventBus
@@ -103,7 +105,7 @@ var tooltipClass = 'djs-tooltip',
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
  */
-export default function Tooltips(eventBus, canvas) {
+export function Tooltips(eventBus, canvas) {
 
   this._eventBus = eventBus;
   this._canvas = canvas;

--- a/lib/i18n/I18N.js
+++ b/lib/i18n/I18N.js
@@ -1,3 +1,5 @@
+export default I18N;
+
 /**
  * @typedef {import('../core/EventBus').default} EventBus
  */
@@ -7,7 +9,7 @@
  *
  * @param {EventBus} eventBus
  */
-export default function I18N(eventBus) {
+export function I18N(eventBus) {
 
   /**
    * Inform components that the language changed.

--- a/lib/i18n/translate/translate.js
+++ b/lib/i18n/translate/translate.js
@@ -1,3 +1,5 @@
+export default translate;
+
 /**
  * @typedef { {
  *   [key: string]: string;
@@ -24,7 +26,7 @@
  *
  * @return {string} the translated string
  */
-export default function translate(template, replacements) {
+export function translate(template, replacements) {
 
   replacements = replacements || {};
 

--- a/lib/layout/BaseLayouter.js
+++ b/lib/layout/BaseLayouter.js
@@ -1,3 +1,5 @@
+export default BaseLayouter;
+
 /**
  * @typedef {import('../core/Types').ElementLike} Element
  * @typedef {import('../core/Types').ConnectionLike} Connection
@@ -22,7 +24,7 @@ import {
  * that layouts the connection by directly connecting
  * mid(source) + mid(target).
  */
-export default function BaseLayouter() {}
+export function BaseLayouter() {}
 
 
 /**

--- a/lib/layout/ConnectionDocking.js
+++ b/lib/layout/ConnectionDocking.js
@@ -1,3 +1,5 @@
+export default ConnectionDocking;
+
 /**
  * @typedef {import('../../core/Types').ElementLike} Element
  * @typedef {import('../../core/Types').ConnectionLike} Connection
@@ -19,7 +21,7 @@
  * @class
  * @constructor
  */
-export default function ConnectionDocking() {}
+export function ConnectionDocking() {}
 
 
 /**

--- a/lib/layout/CroppingConnectionDocking.js
+++ b/lib/layout/CroppingConnectionDocking.js
@@ -6,6 +6,8 @@ import {
   getElementLineIntersection
 } from './LayoutUtil';
 
+export default CroppingConnectionDocking;
+
 /**
  * @typedef {import('../core/ElementRegistry').default} ElementRegistry
  * @typedef {import('../core/GraphicsFactory').default} GraphicsFactory
@@ -26,7 +28,7 @@ function dockingToPoint(docking) {
  * @param {ElementRegistry} elementRegistry
  * @param {GraphicsFactory} graphicsFactory
  */
-export default function CroppingConnectionDocking(elementRegistry, graphicsFactory) {
+export function CroppingConnectionDocking(elementRegistry, graphicsFactory) {
   this._elementRegistry = elementRegistry;
   this._graphicsFactory = graphicsFactory;
 }

--- a/lib/navigation/keyboard-move/KeyboardMove.js
+++ b/lib/navigation/keyboard-move/KeyboardMove.js
@@ -1,5 +1,7 @@
 import { assign } from 'min-dash';
 
+export default KeyboardMove;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../features/keyboard/Keyboard').default} Keyboard
@@ -20,7 +22,7 @@ var DEFAULT_CONFIG = {
  * @param {Keyboard} keyboard
  * @param {Canvas} canvas
  */
-export default function KeyboardMove(
+export function KeyboardMove(
     config,
     keyboard,
     canvas

--- a/lib/navigation/movecanvas/MoveCanvas.js
+++ b/lib/navigation/movecanvas/MoveCanvas.js
@@ -20,6 +20,8 @@ import {
   toPoint
 } from '../../util/Event';
 
+export default MoveCanvas;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/EventBus').default} EventBus
@@ -34,7 +36,7 @@ var THRESHOLD = 15;
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
  */
-export default function MoveCanvas(eventBus, canvas) {
+export function MoveCanvas(eventBus, canvas) {
 
   var context;
 

--- a/lib/navigation/zoomscroll/ZoomScroll.js
+++ b/lib/navigation/zoomscroll/ZoomScroll.js
@@ -20,6 +20,8 @@ import {
   bind
 } from 'min-dash';
 
+export default ZoomScroll;
+
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/EventBus').default} EventBus
@@ -51,7 +53,7 @@ var DEFAULT_SCALE = 0.75;
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
  */
-export default function ZoomScroll(config, eventBus, canvas) {
+export function ZoomScroll(config, eventBus, canvas) {
 
   config = config || {};
 

--- a/lib/util/IdGenerator.js
+++ b/lib/util/IdGenerator.js
@@ -1,3 +1,5 @@
+export default IdGenerator;
+
 /**
  * Util that provides unique IDs.
  *
@@ -8,7 +10,7 @@
  *
  * @param {string} [prefix] a prefix to prepend to generated ids (for better readability)
  */
-export default function IdGenerator(prefix) {
+export function IdGenerator(prefix) {
 
   this._counter = 0;
   this._prefix = (prefix ? prefix + '-' : '') + Math.floor(Math.random() * 1000000000) + '-';

--- a/lib/util/Text.js
+++ b/lib/util/Text.js
@@ -17,6 +17,8 @@ import {
 } from 'min-dom';
 
 
+export default Text;
+
 /**
  * @typedef {import('../util/Types').Dimensions} Dimensions
  *
@@ -297,7 +299,7 @@ function getHelperSvg() {
  *
  * @param {TextConfig} config
  */
-export default function Text(config) {
+export function Text(config) {
 
   this._config = assign({}, {
     size: DEFAULT_LABEL_SIZE,


### PR DESCRIPTION
## The issue

Currently all classes (I know they are not technically ES6 classes, but I'm sure you know what I mean) are the default export of the package, which is fine, but since the declaration reads `export default function ClassName(){}`, when the typings are generated and documentation from those typings, all the class names become named `default`. See this from https://joe.skeen.rocks/diagram-js/classes/core_ElementFactory.default.html:

![image](https://github.com/bpmn-io/diagram-js/assets/12286274/0a7b3a4a-c582-4360-a28f-e395f62c3fcd)

This leads to a potentially confusing experience for those consuming typings or docs from the library.

## Proposed solution

This PR exports each class as its own export, but also sets the default export to that class. The only change should be an additional export with the name of the class attached. This enables documentation to work better, as the names will exist in the docs, as well as links between referenced types.

![image](https://github.com/bpmn-io/diagram-js/assets/12286274/e8b3d1e2-ecb9-41c6-a24b-8d6f712a0ef1)

## How the code changes were made

In VSCode, I did a RegEx global search in `lib/**/*.js` for:

```
(\/\*\*\n(.*?\n)+? \*\/)\nexport default function ([^\(]+)\(
```

and replaced it with:

```
export default $3;\n\n$1\nexport function $3(
```

Related to #78 
Related to https://github.com/bpmn-io/diagram-js/pull/857