### PR TITLE
fix(PopupMenu): show `emptyPlaceholder` when no entries exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+* `FIX`: show empty placeholder in popup menu when no entries were returned ([#876](https://github.com/bpmn-io/diagram-js/pull/876))
+
 ## 14.2.0
 
 * `FEAT`: be able to type diagram services and events ([#862](https://github.com/bpmn-io/diagram-js/pull/862))

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -248,10 +248,10 @@ export default function PopupMenuComponent(props) {
             onAction=${ onSelect }
           />
         </div>
-        ${ emptyPlaceholder && entries.length === 0 && html`
-          <div class="djs-popup-no-results">${ isFunction(emptyPlaceholder) ? emptyPlaceholder(value) : emptyPlaceholder }</div>
-        ` }
       ` }
+    ${ emptyPlaceholder && entries.length === 0 && html`
+      <div class="djs-popup-no-results">${ isFunction(emptyPlaceholder) ? emptyPlaceholder(value) : emptyPlaceholder }</div>
+    ` }
     </${PopupMenuWrapper}>
   `;
 }

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -347,6 +347,20 @@ describe('features/popup-menu - <PopupMenu>', function() {
       expect(onSelectSpy).to.have.been.calledOnce;
     });
 
+
+    it('should show placeholder if no entries', async function() {
+
+      // given
+      await createPopupMenu({
+        container,
+        emptyPlaceholder: 'No Entries'
+      });
+
+      // then
+      expect(domQueryAll('.entry', container)).to.have.length(0);
+      expect(domQuery('.djs-popup-no-results', container)).to.exist;
+    });
+
   });
 
 


### PR DESCRIPTION
This allows us to show empty placeholder when no entries were returned (e.g. still fetching), not just when the search filters out all entries

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
