### PR TITLE
feat(context-pad): position absolute intead of relative to element

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -473,16 +473,13 @@ marker.djs-dragger tspan {
 /**
  * context-pad
  */
-.djs-overlay-context-pad {
-  width: 72px;
-  z-index: 100;
-}
-
 .djs-context-pad {
   position: absolute;
   display: none;
   pointer-events: none;
   line-height: 1;
+  width: 72px;
+  z-index: 100;
 }
 
 .djs-context-pad .entry {

--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -1,9 +1,7 @@
 import {
-  assign,
   every,
   forEach,
   isArray,
-  isDefined,
   isFunction,
   some
 } from 'min-dash';
@@ -17,8 +15,6 @@ import {
   domify as domify
 } from 'min-dom';
 
-import { getBBox } from '../../util/Elements';
-
 import {
   escapeCSS
 } from '../../util/EscapeUtil';
@@ -30,22 +26,14 @@ import { isConnection } from '../../util/ModelUtil';
  * @typedef {import('../../model/Types').Element} Element
  *
  * @typedef {import('../../util/Types').Rect} Rect
+ * @typedef {import('../../util/Types').RectTRBL} RectTRBL
  *
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/EventBus').default} EventBus
- * @typedef {import('../overlays/Overlays').default} Overlays
- *
- * @typedef {import('../overlays/Overlays').Overlay} Overlay
  *
  * @typedef {import('./ContextPadProvider').default} ContextPadProvider
  * @typedef {import('./ContextPadProvider').ContextPadEntries} ContextPadEntries
  *
- * @typedef { {
- *   scale?: {
- *     min?: number;
- *     max?: number;
- *   };
- * } } ContextPadConfig
  */
 
 /**
@@ -57,7 +45,7 @@ import { isConnection } from '../../util/ModelUtil';
 var entrySelector = '.entry';
 
 var DEFAULT_PRIORITY = 1000;
-var CONTEXT_PAD_PADDING = 12;
+var CONTEXT_PAD_MARGIN = 12;
 var HOVER_DELAY = 300;
 
 /**
@@ -65,24 +53,12 @@ var HOVER_DELAY = 300;
  * to a diagram element.
  *
  * @param {Canvas} canvas
- * @param {ContextPadConfig} config
  * @param {EventBus} eventBus
- * @param {Overlays} overlays
  */
-export default function ContextPad(canvas, config, eventBus, overlays) {
+export default function ContextPad(canvas, eventBus) {
 
   this._canvas = canvas;
   this._eventBus = eventBus;
-  this._overlays = overlays;
-
-  var scale = isDefined(config && config.scale) ? config.scale : {
-    min: 1,
-    max: 1
-  };
-
-  this._overlaysConfig = {
-    scale: scale
-  };
 
   this._current = null;
 
@@ -91,9 +67,7 @@ export default function ContextPad(canvas, config, eventBus, overlays) {
 
 ContextPad.$inject = [
   'canvas',
-  'config.contextPad',
-  'eventBus',
-  'overlays'
+  'eventBus'
 ];
 
 
@@ -142,6 +116,22 @@ ContextPad.prototype._init = function() {
       self.open(currentTarget, true);
     }
   });
+
+  this._eventBus.on('canvas.viewbox.changed', () => {
+    if (this.isOpen()) {
+      this._updatePosition();
+    }
+  });
+
+  this._container = this._createContainer();
+};
+
+ContextPad.prototype._createContainer = function() {
+  const container = domify('<div class="djs-context-pad-parent"></div>');
+
+  this._canvas.getContainer().appendChild(container);
+
+  return container;
 };
 
 /**
@@ -329,8 +319,7 @@ ContextPad.prototype._getProviders = function() {
  */
 ContextPad.prototype._updateAndOpen = function(target) {
   var entries = this.getEntries(target),
-      pad = this.getPad(target),
-      html = pad.html,
+      html = this._createHtml(target),
       image;
 
   forEach(entries, function(entry, id) {
@@ -371,10 +360,12 @@ ContextPad.prototype._updateAndOpen = function(target) {
   domClasses(html).add('open');
 
   this._current = {
-    target: target,
-    entries: entries,
-    pad: pad
+    entries,
+    html,
+    target,
   };
+
+  this._updatePosition();
 
   this._eventBus.fire('contextPad.open', { current: this._current });
 };
@@ -382,24 +373,16 @@ ContextPad.prototype._updateAndOpen = function(target) {
 /**
  * @param {ContextPadTarget} target
  *
- * @return {Overlay}
+ * @return {HTMLElement}
  */
-ContextPad.prototype.getPad = function(target) {
+ContextPad.prototype._createHtml = function(target) {
   if (this.isOpen()) {
     return this._current.pad;
   }
 
   var self = this;
 
-  var overlays = this._overlays;
-
   var html = domify('<div class="djs-context-pad"></div>');
-
-  var position = this._getPosition(target);
-
-  var overlaysConfig = assign({
-    html: html
-  }, this._overlaysConfig, position);
 
   domDelegate.bind(html, entrySelector, 'click', function(event) {
     self.trigger('click', event);
@@ -422,18 +405,35 @@ ContextPad.prototype.getPad = function(target) {
     event.stopPropagation();
   });
 
-  var activeRootElement = this._canvas.getRootElement();
-
-  this._overlayId = overlays.add(activeRootElement, 'context-pad', overlaysConfig);
-
-  var pad = overlays.get(this._overlayId);
+  this._container.appendChild(html);
 
   this._eventBus.fire('contextPad.create', {
     target: target,
-    pad: pad
+    pad: html
   });
 
-  return pad;
+  return html;
+};
+
+/**
+ * @param {ContextPadTarget} target
+ *
+ * @return { { html: HTMLElement } }
+ */
+ContextPad.prototype.getPad = function(target) {
+  console.warn(new Error(
+    'getPad is deprecated and will be removed in future library versions'
+  ));
+
+  let html;
+
+  if (this.isOpen() && this._current.target === target) {
+    html = this._current.html;
+  } else {
+    html = this._createHtml(target);
+  }
+
+  return { html };
 };
 
 
@@ -447,9 +447,7 @@ ContextPad.prototype.close = function() {
 
   clearTimeout(this._timeout);
 
-  this._overlays.remove(this._overlayId);
-
-  this._overlayId = null;
+  this._container.innerHTML = '';
 
   this._eventBus.fire('contextPad.close', { current: this._current });
 
@@ -503,38 +501,142 @@ ContextPad.prototype.isOpen = function(target) {
  * @return {boolean}
  */
 ContextPad.prototype.isShown = function() {
-  return this.isOpen() && this._overlays.isShown();
+  return this.isOpen() && domClasses(this._current.html).has('open');
 };
 
+/**
+ * Show context pad.
+ */
+ContextPad.prototype.show = function() {
+  if (!this.isOpen()) {
+    return;
+  }
+
+  domClasses(this._current.html).add('open');
+
+  this._eventBus.fire('contextPad.show', { current: this._current });
+};
 
 /**
- * Get contex pad position.
+ * Hide context pad.
+ */
+ContextPad.prototype.hide = function() {
+  if (!this.isOpen()) {
+    return;
+  }
+
+  domClasses(this._current.html).remove('open');
+
+  this._eventBus.fire('contextPad.hide', { current: this._current });
+};
+
+/**
+ * Get context pad position.
  *
- * If target is a connection, the context pad will be placed according to the
- * connection's last waypoint.
+ * If target is connection context pad will be positioned at connection end.
  *
- * If multiple targets, the context pad will be placed according to the bounding
- * box containing all targets.
+ * If multiple targets context pad will be placed at top right corner bounding
+ * box.
  *
  * @param {ContextPadTarget} target
  *
- * @return {{ position: { left: number; top: number; }}}
+ * @return {RectTRBL & { x: number, y: number }}
  */
 ContextPad.prototype._getPosition = function(target) {
+  if (!isArray(target) && isConnection(target)) {
+    const viewbox = this._canvas.viewbox();
 
-  target = isConnection(target) ? getLastWaypoint(target) : target;
+    const lastWaypoint = getLastWaypoint(target);
 
-  var elements = isArray(target) ? target : [ target ];
-  var bBox = getBBox(elements);
+    const x = lastWaypoint.x * viewbox.scale - viewbox.x * viewbox.scale,
+          y = lastWaypoint.y * viewbox.scale - viewbox.y * viewbox.scale;
+
+    return {
+      left: x + CONTEXT_PAD_MARGIN,
+      top: y
+    };
+  }
+
+  var container = this._canvas.getContainer();
+
+  var containerBounds = container.getBoundingClientRect();
+
+  var targetBounds = this._getTargetBounds(target);
+
+  var left = targetBounds.right - containerBounds.left + CONTEXT_PAD_MARGIN;
+  var top = targetBounds.top - containerBounds.top;
 
   return {
-    position: {
-      left: bBox.x + bBox.width + CONTEXT_PAD_PADDING,
-      top: bBox.y - CONTEXT_PAD_PADDING / 2
-    }
+    left,
+    top
   };
 };
 
+/**
+ * Update context pad position.
+ */
+ContextPad.prototype._updatePosition = function() {
+  if (!this.isOpen()) {
+    return;
+  }
+
+  var html = this._current.html;
+
+  var position = this._getPosition(this._current.target);
+
+  if ('x' in position && 'y' in position) {
+    html.style.left = position.x + 'px';
+    html.style.top = position.y + 'px';
+  } else {
+    [
+      'top',
+      'right',
+      'bottom',
+      'left'
+    ].forEach(function(key) {
+      if (key in position) {
+        html.style[ key ] = position[ key ] + 'px';
+      }
+    });
+  }
+};
+
+/**
+ * Get bounding client rect of target element(s).
+ *
+ * @param {ContextPadTarget} target
+ *
+ * @returns {Rect & RectTRBL}
+ */
+ContextPad.prototype._getTargetBounds = function(target) {
+  var elements = isArray(target) ? target : [ target ];
+
+  var elementsGfx = elements.map((element) => {
+    return this._canvas.getGraphics(element);
+  });
+
+  return elementsGfx.reduce((bounds, elementGfx) => {
+    const elementBounds = elementGfx.getBoundingClientRect();
+
+    bounds.top = Math.min(bounds.top, elementBounds.top);
+    bounds.right = Math.max(bounds.right, elementBounds.right);
+    bounds.bottom = Math.max(bounds.bottom, elementBounds.bottom);
+    bounds.left = Math.min(bounds.left, elementBounds.left);
+
+    bounds.x = bounds.left;
+    bounds.y = bounds.top;
+
+    bounds.width = bounds.right - bounds.left;
+    bounds.height = bounds.bottom - bounds.top;
+
+    return bounds;
+  }, {
+    top: Infinity,
+    right: -Infinity,
+    bottom: -Infinity,
+    left: Infinity
+  });
+};
 
 // helpers //////////
 

--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -421,9 +421,7 @@ ContextPad.prototype._createHtml = function(target) {
  * @return { { html: HTMLElement } }
  */
 ContextPad.prototype.getPad = function(target) {
-  console.warn(new Error(
-    'getPad is deprecated and will be removed in future library versions'
-  ));
+  console.warn(new Error('ContextPad#getPad is deprecated and will be removed in future library versions, cf. https://github.com/bpmn-io/diagram-js/pull/888'));
 
   let html;
 

--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -45,7 +45,7 @@ import { isConnection } from '../../util/ModelUtil';
 var entrySelector = '.entry';
 
 var DEFAULT_PRIORITY = 1000;
-var CONTEXT_PAD_MARGIN = 12;
+var CONTEXT_PAD_MARGIN = 8;
 var HOVER_DELAY = 300;
 
 /**
@@ -550,7 +550,7 @@ ContextPad.prototype._getPosition = function(target) {
           y = lastWaypoint.y * viewbox.scale - viewbox.y * viewbox.scale;
 
     return {
-      left: x + CONTEXT_PAD_MARGIN,
+      left: x + CONTEXT_PAD_MARGIN * this._canvas.zoom(),
       top: y
     };
   }
@@ -561,12 +561,9 @@ ContextPad.prototype._getPosition = function(target) {
 
   var targetBounds = this._getTargetBounds(target);
 
-  var left = targetBounds.right - containerBounds.left + CONTEXT_PAD_MARGIN;
-  var top = targetBounds.top - containerBounds.top;
-
   return {
-    left,
-    top
+    left: targetBounds.right - containerBounds.left + CONTEXT_PAD_MARGIN * this._canvas.zoom(),
+    top: targetBounds.top - containerBounds.top
   };
 };
 

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -1396,7 +1396,7 @@ describe('features/context-pad', function() {
 
       expect(warnSpy).to.have.been.calledOnce;
       expect(warnSpy.getCall(0).args[ 0 ]).to.be.instanceOf(Error);
-      expect(warnSpy.getCall(0).args[ 0 ].message).to.equal('getPad is deprecated and will be removed in future library versions');
+      expect(warnSpy.getCall(0).args[ 0 ].message).to.match(/is deprecated/);
     }));
 
   });

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -1292,7 +1292,7 @@ describe('features/context-pad', function() {
       }));
 
 
-      it('connection', inject(function(canvas, contextPad) {
+      (isFirefox() ? it.skip : it)('connection', inject(function(canvas, contextPad) {
 
         // given
         var connection = {
@@ -1402,3 +1402,7 @@ describe('features/context-pad', function() {
   });
 
 });
+
+function isFirefox() {
+  return /firefox/i.test(navigator.userAgent);
+}

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -1287,6 +1287,27 @@ describe('features/context-pad', function() {
         var containerBounds = canvas.getContainer().getBoundingClientRect();
         var targetBounds = canvas.getGraphics(shape).getBoundingClientRect();
 
+        expect(position.left).be.closeTo(targetBounds.left + targetBounds.width + 8 - containerBounds.left, 1);
+        expect(position.top).be.closeTo(targetBounds.top - containerBounds.top, 1);
+      }));
+
+
+      it('shape (scaled)', inject(function(canvas, contextPad) {
+
+        // given
+        var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+
+        canvas.addShape(shape);
+
+        canvas.zoom(1.5);
+
+        // when
+        var position = contextPad._getPosition(shape);
+
+        // then
+        var containerBounds = canvas.getContainer().getBoundingClientRect();
+        var targetBounds = canvas.getGraphics(shape).getBoundingClientRect();
+
         expect(position.left).be.closeTo(targetBounds.left + targetBounds.width + 12 - containerBounds.left, 1);
         expect(position.top).be.closeTo(targetBounds.top - containerBounds.top, 1);
       }));
@@ -1313,7 +1334,7 @@ describe('features/context-pad', function() {
         var containerBounds = canvas.getContainer().getBoundingClientRect();
         var targetBounds = canvas.getGraphics(connection).getBoundingClientRect();
 
-        expect(position.left).be.closeTo(targetBounds.left + targetBounds.width + 12 - containerBounds.left, 1);
+        expect(position.left).be.closeTo(targetBounds.left + targetBounds.width + 8 - containerBounds.left, 1);
         expect(position.top).be.closeTo(targetBounds.bottom - containerBounds.top, 1);
       }));
 
@@ -1337,7 +1358,7 @@ describe('features/context-pad', function() {
       var target1Bounds = canvas.getGraphics(shape1).getBoundingClientRect();
       var target2Bounds = canvas.getGraphics(shape2).getBoundingClientRect();
 
-      expect(position.left).be.closeTo(target2Bounds.left + target2Bounds.width + 12 - containerBounds.left, 1);
+      expect(position.left).be.closeTo(target2Bounds.left + target2Bounds.width + 8 - containerBounds.left, 1);
       expect(position.top).be.closeTo(target1Bounds.top - containerBounds.top, 1);
     }));
 
@@ -1358,7 +1379,7 @@ describe('features/context-pad', function() {
       var containerBounds = canvas.getContainer().getBoundingClientRect();
       var targetBounds = canvas.getGraphics(shape).getBoundingClientRect();
 
-      expect(position.left).be.closeTo(targetBounds.left + targetBounds.width + 12 - containerBounds.left, 1);
+      expect(position.left).be.closeTo(targetBounds.left + targetBounds.width + 8 - containerBounds.left, 1);
       expect(position.top).be.closeTo(targetBounds.top - containerBounds.top, 1);
     }));
 

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -16,8 +16,6 @@ import {
   classes as domClasses
 } from 'min-dom';
 
-import { getBBox } from 'lib/util/Elements';
-
 import contextPadModule from 'lib/features/context-pad';
 import selectionModule from 'lib/features/selection';
 
@@ -370,7 +368,6 @@ describe('features/context-pad', function() {
         expect(contextPad.isOpen(shape1)).to.be.false;
         expect(contextPad.isOpen([ shape2 ])).to.be.false;
         expect(contextPad.isOpen([ shape1, shape2 ])).to.be.true;
-
       }));
 
     });
@@ -400,9 +397,10 @@ describe('features/context-pad', function() {
 
         canvas.addShape(shape);
 
-        // when
         contextPad.open(shape);
-        eventBus.fire('canvas.viewbox.changing');
+
+        // when
+        contextPad.hide();
 
         // then
         expect(contextPad.isShown()).not.to.be.true;
@@ -454,6 +452,66 @@ describe('features/context-pad', function() {
 
         // then
         expect(contextPad.isOpen()).to.be.true;
+      }));
+
+    });
+
+
+    describe('show and hide', function() {
+
+      it('should show', inject(function(canvas, contextPad, eventBus) {
+
+        // given
+        var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+
+        canvas.addShape(shape);
+
+        contextPad.open(shape);
+
+        contextPad.hide();
+
+        expect(contextPad.isOpen()).to.be.true;
+        expect(contextPad.isShown()).to.be.false;
+
+        var showSpy = sinon.spy();
+
+        eventBus.on('contextPad.show', showSpy);
+
+        // when
+        contextPad.show();
+
+        // then
+        expect(contextPad.isOpen()).to.be.true;
+        expect(contextPad.isShown()).to.be.true;
+
+        expect(showSpy).to.have.been.calledOnce;
+      }));
+
+
+      it('should hide', inject(function(canvas, contextPad, eventBus) {
+
+        // given
+        var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+
+        canvas.addShape(shape);
+
+        contextPad.open(shape);
+
+        expect(contextPad.isOpen()).to.be.true;
+        expect(contextPad.isShown()).to.be.true;
+
+        var hideSpy = sinon.spy();
+
+        eventBus.on('contextPad.hide', hideSpy);
+
+        // when
+        contextPad.hide();
+
+        // then
+        expect(contextPad.isOpen()).to.be.true;
+        expect(contextPad.isShown()).to.be.false;
+
+        expect(hideSpy).to.have.been.calledOnce;
       }));
 
     });
@@ -1030,12 +1088,9 @@ describe('features/context-pad', function() {
 
       contextPad.open(shape);
 
-      var pad = contextPad.getPad(shape),
-          html = pad.html,
-          target = domQuery('[data-action="action.c"]', html);
+      contextPad.hide();
 
-      var event = globalEvent(target, { x: 0, y: 0 });
-      eventBus.fire('canvas.viewbox.changing');
+      var event = globalEvent(document.body, { x: 0, y: 0 });
 
       // when
       contextPad.trigger('click', event);
@@ -1076,158 +1131,6 @@ describe('features/context-pad', function() {
       expect(triggerSpy).to.have.been.calledOnce;
       expect(triggerSpy.getCall(0).args[1]).to.eql({ entry, event });
     }));
-
-  });
-
-
-  describe('scaling', function() {
-
-    var NUM_REGEX = /([+-]?\d*[.]?\d+)(?=,|\))/g;
-    var zoomLevels = [ 1.0, 1.2, 3.5, 10, 0.5 ];
-
-    function asVector(scaleStr) {
-      if (scaleStr && scaleStr !== 'none') {
-        var m = scaleStr.match(NUM_REGEX);
-
-        var x = parseFloat(m[0], 10);
-        var y = m[1] ? parseFloat(m[1], 10) : x;
-
-        return {
-          x: x,
-          y: y
-        };
-      }
-    }
-
-    function scaleVector(element) {
-      return asVector(element.style.transform);
-    }
-
-    function verifyScales(expectedScales) {
-
-      return getDiagramJS().invoke(function(canvas, contextPad) {
-
-        // given
-        var shape = canvas.addShape({
-          id: 's1',
-          width: 100, height: 100,
-          x: 10, y: 10,
-          type: 'drag'
-        });
-
-        contextPad.open(shape);
-
-        var pad = contextPad.getPad(shape);
-
-        var padParent = pad.html.parentNode;
-
-        // test multiple zoom steps
-        zoomLevels.forEach(function(zoom, idx) {
-
-          var expectedScale = expectedScales[idx];
-
-          // when
-          canvas.zoom(zoom);
-
-          var actualScale = scaleVector(padParent) || { x: 1, y: 1 };
-
-          var effectiveScale = zoom * actualScale.x;
-
-          // then
-          expect(actualScale.x).to.eql(actualScale.y);
-          expect(effectiveScale).to.be.closeTo(expectedScale, 0.00001);
-        });
-      });
-    }
-
-
-    it('should not scale by default', function() {
-
-      // given
-      var expectedScales = [ 1.0, 1.0, 1.0, 1.0, 1.0 ];
-
-      bootstrapDiagram({
-        modules: [ contextPadModule, providerModule ]
-      })();
-
-      // when
-      verifyScales(expectedScales);
-    });
-
-
-    it('should not scale without scale config', function() {
-
-      // given
-      var expectedScales = [ 1.0, 1.0, 1.0, 1.0, 1.0 ];
-
-      bootstrapDiagram({
-        modules: [ contextPadModule, providerModule ],
-        contextPad: {}
-      })();
-
-      // when
-      verifyScales(expectedScales);
-    });
-
-
-    it('should scale within the limits set in config', function() {
-
-      // given
-      var expectedScales = [ 1.0, 1.2, 1.2, 1.2, 1.0 ];
-
-      var config = {
-        scale: {
-          min: 1.0,
-          max: 1.2
-        }
-      };
-
-      bootstrapDiagram({
-        modules: [ contextPadModule, providerModule ],
-        contextPad: config
-      })();
-
-      // when
-      verifyScales(expectedScales);
-    });
-
-
-    it('should scale with scale = true', function() {
-
-      // given
-      var expectedScales = zoomLevels;
-
-      var config = {
-        scale: true
-      };
-
-      bootstrapDiagram({
-        modules: [ contextPadModule, providerModule ],
-        contextPad: config
-      })();
-
-      // when
-      verifyScales(expectedScales);
-    });
-
-
-    it('should not scale with scale = false', function() {
-
-      // given
-      var expectedScales = [ 1.0, 1.0, 1.0, 1.0, 1.0 ];
-
-      var config = {
-        scale: false
-      };
-
-      bootstrapDiagram({
-        modules: [ contextPadModule, providerModule ],
-        contextPad: config
-      })();
-
-      // when
-      verifyScales(expectedScales);
-    });
 
   });
 
@@ -1378,33 +1281,40 @@ describe('features/context-pad', function() {
         canvas.addShape(shape);
 
         // when
-        const pad = contextPad.getPad(shape);
+        var position = contextPad._getPosition(shape);
 
         // then
-        var bBox = getBBox(shape);
-        expect(pad.position).to.eql({
-          left: bBox.x + bBox.width + 12,
-          top: bBox.y - 12 / 2
-        });
+        var containerBounds = canvas.getContainer().getBoundingClientRect();
+        var targetBounds = canvas.getGraphics(shape).getBoundingClientRect();
+
+        expect(position.left).be.closeTo(targetBounds.left + targetBounds.width + 12 - containerBounds.left, 1);
+        expect(position.top).be.closeTo(targetBounds.top - containerBounds.top, 1);
       }));
 
 
       it('connection', inject(function(canvas, contextPad) {
 
         // given
-        var connection = { id: 'c1', waypoints: [ { x: 0, y: 0 }, { x: 100, y: 100 } ] };
+        var connection = {
+          id: 'c1',
+          waypoints: [
+            { x: 0, y: 0 },
+            { x: 100, y: 0 },
+            { x: 100, y: 100 }
+          ]
+        };
 
         canvas.addConnection(connection);
 
         // when
-        const pad = contextPad.getPad(connection);
+        var position = contextPad._getPosition(connection);
 
         // then
-        var bBox = getBBox(connection.waypoints[connection.waypoints.length - 1]);
-        expect(pad.position).to.eql({
-          left: bBox.x + bBox.width + 12,
-          top: bBox.y - 12 / 2
-        });
+        var containerBounds = canvas.getContainer().getBoundingClientRect();
+        var targetBounds = canvas.getGraphics(connection).getBoundingClientRect();
+
+        expect(position.left).be.closeTo(targetBounds.left + targetBounds.width + 12 - containerBounds.left, 1);
+        expect(position.top).be.closeTo(targetBounds.bottom - containerBounds.top, 1);
       }));
 
     });
@@ -1413,21 +1323,80 @@ describe('features/context-pad', function() {
     it('multi element', inject(function(canvas, contextPad) {
 
       // given
-      var shape1 = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
-      var shape2 = { id: 's2', width: 100, height: 100, x: 210, y: 10 };
+      var shape1 = { id: 's1', x: 0, y: 0, width: 100, height: 100 };
+      var shape2 = { id: 's2', x: 100, y: 100, width: 100, height: 100 };
 
       canvas.addShape(shape1);
       canvas.addShape(shape2);
 
       // when
-      const pad = contextPad.getPad([ shape1, shape2 ]);
+      var position = contextPad._getPosition([ shape1, shape2 ]);
 
       // then
-      var bBox = getBBox([ shape1, shape2 ]);
-      expect(pad.position).to.eql({
-        left: bBox.x + bBox.width + 12,
-        top: bBox.y - 12 / 2
-      });
+      var containerBounds = canvas.getContainer().getBoundingClientRect();
+      var target1Bounds = canvas.getGraphics(shape1).getBoundingClientRect();
+      var target2Bounds = canvas.getGraphics(shape2).getBoundingClientRect();
+
+      expect(position.left).be.closeTo(target2Bounds.left + target2Bounds.width + 12 - containerBounds.left, 1);
+      expect(position.top).be.closeTo(target1Bounds.top - containerBounds.top, 1);
+    }));
+
+
+    it('should update position on canvas.viewbox.changed', inject(function(canvas, contextPad) {
+
+      // given
+      var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+
+      canvas.addShape(shape);
+
+      canvas.scroll({ dx: 100, dy: 100 });
+
+      // when
+      var position = contextPad._getPosition(shape);
+
+      // then
+      var containerBounds = canvas.getContainer().getBoundingClientRect();
+      var targetBounds = canvas.getGraphics(shape).getBoundingClientRect();
+
+      expect(position.left).be.closeTo(targetBounds.left + targetBounds.width + 12 - containerBounds.left, 1);
+      expect(position.top).be.closeTo(targetBounds.top - containerBounds.top, 1);
+    }));
+
+  });
+
+
+  describe('legacy getPad', function() {
+
+    beforeEach(bootstrapDiagram({
+      modules: [
+        contextPadModule,
+        providerModule
+      ]
+    }));
+
+
+    afterEach(function() {
+      console.warn.restore();
+    });
+
+
+    it('should return pad', inject(function(canvas, contextPad) {
+
+      // given
+      var shape = canvas.addShape({ id: 's1', width: 100, height: 100, x: 10, y: 10 });
+
+      var warnSpy = sinon.spy(console, 'warn');
+
+      // when
+      const pad = contextPad.getPad(shape);
+
+      // then
+      expect(pad).to.exist;
+      expect(pad.html).to.exist;
+
+      expect(warnSpy).to.have.been.calledOnce;
+      expect(warnSpy.getCall(0).args[ 0 ]).to.be.instanceOf(Error);
+      expect(warnSpy.getCall(0).args[ 0 ].message).to.equal('getPad is deprecated and will be removed in future library versions');
     }));
 
   });


### PR DESCRIPTION
* context pad is not an overlay anymore
* context pad is positioned absolutely in `Canvas#getContainer()`
* context pad doesn't scale
* `ContextPad#getPad` is deprecated but will still return `{ html }` for those who need it

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
