### PR TITLE
fix(context-pad): do not hide context pad on `djs-label-hidden` added

### DIFF
--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -20,10 +20,7 @@ import {
 
 import { isConnection } from '../../util/ModelUtil';
 
-var MARKERS_HIDDEN = [
-  'djs-element-hidden',
-  'djs-label-hidden'
-];
+var MARKER_HIDDEN = 'djs-element-hidden';
 
 /**
  * @typedef {import('../../model/Types').Element} Element
@@ -636,9 +633,7 @@ ContextPad.prototype._updateVisibility = function() {
   var targets = isArray(target) ? target : [ target ];
 
   var isHidden = targets.some(function(target) {
-    return MARKERS_HIDDEN.some(function(marker) {
-      return self._canvas.hasMarker(target, marker);
-    });
+    return self._canvas.hasMarker(target, MARKER_HIDDEN);
   });
 
   if (isHidden) {

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -976,50 +976,6 @@ describe('features/context-pad', function() {
         expect(contextPad.isShown()).to.be.true;
       }));
 
-
-      it('should hide context pad when djs-label-hidden is added', inject(function(canvas, contextPad) {
-
-        // given
-        var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
-
-        canvas.addShape(shape);
-
-        contextPad.open(shape);
-
-        expect(contextPad.isOpen()).to.be.true;
-        expect(contextPad.isShown()).to.be.true;
-
-        // when
-        canvas.addMarker(shape, 'djs-label-hidden');
-
-        // then
-        expect(contextPad.isOpen()).to.be.true;
-        expect(contextPad.isShown()).to.be.false;
-      }));
-
-
-      it('should show context pad when djs-label-hidden is removed', inject(function(canvas, contextPad) {
-
-        // given
-        var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
-
-        canvas.addShape(shape);
-
-        canvas.addMarker(shape, 'djs-label-hidden');
-
-        contextPad.open(shape);
-
-        expect(contextPad.isOpen()).to.be.true;
-        expect(contextPad.isShown()).to.be.false;
-
-        // when
-        canvas.removeMarker(shape, 'djs-label-hidden');
-
-        // then
-        expect(contextPad.isOpen()).to.be.true;
-        expect(contextPad.isShown()).to.be.true;
-      }));
-
     });
 
   });


### PR DESCRIPTION
Turns out I was too eager hiding the context pad. `djs-label-hidden` should not hide the context pad.
