### PR TITLE
docs: Update Canvas.js

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -1318,7 +1318,9 @@ Canvas.prototype.scrollToElement = function(element, padding) {
  *
  * @param {number|'fit-viewport'} [newScale] The new zoom level, either a number,
  * i.e. 0.9, or `fit-viewport` to adjust the size to fit the current viewport.
- * @param {Point} [center] The reference point { x: ..., y: ...} to zoom to.
+ * @param {Point|true} [center] The reference point { x: ..., y: ...} to zoom to, 
+ * or `true` to automatically center when passing 'fit-viewport' as the first 
+ * parameter.
  *
  * @return {number} The set zoom level.
  */


### PR DESCRIPTION
I was trying to use `canvas.zoom('fit-viewport')` but wanted it centered. Looking at the code, it appears that the second parameter can be `true` in this case to have it automatically center (rather than providing a point). Updating the documentation to reflect this.

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
