### PR TITLE
fix(popup-menu): keep given top-left position with scale

### DIFF
--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -321,7 +321,8 @@ function PopupMenuWrapper(props) {
 function getPopupStyle(props) {
   return {
     transform: `scale(${props.scale})`,
-    width: `${props.width}px`
+    width: `${props.width}px`,
+    'transform-origin': 'top left'
   };
 }
 


### PR DESCRIPTION
This ensures the position given to the Popup menu when opening (x, y) are the real coordinates it is displayed at.

Currently, the scale origin is in the center of the container, which creates weird UI when you zoomed in to the canvas:
![image](https://github.com/bpmn-io/diagram-js/assets/21984219/4e69fefb-5593-4e13-a518-5f3ec40555e3)


With the fix, the transform is applied to the corner instead:
![image](https://github.com/bpmn-io/diagram-js/assets/21984219/7e416b66-6a9c-41fe-988e-96bdd69786f5)


<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
