### PR TITLE
Do not update context pad visibility on `element.marker.update` if element is not target

### DIFF
--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -106,7 +106,7 @@ ContextPad.prototype._init = function() {
       return;
     }
 
-    var { target } = current;
+    var target = current.target;
 
     var targets = isArray(target) ? target : [ target ];
 
@@ -132,8 +132,8 @@ ContextPad.prototype._init = function() {
     }
   });
 
-  this._eventBus.on('canvas.viewbox.changed', () => {
-    this._updatePosition();
+  this._eventBus.on('canvas.viewbox.changed', function() {
+    self._updatePosition();
   });
 
   this._eventBus.on('element.marker.update', function(event) {
@@ -158,7 +158,7 @@ ContextPad.prototype._init = function() {
 };
 
 ContextPad.prototype._createContainer = function() {
-  const container = domify('<div class="djs-context-pad-parent"></div>');
+  var container = domify('<div class="djs-context-pad-parent"></div>');
 
   this._canvas.getContainer().appendChild(container);
 
@@ -242,6 +242,7 @@ ContextPad.prototype.getEntries = function(target) {
  * @param {boolean} [autoActivate=false]
  */
 ContextPad.prototype.trigger = function(action, event, autoActivate) {
+  var self = this;
 
   var entry,
       originalEvent,
@@ -255,8 +256,8 @@ ContextPad.prototype.trigger = function(action, event, autoActivate) {
   originalEvent = event.originalEvent || event;
 
   if (action === 'mouseover') {
-    this._timeout = setTimeout(() => {
-      this._mouseout = this.triggerEntry(entry, 'hover', originalEvent, autoActivate);
+    this._timeout = setTimeout(function() {
+      self._mouseout = self.triggerEntry(entry, 'hover', originalEvent, autoActivate);
     }, HOVER_DELAY);
 
     return;
@@ -577,12 +578,12 @@ ContextPad.prototype.hide = function() {
  */
 ContextPad.prototype._getPosition = function(target) {
   if (!isArray(target) && isConnection(target)) {
-    const viewbox = this._canvas.viewbox();
+    var viewbox = this._canvas.viewbox();
 
-    const lastWaypoint = getLastWaypoint(target);
+    var lastWaypoint = getLastWaypoint(target);
 
-    const x = lastWaypoint.x * viewbox.scale - viewbox.x * viewbox.scale,
-          y = lastWaypoint.y * viewbox.scale - viewbox.y * viewbox.scale;
+    var x = lastWaypoint.x * viewbox.scale - viewbox.x * viewbox.scale,
+        y = lastWaypoint.y * viewbox.scale - viewbox.y * viewbox.scale;
 
     return {
       left: x + CONTEXT_PAD_MARGIN * this._canvas.zoom(),
@@ -665,13 +666,15 @@ ContextPad.prototype._updateVisibility = function() {
  * @returns {Rect & RectTRBL}
  */
 ContextPad.prototype._getTargetBounds = function(target) {
+  var self = this;
+
   var elements = isArray(target) ? target : [ target ];
 
-  var elementsGfx = elements.map((element) => {
-    return this._canvas.getGraphics(element);
+  var elementsGfx = elements.map(function(element) {
+    return self._canvas.getGraphics(element);
   });
 
-  return elementsGfx.reduce((bounds, elementGfx) => {
+  return elementsGfx.reduce(function(bounds, elementGfx) {
     const elementBounds = elementGfx.getBoundingClientRect();
 
     bounds.top = Math.min(bounds.top, elementBounds.top);

--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -137,6 +137,20 @@ ContextPad.prototype._init = function() {
   });
 
   this._eventBus.on('element.marker.update', function(event) {
+    if (!self.isOpen()) {
+      return;
+    }
+
+    var element = event.element;
+
+    var current = self._current;
+
+    var targets = isArray(current.target) ? current.target : [ current.target ];
+
+    if (!targets.includes(element)) {
+      return;
+    }
+
     self._updateVisibility();
   });
 

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -976,6 +976,49 @@ describe('features/context-pad', function() {
         expect(contextPad.isShown()).to.be.true;
       }));
 
+
+      it('should not update visibility if not open', inject(function(canvas, contextPad) {
+
+        // given
+        var shape = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+
+        canvas.addShape(shape);
+
+        expect(contextPad.isOpen()).to.be.false;
+
+        var spy = sinon.spy(contextPad, '_updateVisibility');
+
+        // when
+        canvas.addMarker(shape, 'djs-element-hidden');
+
+        // then
+        expect(spy).not.to.have.been.called;
+      }));
+
+
+      it('should not update visibility if element is not target', inject(function(canvas, contextPad) {
+
+        // given
+        var shape1 = { id: 's1', width: 100, height: 100, x: 10, y: 10 };
+
+        var shape2 = { id: 's2', width: 100, height: 100, x: 10, y: 10 };
+
+        canvas.addShape(shape1);
+        canvas.addShape(shape2);
+
+        contextPad.open(shape1);
+
+        expect(contextPad.isOpen()).to.be.true;
+
+        var spy = sinon.spy(contextPad, '_updateVisibility');
+
+        // when
+        canvas.addMarker(shape2, 'djs-element-hidden');
+
+        // then
+        expect(spy).not.to.have.been.called;
+      }));
+
     });
 
   });

--- a/test/spec/features/context-pad/ContextPadSpec.js
+++ b/test/spec/features/context-pad/ContextPadSpec.js
@@ -1330,7 +1330,7 @@ describe('features/context-pad', function() {
       contextPad.trigger('click', event);
 
       // then
-      const entry = contextPad._current.entries['action.c'];
+      var entry = contextPad._current.entries['action.c'];
 
       expect(triggerSpy).to.have.been.calledOnce;
       expect(triggerSpy.getCall(0).args[1]).to.eql({ entry, event });
@@ -1606,7 +1606,7 @@ describe('features/context-pad', function() {
       var shape = canvas.addShape({ id: 's1', width: 100, height: 100, x: 10, y: 10 });
 
       // when
-      const pad = contextPad.getPad(shape);
+      var pad = contextPad.getPad(shape);
 
       // then
       expect(pad).to.exist;
@@ -1624,7 +1624,7 @@ describe('features/context-pad', function() {
       var spy = sinon.spy(contextPad, '_createHtml');
 
       // when
-      const pad = contextPad.getPad(shape);
+      var pad = contextPad.getPad(shape);
 
       // then
       expect(pad).to.exist;
@@ -1642,7 +1642,7 @@ describe('features/context-pad', function() {
       var spy = sinon.spy(contextPad, '_createHtml');
 
       // when
-      const pad = contextPad.getPad([ shape ]);
+      var pad = contextPad.getPad([ shape ]);
 
       // then
       expect(pad).to.exist;
@@ -1660,7 +1660,7 @@ describe('features/context-pad', function() {
       var spy = sinon.spy(contextPad, '_createHtml');
 
       // when
-      const pad = contextPad.getPad(shape);
+      var pad = contextPad.getPad(shape);
 
       // then
       expect(pad).to.exist;
@@ -1679,7 +1679,7 @@ describe('features/context-pad', function() {
       var spy = sinon.spy(contextPad, '_createHtml');
 
       // when
-      const pad = contextPad.getPad(shape2);
+      var pad = contextPad.getPad(shape2);
 
       // then
       expect(pad).to.exist;
@@ -1705,7 +1705,7 @@ describe('features/context-pad', function() {
         var shape = canvas.addShape({ id: 's1', width: 100, height: 100, x: 10, y: 10 });
 
         // when
-        const pad = contextPad.getPad(shape);
+        var pad = contextPad.getPad(shape);
 
         // then
         expect(pad).to.exist;


### PR DESCRIPTION
I investigated https://camunda-modeling.sentry.io/share/issue/d4edab8eb6044c74b7c933158b06a69a/ which happens when reacting to `element.marker.update` which calls `canvas.hasMarker` for each of the current targets. In some cases that I couldn't reproduce it seems like at least one of the targets has been deleted at the time of calling `canvas.hasMarker` which leads to a `A DOM element reference is required` since there is no graphical element anymore. While I couldn't reproduce the issue I changed the implementation so context pad visibility is updated on `element.marker.update` only if the element is a target. This might or might not fix the issue. We'll have to keep an eye on the Sentry issue.