### PR TITLE
chore: add some additional type corrections

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -75,6 +75,7 @@ import { createMatrix as createMatrix } from 'tiny-svg';
  * @typedef {import('../util/Types').Point} Point
  * @typedef {import('../util/Types').Rect} Rect
  * @typedef {import('../util/Types').RectTRBL} RectTRBL
+ * @typedef {import('../util/Types').ScrollDelta} ScrollDelta
  */
 
 function round(number, resolution) {
@@ -775,7 +776,7 @@ Canvas.prototype.removeRootElement = function(rootElement) {
 Canvas.prototype.setRootElement = function(rootElement) {
 
   if (rootElement === this._rootElement) {
-    return;
+    return rootElement;
   }
 
   let plane;
@@ -1210,7 +1211,7 @@ Canvas.prototype.viewbox = function(box) {
 /**
  * Gets or sets the scroll of the canvas.
  *
- * @param {Point} [delta] The scroll to be set.
+ * @param {ScrollDelta} [delta] The scroll to be set.
  *
  * @return {Point}
  */

--- a/lib/core/Canvas.spec.ts
+++ b/lib/core/Canvas.spec.ts
@@ -158,7 +158,7 @@ canvas.removeConnection(connectionLike);
 
 canvas.resized();
 
-canvas.scroll({ x: 100, y: 100 });
+canvas.scroll({ dx: 100, dy: 100 });
 
 canvas.scrollToElement('shape');
 

--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -518,7 +518,7 @@ ContextPad.prototype.isShown = function() {
  *
  * @param {ContextPadTarget} target
  *
- * @return {Rect}
+ * @return {{ position: { left: number; top: number; }}}
  */
 ContextPad.prototype._getPosition = function(target) {
 

--- a/lib/features/editor-actions/EditorActions.js
+++ b/lib/features/editor-actions/EditorActions.js
@@ -242,9 +242,9 @@ EditorActions.prototype.unregister = function(action) {
 };
 
 /**
- * Returns the number of actions that are currently registered
+ * Returns the identifiers of all currently registered editor actions
  *
- * @return {number}
+ * @return {string[]}
  */
 EditorActions.prototype.getActions = function() {
   return Object.keys(this._actions);

--- a/lib/features/hand-tool/HandTool.js
+++ b/lib/features/hand-tool/HandTool.js
@@ -120,7 +120,12 @@ HandTool.$inject = [
   'mouse'
 ];
 
-
+/**
+ *
+ * @param event
+ * @param {boolean} [autoActivate]
+ * @param {object} [context]
+ */
 HandTool.prototype.activateMove = function(event, autoActivate, context) {
   if (typeof autoActivate === 'object') {
     context = autoActivate;
@@ -136,6 +141,12 @@ HandTool.prototype.activateMove = function(event, autoActivate, context) {
   });
 };
 
+/**
+ *
+ * @param event
+ * @param {boolean} [autoActivate]
+ * @param {boolean} [reactivate]
+ */
 HandTool.prototype.activateHand = function(event, autoActivate, reactivate) {
   this._dragging.init(event, 'hand', {
     trapClick: false,

--- a/lib/features/overlays/Overlays.js
+++ b/lib/features/overlays/Overlays.js
@@ -173,7 +173,7 @@ export default function Overlays(config, eventBus, canvas, elementRegistry) {
   }, config && config.defaults);
 
   /**
-   * @type {Map<string, Overlay>}
+   * @type {Record<string, Overlay>}
    */
   this._overlays = {};
 

--- a/lib/navigation/zoomscroll/ZoomScroll.js
+++ b/lib/navigation/zoomscroll/ZoomScroll.js
@@ -25,6 +25,7 @@ import {
  * @typedef {import('../../core/EventBus').default} EventBus
  *
  * @typedef {import('../../util/Types').Point} Point
+ * @typedef {import('../../util/Types').ScrollDelta} ScrollDelta
  */
 
 var sign = Math.sign || function(n) {
@@ -79,7 +80,7 @@ ZoomScroll.$inject = [
 ];
 
 /**
- * @param {Point} delta
+ * @param {ScrollDelta} delta
  */
 ZoomScroll.prototype.scroll = function scroll(delta) {
   this._canvas.scroll(delta);

--- a/lib/util/Text.js
+++ b/lib/util/Text.js
@@ -30,8 +30,8 @@ import {
  * @typedef { number | Partial<Padding> } PaddingConfig
  *
  * @typedef { {
- *   horizontal: 'center' | 'left';
- *   vertical: 'top' | 'center';
+ *   horizontal: 'center' | 'left' | 'right';
+ *   vertical: 'top' | 'middle';
  * } } Alignment
  *
  *  @typedef { 'center-middle' | 'center-top' } AlignmentConfig

--- a/lib/util/Types.ts
+++ b/lib/util/Types.ts
@@ -3,6 +3,11 @@ export type Point = {
   y: number;
 };
 
+export type ScrollDelta = {
+  dx?: number;
+  dy?: number;
+}
+
 export type Vector = Point;
 
 export type Dimension = 'width' | 'height';

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -598,6 +598,20 @@ describe('Canvas', function() {
     }));
 
 
+    it('should return the current root element when attempting to set it again', inject(function(canvas, elementRegistry) {
+
+      // given
+      var rootElement = canvas.setRootElement({ id: 'XXXX' });
+
+      // when
+      var updatedRootElement = canvas.setRootElement(rootElement);
+
+      // then
+      // is the current root element returned from setter?
+      expect(updatedRootElement).to.equal(rootElement);
+    }));
+
+
     it('should list root elements', inject(function(canvas, elementRegistry) {
 
       // given


### PR DESCRIPTION
Hi, 

I found some additional type incompatibilities when migrating to the most recent diagram-js version.
Most of them seem to be non issues and just documenting incorrect types. Some of them were found due to intellij complaining that e.g. a switch uses a case which isn't possible according to the types.

I'm unsure if the `Canvas.spec.ts` `canvas.scroll` call previously actually tested something, because the x/y parameters weren't used anywhere in the `canvas.scroll` method.

The `setRootElement` return value is only there because the return type specifies it always returns something but in that case returned `undefined`