### PR TITLE
deps: bump to tiny-svg@3.1.2 / min-dom@4.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
         "didi": "^10.2.2",
         "inherits-browser": "^0.1.0",
         "min-dash": "^4.1.0",
-        "min-dom": "^4.1.0",
+        "min-dom": "^4.2.1",
         "object-refs": "^0.4.0",
         "path-intersection": "^3.0.0",
-        "tiny-svg": "^3.0.1"
+        "tiny-svg": "^3.1.2"
       },
       "devDependencies": {
         "@babel/core": "^7.23.9",
@@ -5556,18 +5556,18 @@
       }
     },
     "node_modules/min-dash": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.1.0.tgz",
-      "integrity": "sha512-wAOONxERkwcJQXJvrxsqyOFci4M0355GDS8feDfsSp8GhS4yontVfONYpFWXHjxQrnisRZdQHQ4ES2LO/1kCpw=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.1.tgz",
+      "integrity": "sha512-to+unsToePnm7cUeR9TrMzFlETHd/UXmU+ELTRfWZj5XGT41KF6X3L233o3E/GdEs3sk2Tbw/lOLD1avmWkg8A=="
     },
     "node_modules/min-dom": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
-      "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.2.1.tgz",
+      "integrity": "sha512-TMoL8SEEIhUWYgkj7XMSgxmwSyGI+4fP2KFFGnN3FbHfbGHVdsLYSz8LoIsgPhz4dWRmLvxWWSMgzZMJW5sZuA==",
       "dependencies": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
-        "min-dash": "^4.0.0"
+        "min-dash": "^4.2.1"
       }
     },
     "node_modules/min-indent": {
@@ -7816,9 +7816,9 @@
       }
     },
     "node_modules/tiny-svg": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.1.tgz",
-      "integrity": "sha512-P8T4iwiW1t95vpHVHqrD36Brn7TqFYCPSHIWk9WLJtYK1X4aDd+5cgqcAADIWSjf1/i5idKnpCh9mim8hEdRBg=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.1.2.tgz",
+      "integrity": "sha512-qvNlv/4N48HqbNpwAhzQ9HKHlBUKgA4091x+aVfsrRXHIcQ9NA3W6ZYwdmYAIdwT+vfAAksrc9L/3RQBj5KwPw=="
     },
     "node_modules/tmp": {
       "version": "0.2.1",
@@ -12474,18 +12474,18 @@
       }
     },
     "min-dash": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.1.0.tgz",
-      "integrity": "sha512-wAOONxERkwcJQXJvrxsqyOFci4M0355GDS8feDfsSp8GhS4yontVfONYpFWXHjxQrnisRZdQHQ4ES2LO/1kCpw=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.1.tgz",
+      "integrity": "sha512-to+unsToePnm7cUeR9TrMzFlETHd/UXmU+ELTRfWZj5XGT41KF6X3L233o3E/GdEs3sk2Tbw/lOLD1avmWkg8A=="
     },
     "min-dom": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
-      "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.2.1.tgz",
+      "integrity": "sha512-TMoL8SEEIhUWYgkj7XMSgxmwSyGI+4fP2KFFGnN3FbHfbGHVdsLYSz8LoIsgPhz4dWRmLvxWWSMgzZMJW5sZuA==",
       "requires": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
-        "min-dash": "^4.0.0"
+        "min-dash": "^4.2.1"
       }
     },
     "min-indent": {
@@ -14049,9 +14049,9 @@
       }
     },
     "tiny-svg": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.1.tgz",
-      "integrity": "sha512-P8T4iwiW1t95vpHVHqrD36Brn7TqFYCPSHIWk9WLJtYK1X4aDd+5cgqcAADIWSjf1/i5idKnpCh9mim8hEdRBg=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.1.2.tgz",
+      "integrity": "sha512-qvNlv/4N48HqbNpwAhzQ9HKHlBUKgA4091x+aVfsrRXHIcQ9NA3W6ZYwdmYAIdwT+vfAAksrc9L/3RQBj5KwPw=="
     },
     "tmp": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -86,9 +86,9 @@
     "didi": "^10.2.2",
     "inherits-browser": "^0.1.0",
     "min-dash": "^4.1.0",
-    "min-dom": "^4.1.0",
+    "min-dom": "^4.2.1",
     "object-refs": "^0.4.0",
     "path-intersection": "^3.0.0",
-    "tiny-svg": "^3.0.1"
+    "tiny-svg": "^3.1.2"
   }
 }


### PR DESCRIPTION
Improves [`clear`](https://github.com/bpmn-io/tiny-svg/blob/main/lib/clear.js).