### PR TITLE
feat(context-pad): do not scale by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+* `FEAT`: do not scale context pad and popup menu by default ([#883](https://github.com/bpmn-io/diagram-js/pull/883))
+
 ## 14.3.3
 
 * `FIX`: do not cancel dragging on tool deselection ([#881](https://github.com/bpmn-io/diagram-js/pull/881))

--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -77,7 +77,7 @@ export default function ContextPad(canvas, config, eventBus, overlays) {
 
   var scale = isDefined(config && config.scale) ? config.scale : {
     min: 1,
-    max: 1.5
+    max: 1
   };
 
   this._overlaysConfig = {

--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -68,7 +68,7 @@ export default function PopupMenu(config, eventBus, canvas) {
 
   var scale = isDefined(config && config.scale) ? config.scale : {
     min: 1,
-    max: 1.5
+    max: 1
   };
 
   this._config = {

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -1141,10 +1141,10 @@ describe('features/context-pad', function() {
     }
 
 
-    it('should scale [ 1.0, 1.5 ] by default', function() {
+    it('should not scale by default', function() {
 
       // given
-      var expectedScales = [ 1.0, 1.2, 1.5, 1.5, 1.0 ];
+      var expectedScales = [ 1.0, 1.0, 1.0, 1.0, 1.0 ];
 
       bootstrapDiagram({
         modules: [ contextPadModule, providerModule ]
@@ -1155,10 +1155,10 @@ describe('features/context-pad', function() {
     });
 
 
-    it('should scale [ 1.0, 1.5 ] without scale config', function() {
+    it('should not scale without scale config', function() {
 
       // given
-      var expectedScales = [ 1.0, 1.2, 1.5, 1.5, 1.0 ];
+      var expectedScales = [ 1.0, 1.0, 1.0, 1.0, 1.0 ];
 
       bootstrapDiagram({
         modules: [ contextPadModule, providerModule ],

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -2112,10 +2112,10 @@ describe('features/popup-menu', function() {
     }
 
 
-    it('should scale within [ 1.0, 1.5 ] by default', function() {
+    it('should not scale by default', function() {
 
       // given
-      var expectedScales = [ 1.0, 1.2, 1.5, 1.5, 1.0 ];
+      var expectedScales = [ 1.0, 1.0, 1.0, 1.0, 1.0 ];
 
       bootstrapDiagram({
         modules: [
@@ -2129,10 +2129,10 @@ describe('features/popup-menu', function() {
     });
 
 
-    it('should scale within [ 1.0, 1.5 ] without scale config', function() {
+    it('should not scale without scale config', function() {
 
       // given
-      var expectedScales = [ 1.0, 1.2, 1.5, 1.5, 1.0 ];
+      var expectedScales = [ 1.0, 1.0, 1.0, 1.0, 1.0 ];
 
       bootstrapDiagram({
         modules: [


### PR DESCRIPTION
With this PR, the context pad and popup menu will no longer scale with the canvas zoom. To restore the old behavior, you can add the following to your configuration:
  ```
  {
    popupMenu: {
      scale: {
        min: 1.0,
        max: 1.5
      }
    },
    contextPad: {
      scale: {
        min: 1.0,
        max: 1.5
      }
    }
  }
  ```

closes #879 
