### PR TITLE
fix(context-pad): do not re-open for targets that were removed

### DIFF
--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -2,8 +2,7 @@ import {
   every,
   forEach,
   isArray,
-  isFunction,
-  some
+  isFunction
 } from 'min-dash';
 
 import {
@@ -29,6 +28,7 @@ import { isConnection } from '../../util/ModelUtil';
  * @typedef {import('../../util/Types').RectTRBL} RectTRBL
  *
  * @typedef {import('../../core/Canvas').default} Canvas
+ * @typedef {import('../../core/ElementRegistry').default} ElementRegistry
  * @typedef {import('../../core/EventBus').default} EventBus
  *
  * @typedef {import('./ContextPadProvider').default} ContextPadProvider
@@ -53,11 +53,13 @@ var HOVER_DELAY = 300;
  * to a diagram element.
  *
  * @param {Canvas} canvas
+ * @param {ElementRegistry} elementRegistry
  * @param {EventBus} eventBus
  */
-export default function ContextPad(canvas, eventBus) {
+export default function ContextPad(canvas, elementRegistry, eventBus) {
 
   this._canvas = canvas;
+  this._elementRegistry = elementRegistry;
   this._eventBus = eventBus;
 
   this._current = null;
@@ -67,6 +69,7 @@ export default function ContextPad(canvas, eventBus) {
 
 ContextPad.$inject = [
   'canvas',
+  'elementRegistry',
   'eventBus'
 ];
 
@@ -102,18 +105,29 @@ ContextPad.prototype._init = function() {
       return;
     }
 
-    var currentTarget = current.target;
+    var { target } = current;
 
-    var currentChanged = some(
-      isArray(currentTarget) ? currentTarget : [ currentTarget ],
-      function(element) {
-        return includes(elements, element);
+    var targets = isArray(target) ? target : [ target ];
+
+    var targetsChanged = targets.filter(function(element) {
+      return includes(elements, element);
+    });
+
+    if (targetsChanged.length) {
+
+      // (1) close
+      self.close();
+
+      var targetsNew = targets.filter(function(element) {
+        return self._elementRegistry.get(element.id);
+      });
+
+      if (targetsNew.length) {
+
+        // (2) re-open with new targets being all previous targets that still
+        // exist
+        self._updateAndOpen(targetsNew.length > 1 ? targetsNew : targetsNew[ 0 ]);
       }
-    );
-
-    // re-open if elements in current selection changed
-    if (currentChanged) {
-      self.open(currentTarget, true);
     }
   });
 

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -390,7 +390,7 @@ describe('features/context-pad', function() {
       }));
 
 
-      it('open and hidden', inject(function(canvas, contextPad, eventBus) {
+      it('open and hidden', inject(function(canvas, contextPad) {
 
         // given
         var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
@@ -407,7 +407,7 @@ describe('features/context-pad', function() {
       }));
 
 
-      it('closed', inject(function(canvas, contextPad, eventBus) {
+      it('closed', inject(function(canvas, contextPad) {
 
         // given
         var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
@@ -575,8 +575,7 @@ describe('features/context-pad', function() {
       contextPad.close();
 
       // then
-      expect(overlays.get({ element: shape })).to.have.length(0);
-      expect(!!contextPad.isOpen()).to.be.false;
+      expect(contextPad.isOpen()).to.be.false;
     }));
 
 
@@ -654,10 +653,20 @@ describe('features/context-pad', function() {
         });
       }
 
+      function remove(elements) {
+        getDiagramJS().invoke(function(canvas) {
+          (isArray(elements) ? elements : [ elements ]).forEach(function(element) {
+            canvas.removeShape(element);
+          });
+        });
+
+        change(elements);
+      }
+
 
       describe('should handle changed', function() {
 
-        it('single target', inject(function(eventBus, canvas, contextPad) {
+        it('single target', inject(function(canvas, contextPad) {
 
           // given
           var shape_1 = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
@@ -678,7 +687,7 @@ describe('features/context-pad', function() {
         }));
 
 
-        it('multiple targets', inject(function(eventBus, canvas, contextPad) {
+        it('multiple targets', inject(function(canvas, contextPad) {
 
           // given
           var shape_1 = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
@@ -703,9 +712,59 @@ describe('features/context-pad', function() {
       });
 
 
+      describe('should handle removed', function() {
+
+        it('some removed', inject(function(canvas, contextPad) {
+
+          // given
+          var shape_1 = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+          var shape_2 = { id: 's2', width: 50, height: 50, x: 210, y: 10 };
+
+          canvas.addShape(shape_1);
+          canvas.addShape(shape_2);
+
+          // assume
+          contextPad.open([ shape_1, shape_2 ]);
+
+          // then
+          expectOpened([ shape_1, shape_2 ]);
+
+          // when
+          remove(shape_1);
+
+          // then
+          expectOpened(shape_2);
+        }));
+
+
+        it('all removed', inject(function(canvas, contextPad) {
+
+          // given
+          var shape_1 = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+          var shape_2 = { id: 's2', width: 50, height: 50, x: 210, y: 10 };
+
+          canvas.addShape(shape_1);
+          canvas.addShape(shape_2);
+
+          // assume
+          contextPad.open([ shape_1, shape_2 ]);
+
+          // then
+          expectOpened([ shape_1, shape_2 ]);
+
+          // when
+          remove([ shape_1, shape_2 ]);
+
+          // then
+          expectClosed();
+        }));
+
+      });
+
+
       describe('should ignore unrelated', function() {
 
-        it('single target', inject(function(eventBus, canvas, contextPad) {
+        it('single target', inject(function(canvas, contextPad) {
 
           // given
           var shape_1 = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
@@ -728,7 +787,7 @@ describe('features/context-pad', function() {
         }));
 
 
-        it('multiple targets', inject(function(eventBus, canvas, contextPad) {
+        it('multiple targets', inject(function(canvas, contextPad) {
 
           // given
           var shape_1 = { id: 's1', width: 100, height: 100, x: 10, y: 10 };


### PR DESCRIPTION
The fact that `elements.changed` could feature elements that were removed wasn't previously taken into account.
