### PR TITLE
chore(CHANGELOG): update to v14.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+## 14.5.1
+
+* `FIX`: do not re-open context pad for elements that were removed ([#893](https://github.com/bpmn-io/diagram-js/pull/893))
+
 ## 14.5.0
 
 * `FEAT`: context pad position absolute instead of relative to element ([#888](https://github.com/bpmn-io/diagram-js/pull/888))


### PR DESCRIPTION
# Changes

* `FIX`: do not re-open context pad for elements that were removed ([#893](https://github.com/bpmn-io/diagram-js/pull/893))
