### PR TITLE
A11y popup menu

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -689,13 +689,6 @@ marker.djs-dragger tspan {
   display: flex;
 }
 
-.entry-content {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  overflow: hidden;
-}
-
 .djs-popup-body {
   flex-direction: column;
   width: auto;

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -674,6 +674,11 @@ marker.djs-dragger tspan {
   line-height: 1.4em;
 }
 
+.djs-popup .entry,
+.djs-popup .entry-header {
+  margin: 1px;
+}
+
 .djs-popup-title,
 .djs-popup-label,
 .djs-popup-entry-description,

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -565,6 +565,12 @@ marker.djs-dragger tspan {
   border-radius: 2px;
 }
 
+.djs-popup button.entry {
+  padding: 0;
+  background: transparent;
+  border: 0;
+}
+
 .djs-popup-header .entry.active {
   color: var(--popup-header-entry-selected-color);
 }

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -55,6 +55,7 @@
   --palette-background-color: var(--color-grey-225-10-97);
   --palette-border-color: var(--color-grey-225-10-75);
 
+  --popup-font-family: "IBM Plex Sans", sans-serif;
   --popup-font-size: 14px;
   --popup-header-entry-selected-color: var(--color-blue-205-100-50);
   --popup-header-font-weight: bolder;
@@ -513,29 +514,20 @@ marker.djs-dragger tspan {
 /**
  * popup styles
  */
-.djs-popup-backdrop {
-  position: fixed;
-  width: 100vw;
-  height: 100vh;
-  top: 0;
-  left: 0;
-  z-index: 200;
-  line-height: 1;
-  font-family: "IBM Plex Sans", sans-serif;
-}
-
 .djs-popup {
+  line-height: 1;
   box-sizing: border-box;
   width: min-content;
   background: var(--popup-background-color);
   overflow: hidden;
-  position: absolute;
+  position: fixed;
 
   box-shadow: 0px 2px 6px var(--popup-shadow-color);
   border: solid 1px var(--popup-border-color);
   min-width: 120px;
   outline: none;
   font-size: var(--popup-font-size);
+  font-family: var(--popup-font-family);
 }
 
 .djs-popup-search input {

--- a/lib/features/keyboard/Keyboard.js
+++ b/lib/features/keyboard/Keyboard.js
@@ -120,7 +120,11 @@ Keyboard.prototype._isEventIgnored = function(event) {
     return true;
   }
 
-  return isInput(event.target) && this._isModifiedKeyIgnored(event);
+  return (
+    isInput(event.target) || (
+      isButton(event.target) && isKey([ ' ', 'Enter' ], event)
+    )
+  ) && this._isModifiedKeyIgnored(event);
 };
 
 Keyboard.prototype._isModifiedKeyIgnored = function(event) {
@@ -229,4 +233,8 @@ Keyboard.prototype.isKey = isKey;
 
 function isInput(target) {
   return target && (domMatches(target, 'input, textarea') || target.contentEditable === 'true');
+}
+
+function isButton(target) {
+  return target && domMatches(target, 'button, input[type=submit], input[type=button], a[href], [aria-role=button]');
 }

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -65,8 +65,6 @@ export default function PopupMenuComponent(props) {
     return originalEntries.length > 5;
   }, [ search, originalEntries ]);
 
-  const inputRef = useRef();
-
   const [ value, setValue ] = useState('');
 
   const filterEntries = useCallback((originalEntries, value) => {
@@ -117,28 +115,6 @@ export default function PopupMenuComponent(props) {
   useEffect(() => {
     updateEntries(filterEntries(originalEntries, value));
   }, [ value, originalEntries ]);
-
-  // register global <Escape> handler
-  useEffect(() => {
-    const handleKeyDown = event => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-
-        return onClose();
-      }
-    };
-
-    document.documentElement.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-      document.documentElement.removeEventListener('keydown', handleKeyDown);
-    };
-  }, []);
-
-  // focus input on initial mount
-  useLayoutEffect(() => {
-    inputRef.current && inputRef.current.focus();
-  }, []);
 
   // handle keyboard seleciton
   const keyboardSelect = useCallback(direction => {
@@ -235,11 +211,7 @@ export default function PopupMenuComponent(props) {
             <svg class="djs-popup-search-icon" width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path fill-rule="evenodd" clip-rule="evenodd" d="M9.0325 8.5H9.625L13.3675 12.25L12.25 13.3675L8.5 9.625V9.0325L8.2975 8.8225C7.4425 9.5575 6.3325 10 5.125 10C2.4325 10 0.25 7.8175 0.25 5.125C0.25 2.4325 2.4325 0.25 5.125 0.25C7.8175 0.25 10 2.4325 10 5.125C10 6.3325 9.5575 7.4425 8.8225 8.2975L9.0325 8.5ZM1.75 5.125C1.75 6.9925 3.2575 8.5 5.125 8.5C6.9925 8.5 8.5 6.9925 8.5 5.125C8.5 3.2575 6.9925 1.75 5.125 1.75C3.2575 1.75 1.75 3.2575 1.75 5.125Z" fill="#22242A"/>
             </svg>
-            <input
-                ref=${ inputRef }
-                type="text"
-                aria-label="${ title }"
-              />
+            <input type="text" aria-label="${ title }" />
           </div>
           ` }
 
@@ -275,17 +247,7 @@ function PopupMenuWrapper(props) {
 
   const popupRef = useRef();
 
-  const checkClose = useCallback((event) => {
-
-    const popup = domClosest(event.target, '.djs-popup', true);
-
-    if (popup) {
-      return;
-    }
-
-    onClose();
-  }, [ onClose ]);
-
+  // initial position
   useLayoutEffect(() => {
     if (typeof positionGetter !== 'function') {
       return;
@@ -298,26 +260,58 @@ function PopupMenuWrapper(props) {
     popupEl.style.top = `${position.y}px`;
   }, [ popupRef.current, positionGetter ]);
 
-  // focus popup initially, on mount
+  // initial focus
   useLayoutEffect(() => {
-    popupRef.current && popupRef.current.focus();
+    const popupEl = popupRef.current;
+
+    if (!popupEl) {
+      return;
+    }
+
+    const inputEl = popupEl.querySelector('input');
+
+    (inputEl || popupEl).focus();
+  }, []);
+
+  // global <Escape> / blur handlers
+  useEffect(() => {
+    const handleKeyDown = event => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+
+        return onClose();
+      }
+    };
+
+    const handleClick = event => {
+      const popup = domClosest(event.target, '.djs-popup', true);
+
+      if (popup) {
+        return;
+      }
+
+      return onClose();
+    };
+
+    document.documentElement.addEventListener('keydown', handleKeyDown);
+    document.body.addEventListener('click', handleClick);
+
+    return () => {
+      document.documentElement.removeEventListener('keydown', handleKeyDown);
+      document.body.removeEventListener('click', handleClick);
+    };
   }, []);
 
   return html`
     <div
-      class="djs-popup-backdrop"
-      onClick=${ checkClose }
+      class=${ classNames('djs-popup', className) }
+      style=${ getPopupStyle(props) }
+      onKeydown=${ onKeydown }
+      onKeyup=${ onKeyup }
+      ref=${ popupRef }
+      tabIndex="-1"
     >
-      <div
-        class=${ classNames('djs-popup', className) }
-        style=${ getPopupStyle(props) }
-        onKeydown=${ onKeydown }
-        onKeyup=${ onKeyup }
-        ref=${ popupRef }
-        tabIndex="-1"
-      >
-        ${ children }
-      </div>
+      ${ children }
     </div>
   `;
 }

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -138,15 +138,15 @@ export default function PopupMenuComponent(props) {
       return onSelect(event, selectedEntry);
     }
 
-    // ARROW_UP or SHIFT + TAB navigation
-    if (event.key === 'ArrowUp' || (event.key === 'Tab' && event.shiftKey)) {
+    // ARROW_UP
+    if (event.key === 'ArrowUp') {
       keyboardSelect(-1);
 
       return event.preventDefault();
     }
 
-    // ARROW_DOWN or TAB navigation
-    if (event.key === 'ArrowDown' || event.key === 'Tab') {
+    // ARROW_DOWN
+    if (event.key === 'ArrowDown') {
       keyboardSelect(1);
 
       return event.preventDefault();

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -183,15 +183,15 @@ export default function PopupMenuComponent(props) {
         <div class="djs-popup-header">
           <h3 class="djs-popup-title" title=${ title }>${ title }</h3>
           ${ headerEntries.map(entry => html`
-            <span
+            <${ entry.action ? 'button' : 'span' }
               class=${ getHeaderClasses(entry, entry === selectedEntry) }
               onClick=${ event => onSelect(event, entry) }
               title=${ entry.title || entry.label }
               data-id=${ entry.id }
               onMouseEnter=${ () => setSelectedEntry(entry) }
               onMouseLeave=${ () => setSelectedEntry(null) }
-              aria-role="button"
-              tabIndex="0"
+              onFocus=${ () => setSelectedEntry(entry) }
+              onBlur=${ () => setSelectedEntry(null) }
             >
             ${(entry.imageUrl && html`<img class="djs-popup-entry-icon" src=${ entry.imageUrl } alt="" />`) ||
             (entry.imageHtml && html`<div class="djs-popup-entry-icon" dangerouslySetInnerHTML=${ { __html: entry.imageHtml } } />`)}
@@ -199,7 +199,7 @@ export default function PopupMenuComponent(props) {
               ${ entry.label ? html`
                 <span class="djs-popup-label">${ entry.label }</span>
               ` : null }
-            </span>
+            </${ entry.action ? 'button' : 'span' }>
           `) }
         </div>
       ` }

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -151,7 +151,7 @@ export default function PopupMenuComponent(props) {
 
       return event.preventDefault();
     }
-  }, [ onSelect, onClose, selectedEntry, keyboardSelect ]);
+  }, [ onSelect, selectedEntry, keyboardSelect ]);
 
   const handleKey = useCallback(event => {
     if (domMatches(event.target, 'input')) {

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -214,6 +214,8 @@ export default function PopupMenuComponent(props) {
               data-id=${ entry.id }
               onMouseEnter=${ () => setSelectedEntry(entry) }
               onMouseLeave=${ () => setSelectedEntry(null) }
+              aria-role="button"
+              tabIndex="0"
             >
             ${(entry.imageUrl && html`<img class="djs-popup-entry-icon" src=${ entry.imageUrl } alt="" />`) ||
             (entry.imageHtml && html`<div class="djs-popup-entry-icon" dangerouslySetInnerHTML=${ { __html: entry.imageHtml } } />`)}

--- a/lib/features/popup-menu/PopupMenuItem.js
+++ b/lib/features/popup-menu/PopupMenuItem.js
@@ -33,10 +33,14 @@ export default function PopupMenuItem(props) {
       class=${ classNames('entry', { selected }) }
       data-id=${ entry.id }
       title=${ entry.title || entry.label }
+      tabIndex="0"
       onClick=${ onAction }
+      onFocus=${ onMouseEnter }
+      onBlur=${ onMouseLeave }
       onMouseEnter=${ onMouseEnter }
       onMouseLeave=${ onMouseLeave }
       onDragStart=${ (event) => onAction(event, entry, 'dragstart') }
+      aria-role="button"
       draggable=${ true }
     >
       <div class="djs-popup-entry-content">

--- a/test/spec/features/keyboard/KeyboardSpec.js
+++ b/test/spec/features/keyboard/KeyboardSpec.js
@@ -180,6 +180,46 @@ describe('features/keyboard', function() {
     });
 
 
+    describe('should ignore ENTER and SPACE on button like elements', function() {
+
+      const SPACE_KEY = ' ';
+      const ENTER_KEY = 'Enter';
+
+      const testScenarios = {
+        'input[type=button]': () => domify('<input type="button" value="BUTTON" />'),
+        'input[type=submit]': () => domify('<input type="submit" value="BUTTON" />'),
+        'button': () => domify('<button>BUTTON</button>'),
+        'a[href]': () => domify('<a href="#">LINK</a>'),
+        '[aria-role=button]': () => domify('<span aria-role="button">FAKE Button</span>')
+      };
+
+      for (const [ name, createElement ] of Object.entries(testScenarios)) {
+
+        it(name, inject(
+          function(keyboard, eventBus) {
+
+            // given
+            var eventBusSpy = sinon.spy(eventBus, 'fire');
+
+            var buttonEl = createElement();
+            testDiv.appendChild(buttonEl);
+
+            // when
+            keyboard._keyHandler({ key: SPACE_KEY, target: buttonEl });
+            keyboard._keyHandler({ key: SPACE_KEY, shiftKey: true, target: buttonEl });
+
+            keyboard._keyHandler({ key: ENTER_KEY, target: buttonEl });
+            keyboard._keyHandler({ key: ENTER_KEY, shiftKey: true, target: buttonEl });
+
+            // then
+            expect(eventBusSpy).to.not.be.called;
+          })
+        );
+      }
+
+    });
+
+
     it('should ignore propagation stopped events', inject(
       function(keyboard, eventBus) {
 

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -185,7 +185,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
 
       await createPopupMenu({ container, onClose });
 
-      container.children[0].click();
+      document.body.click();
 
       expect(onClose).to.have.been.calledOnce;
     });

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -272,7 +272,6 @@ describe('features/popup-menu', function() {
 
       // then
       expect(domClasses(container).has('djs-popup-parent')).to.be.true;
-      expect(queryPopupAll('.djs-popup-backdrop')).to.have.length(1);
       expect(queryPopupAll('.djs-popup')).to.have.length(1);
 
       expect(domClasses(queryPopup('.djs-popup')).has('menu')).to.be.true;
@@ -1670,9 +1669,7 @@ describe('features/popup-menu', function() {
         expect(queryPopup('.popup-menu1')).to.be.null;
         expect(queryPopup('.popup-menu2')).not.to.be.null;
 
-        var popupBackdropEl = container.childNodes[0];
-
-        var popupEl = popupBackdropEl.childNodes[0];
+        var popupEl = container.childNodes[0];
         expect(popupEl.style.left).to.eql('200px');
         expect(popupEl.style.top).to.eql('200px');
         expect(domClasses(popupEl).has('popup-menu2')).to.be.true;


### PR DESCRIPTION
#### Firefox

![capture 5fPyRh_optimized](https://github.com/bpmn-io/diagram-js/assets/58601/b2b04758-5778-4d83-a7b6-0e09bdce583e)

#### Chrome

![capture 5w5PjG_optimized](https://github.com/bpmn-io/diagram-js/assets/58601/eed7419c-6ea5-49aa-907d-15075acf67e8)

---

This PR improves the accessibility of the popup menu:

* Ensures all items are keyboard accessible
* Ensures that existing TAB and arrow key navigation continues to work
* Ensures that `SPACE` and `ENTER` can be used as expected to toggle features
* Ensure that outside click is no longer trapped
* Use browser native outline for keyboard focus state

---

Additional notes:

* I decided that tabbing through the whole component (all entries) shall be possible
* I decided against making this a partial select/fake drop down from aria perspective, as it does not work in scenarios without search

----

Can be tried out using the following command on your local machine:

```
npx @bpmn-io/sr bpmn-io/bpmn-js -l bpmn-io/diagram-js#a11y-popup-menu
```


----


Closes #871 