### PR TITLE
Prevent duplicate marker ids in preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+* `FIX`: ensure cloned marker IDs are unique ([#909](https://github.com/bpmn-io/diagram-js/pull/909))
+
 ## 14.7.0
 
 * `FEAT`: support nested `defs` in the SVG ([#906](https://github.com/bpmn-io/diagram-js/pull/906))

--- a/lib/features/move/MovePreview.js
+++ b/lib/features/move/MovePreview.js
@@ -4,7 +4,6 @@ import {
   filter,
   find,
   groupBy,
-  map,
   matchPattern,
   size
 } from 'min-dash';
@@ -64,11 +63,14 @@ export default function MovePreview(
   function getAllDraggedElements(shapes) {
     var allShapes = selfAndAllChildren(shapes, true);
 
-    var allConnections = map(allShapes, function(shape) {
-      return (shape.incoming || []).concat(shape.outgoing || []);
-    });
+    var allConnections = allShapes.flatMap(shape =>
+      (shape.incoming || []).concat(shape.outgoing || [])
+    );
 
-    return flatten(allShapes.concat(allConnections));
+    var allElements = allShapes.concat(allConnections);
+    var uniqueElements = [ ...new Set(allElements) ];
+
+    return uniqueElements;
   }
 
   /**

--- a/lib/features/preview-support/PreviewSupport.js
+++ b/lib/features/preview-support/PreviewSupport.js
@@ -10,6 +10,8 @@ import { query as domQuery } from 'min-dom';
 
 import { getVisual } from '../../util/GraphicsUtil';
 
+import Ids from '../../util/IdGenerator';
+
 /**
  * @typedef {import('../../core/Types').ElementLike} Element
  * @typedef {import('../../core/Types').ShapeLike} Shape
@@ -19,6 +21,8 @@ import { getVisual } from '../../util/GraphicsUtil';
  * @typedef {import('../../core/EventBus').default} EventBus
  * @typedef {import('../../draw/Styles').default} Styles
  */
+
+const cloneIds = new Ids('ps');
 
 var MARKER_TYPES = [
   'marker-start',
@@ -50,8 +54,6 @@ export default function PreviewSupport(elementRegistry, eventBus, canvas, styles
   this._elementRegistry = elementRegistry;
   this._canvas = canvas;
   this._styles = styles;
-
-  this._clonedMarkers = {};
 }
 
 PreviewSupport.$inject = [
@@ -175,35 +177,32 @@ PreviewSupport.prototype._cloneMarkers = function(gfx, className = 'djs-dragger'
  * @param {string} [className="djs-dragger"]
  */
 PreviewSupport.prototype._cloneMarker = function(parentGfx, gfx, marker, markerType, className = 'djs-dragger') {
-  var markerId = marker.id + '-' + className;
 
-  var clonedMarker = this._clonedMarkers[ markerId ];
+  // Add a random suffix to the marker ID in case the same marker is previewed multiple times
+  var clonedMarkerId = [ marker.id, className, cloneIds.next() ].join('-');
+
+  // reuse marker if it was part of original gfx
+  var copiedMarker = domQuery('marker#' + marker.id, parentGfx);
 
   parentGfx = parentGfx || this._canvas._svg;
 
-  if (!clonedMarker) {
-    clonedMarker = svgClone(marker);
+  var clonedMarker = copiedMarker || svgClone(marker);
 
-    var clonedMarkerId = markerId + '-clone';
+  clonedMarker.id = clonedMarkerId;
 
-    clonedMarker.id = clonedMarkerId;
+  svgClasses(clonedMarker).add(className);
 
-    svgClasses(clonedMarker).add(className);
+  var defs = domQuery(':scope > defs', parentGfx);
 
-    this._clonedMarkers[ markerId ] = clonedMarker;
+  if (!defs) {
+    defs = svgCreate('defs');
 
-    var defs = domQuery(':scope > defs', parentGfx);
-
-    if (!defs) {
-      defs = svgCreate('defs');
-
-      svgAppend(parentGfx, defs);
-    }
-
-    svgAppend(defs, clonedMarker);
+    svgAppend(parentGfx, defs);
   }
 
-  var reference = idToReference(this._clonedMarkers[ markerId ].id);
+  svgAppend(defs, clonedMarker);
+
+  var reference = idToReference(clonedMarker.id);
 
   svgAttr(gfx, markerType, reference);
 };

--- a/test/spec/features/complex-preview/ComplexPreviewSpec.js
+++ b/test/spec/features/complex-preview/ComplexPreviewSpec.js
@@ -217,8 +217,8 @@ describe('features/complex-preview', function() {
     // then
     expect(domQueryAll('marker.djs-dragging', canvas.getContainer())).to.have.length(2);
 
-    expect(domQuery('marker#marker-start-djs-dragging-clone', canvas.getContainer())).to.exist;
-    expect(domQuery('marker#marker-end-djs-dragging-clone', canvas.getContainer())).to.exist;
+    expect(domQuery('marker[id^="marker-start-djs-dragging-ps"]', canvas.getContainer())).to.exist;
+    expect(domQuery('marker[id^="marker-end-djs-dragging-ps"]', canvas.getContainer())).to.exist;
   }));
 
 
@@ -251,8 +251,8 @@ describe('features/complex-preview', function() {
     expect(layer).to.exist;
 
     expect(layer.childNodes).to.have.length(0);
-    expect(domQuery('marker#marker-start-djs-dragging-clone', canvas.getContainer())).not.to.exist;
-    expect(domQuery('marker#marker-end-djs-dragging-clone', canvas.getContainer())).not.to.exist;
+    expect(domQuery('marker[id^="marker-start-djs-dragging-ps"]', canvas.getContainer())).not.to.exist;
+    expect(domQuery('marker[id^="marker-end-djs-dragging-ps"]', canvas.getContainer())).not.to.exist;
   }));
 
 });

--- a/test/spec/features/move/MovePreviewSpec.js
+++ b/test/spec/features/move/MovePreviewSpec.js
@@ -587,16 +587,16 @@ describe('features/move - MovePreview', function() {
       // then
       var container = canvas.getContainer();
 
-      // var clonedMarkers = domQueryAll('marker.djs-dragger', container);
-      // expect(clonedMarkers).to.have.length(6);
+      var clonedMarkers = domQueryAll('marker.djs-dragger', container);
+      expect(clonedMarkers).to.have.length(6);
 
       var markerStartClones = [ ...domQueryAll('marker[id^="marker-start-djs-dragger-ps"]', container) ],
           markerMidClones = [ ...domQueryAll('marker[id^="marker-mid-djs-dragger-ps"]', container) ],
           markerEndClones = [ ...domQueryAll('marker[id^="marker-end-djs-dragger-ps"]', container) ];
 
-      expect(markerStartClones).to.have.length(4);
-      expect(markerMidClones).to.exist.length(4);
-      expect(markerEndClones).to.exist.length(4);
+      expect(markerStartClones).to.have.length(2);
+      expect(markerMidClones).to.exist.length(2);
+      expect(markerEndClones).to.exist.length(2);
 
       var markerStartCloneIds = markerStartClones.map(marker => marker.id),
           markerMidCloneIds = markerMidClones.map(marker => marker.id),
@@ -743,8 +743,8 @@ describe('features/move - MovePreview', function() {
       // then
       var container = canvas.getContainer();
 
-      // var clonedMarkers = domQueryAll('marker.djs-dragger', container);
-      // expect(clonedMarkers).to.have.length(7);
+      var clonedMarkers = domQueryAll('marker.djs-dragger', container);
+      expect(clonedMarkers).to.have.length(7);
 
       var markerStartClone = domQuery('marker[id^="marker-start-connection3-djs-dragger-ps"]', container),
           markerMidClone = domQuery('marker[id^="marker-mid-connection3-djs-dragger-ps"]', container),
@@ -801,6 +801,7 @@ describe('features/move - MovePreview', function() {
     }));
 
   });
+
 });
 
 // helpers //////////

--- a/test/spec/features/preview-support/nested-renderer/MarkerRenderer.js
+++ b/test/spec/features/preview-support/nested-renderer/MarkerRenderer.js
@@ -41,8 +41,6 @@ export default function MarkerRenderer(canvas, eventBus, styles) {
   DefaultRenderer.call(this, eventBus, styles, HIGH_PRIORITY);
 
   this._canvas = canvas;
-
-  this._markers = {};
 }
 
 inherits(MarkerRenderer, DefaultRenderer);
@@ -66,49 +64,47 @@ MarkerRenderer.prototype.drawConnection = function(parentGfx, connection) {
 
   MARKER_TYPES.forEach(function(markerType) {
     if (hasMarker(connection, markerType)) {
-      self.addMarker(line, markerType);
+      self.addMarker(parentGfx, line, markerType, connection.id);
     }
   });
 
   return line;
 };
 
-MarkerRenderer.prototype.addMarker = function(gfx, markerType) {
-  var marker = this._markers[ markerType ],
-      defs;
+MarkerRenderer.prototype.addMarker = function(parentGfx, gfx, markerType, id) {
+  var defs, marker;
+  parentGfx = parentGfx || this._canvas._svg;
 
-  if (!marker) {
-    marker = this._markers[ markerType ] = svgCreate('marker');
+  marker = svgCreate('marker');
 
-    marker.id = markerType;
+  marker.id = markerType + '-' + id;
 
-    svgAttr(marker, {
-      refX: 5,
-      refY: 5,
-      viewBox: '0 0 10 10'
-    });
+  svgAttr(marker, {
+    refX: 5,
+    refY: 5,
+    viewBox: '0 0 10 10'
+  });
 
-    var circle = svgCreate('circle');
+  var circle = svgCreate('circle');
 
-    svgAttr(circle, {
-      cx: 5,
-      cy: 5,
-      fill: 'fuchsia',
-      r: 5
-    });
+  svgAttr(circle, {
+    cx: 5,
+    cy: 5,
+    fill: 'fuchsia',
+    r: 5
+  });
 
-    svgAppend(marker, circle);
+  svgAppend(marker, circle);
 
-    defs = domQuery(':scope > defs', this._canvas._svg);
+  defs = domQuery(':scope > defs', parentGfx);
 
-    if (!defs) {
-      defs = svgCreate('defs');
+  if (!defs) {
+    defs = svgCreate('defs');
 
-      svgAppend(this._canvas._svg, defs);
-    }
-
-    svgAppend(defs, marker);
+    svgAppend(parentGfx, defs);
   }
+
+  svgAppend(defs, marker);
 
   var reference = idToReference(marker.id);
 

--- a/test/spec/features/preview-support/nested-renderer/index.js
+++ b/test/spec/features/preview-support/nested-renderer/index.js
@@ -1,0 +1,6 @@
+import MarkerRenderer from './MarkerRenderer';
+
+export default {
+  __init__: [ 'defaultRenderer' ],
+  defaultRenderer: [ 'type', MarkerRenderer ]
+};


### PR DESCRIPTION
This PR:

- changes the marker ID if it was part of the `djs-visual` instead of creating a new one.
- Adds a random string to the copied marker ID. This ensures we do not have overlaps if the same connection is present multiple times in a preview. While this should not happen, it did happen in the past so better be safe here.
- Ensures we copy connections only once in move preview

related to https://github.com/bpmn-io/bpmn-js/issues/2179

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
