### PR TITLE
chore: document some arguments as optional

### DIFF
--- a/lib/features/auto-place/AutoPlace.js
+++ b/lib/features/auto-place/AutoPlace.js
@@ -44,6 +44,7 @@ export default function AutoPlace(eventBus, modeling, canvas) {
    *
    * @param {Shape} source
    * @param {Shape} shape
+   * @param {any} [hints={}]
    *
    * @return {Shape} appended shape
    */

--- a/lib/features/create/Create.js
+++ b/lib/features/create/Create.js
@@ -270,6 +270,11 @@ export default function Create(
 
   // API //////////
 
+  /**
+   * @param event
+   * @param elements
+   * @param {any} [context={}]
+   */
   this.start = function(event, elements, context) {
     if (!isArray(elements)) {
       elements = [ elements ];

--- a/lib/navigation/zoomscroll/ZoomScroll.js
+++ b/lib/navigation/zoomscroll/ZoomScroll.js
@@ -179,7 +179,7 @@ ZoomScroll.prototype._handleWheel = function handleWheel(event) {
  * Zoom with fixed step size.
  *
  * @param {number} delta Zoom delta (1 for zooming in, -1 for zooming out).
- * @param {Point} position
+ * @param {Point} [position]
  */
 ZoomScroll.prototype.stepZoom = function stepZoom(delta, position) {
 
@@ -193,7 +193,7 @@ ZoomScroll.prototype.stepZoom = function stepZoom(delta, position) {
  * Zoom in/out given a step size.
  *
  * @param {number} delta
- * @param {Point} position
+ * @param {Point} [position]
  * @param {number} stepSize
  */
 ZoomScroll.prototype._zoom = function(delta, position, stepSize) {

--- a/lib/util/Text.js
+++ b/lib/util/Text.js
@@ -295,7 +295,7 @@ function getHelperSvg() {
 /**
  * Creates a new label utility
  *
- * @param {TextConfig} config
+ * @param {TextConfig} [config]
  */
 export default function Text(config) {
 


### PR DESCRIPTION
Hi,

we're in the process of upgrading from our own typedefs to the official diagram-js ones and found some cases where arguments are theoretically optional but documented as required in the jsdoc.

This PR adjusts the cases we noticed our build complaining.
The changes are usually where the argument is consumed with a fallback value in the javascript code, e.g. `argument || {}`.

If you expect these arguments not to be optional in the generated types, I can also close the PR.

Thanks
