### PR TITLE
fix(context-pad): do not call `triggerEntry` twice when handling hover

### DIFF
--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -237,6 +237,8 @@ ContextPad.prototype.trigger = function(action, event, autoActivate) {
     this._timeout = setTimeout(() => {
       this._mouseout = this.triggerEntry(entry, 'hover', originalEvent, autoActivate);
     }, HOVER_DELAY);
+
+    return;
   } else if (action === 'mouseout') {
     clearTimeout(this._timeout);
 
@@ -245,6 +247,8 @@ ContextPad.prototype.trigger = function(action, event, autoActivate) {
 
       this._mouseout = null;
     }
+
+    return;
   }
 
   return this.triggerEntry(entry, action, originalEvent, autoActivate);

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -828,15 +828,21 @@ describe('features/context-pad', function() {
 
       var event = globalEvent(target, { x: 0, y: 0 });
 
+      sinon.spy(contextPad, 'triggerEntry');
+
       // when
       contextPad.trigger('mouseover', event);
 
       expect(event.__handled).not.to.exist;
 
+      expect(contextPad.triggerEntry).not.to.have.been.called;
+
       clock.tick(500);
 
       // then
       expect(event.__handled).to.be.true;
+
+      expect(contextPad.triggerEntry).to.have.been.calledOnceWith('action.hover', 'hover', event);
     }));
 
 
@@ -865,10 +871,14 @@ describe('features/context-pad', function() {
 
       var event = globalEvent(target, { x: 0, y: 0 });
 
+      sinon.spy(contextPad, 'triggerEntry');
+
       // when
       contextPad.trigger('mouseover', event);
 
       expect(event.__handled).not.to.exist;
+
+      expect(contextPad.triggerEntry).not.to.have.been.called;
 
       clock.tick(250);
 
@@ -878,6 +888,8 @@ describe('features/context-pad', function() {
 
       // then
       expect(event.__handled).not.to.exist;
+
+      expect(contextPad.triggerEntry).not.to.have.been.calledWith('action.hover', 'hover', event);
     }));
 
 


### PR DESCRIPTION
Didn't break anything but would call `triggerEntry` with non-existing action. Discovered in the context of https://github.com/bpmn-io/bpmn-js/issues/2150.
