### PR TITLE
Search improvements

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -81,7 +81,8 @@
   --search-input-border-color: var(--color-grey-225-10-75);
   --search-result-border-color: var(--color-grey-225-10-75);
   --search-result-highlight-color: var(--color-black);
-  --search-result-selected-color: var(--color-blue-205-100-45-opacity-30);
+  --search-result-selected-background-color: var(--color-blue-205-100-45-opacity-30);
+  --search-result-selected-border-color: var(--color-blue-205-100-45);
 
   --shape-attach-allowed-stroke-color: var(--color-blue-205-100-50);
   --shape-connect-allowed-fill-color: var(--color-grey-225-10-97);
@@ -971,7 +972,14 @@ svg.new-parent {
 }
 
 .djs-search-overlay {
-  background: var(--search-result-selected-color);
+  position: absolute;
+  top: -10px;
+  left: -10px;
+  right: -10px;
+  bottom: -10px;
+  border: solid 2px var(--search-result-selected-border-color);
+  background: var(--search-result-selected-background-color);
+  border-radius: 4px;
 }
 
 /**

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -533,7 +533,7 @@ svg.new-parent {
   width: 100%;
   box-sizing: border-box;
   font-size: var(--popup-font-size);
-  padding: 3px 6px;
+  padding: 3px 6px 3px 25px;
   border-radius: 2px;
   border: solid 1px var(--popup-search-border-color);
   line-height: 21px;
@@ -594,6 +594,8 @@ svg.new-parent {
 }
 
 .djs-popup-search {
+  position: relative;
+  width: auto;
   margin: 10px 12px;
 }
 
@@ -604,19 +606,10 @@ svg.new-parent {
   margin: 0;
 }
 
-.djs-popup-search {
-  position: relative;
-  width: auto;
-}
-
 .djs-popup-search-icon {
   position: absolute;
   left: 8px;
   top: 7px;
-}
-
-.djs-popup-search input {
-  padding-left: 25px;
 }
 
 .djs-popup-results {

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -83,8 +83,6 @@
   --search-input-focus-background-color: var(--color-blue-205-100-95);
   --search-result-hover-background-color: var(--color-grey-225-10-95);
   --search-result-secondary-color: var(--color-grey-225-10-55);
-  --search-result-selected-background-color: var(--color-blue-205-100-45-opacity-30);
-  --search-result-selected-border-color: var(--color-blue-205-100-45);
 
   --shape-attach-allowed-stroke-color: var(--color-blue-205-100-50);
   --shape-connect-allowed-fill-color: var(--color-grey-225-10-97);
@@ -885,6 +883,14 @@ svg.new-parent {
 /**
  * search pad
  */
+.djs-search-open .djs-context-pad {
+  display: none;
+}
+
+.djs-search-open .djs-connection.selected .djs-outline {
+  display: block;
+}
+
 .djs-search-container {
   position: absolute;
   top: 20px;
@@ -971,17 +977,6 @@ svg.new-parent {
 
 .djs-search-result-selected:hover {
   background: var(--search-result-hover-background-color);
-}
-
-.djs-search-overlay {
-  position: absolute;
-  top: -10px;
-  left: -10px;
-  right: -10px;
-  bottom: -10px;
-  border: solid 2px var(--search-result-selected-border-color);
-  background: var(--search-result-selected-background-color);
-  border-radius: 4px;
 }
 
 /**

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -951,11 +951,17 @@ svg.new-parent {
 
 .djs-search-result-primary {
   margin: 0 0 10px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .djs-search-result-secondary {
   font-family: monospace;
   margin: 0;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .djs-search-result:hover {

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -74,13 +74,15 @@
   --resizer-fill-color: var(--color-blue-205-100-45);
   --resizer-stroke-color: var(--canvas-fill-color);
 
-  --search-container-background-color: var(--color-grey-225-10-97);
-  --search-container-border-color: var(--color-blue-205-100-50);
-  --search-container-box-shadow-color: var(--color-blue-205-100-95);
-  --search-container-box-shadow-inset-color: var(--color-grey-225-10-80);
+  --search-font-family: "IBM Plex Sans", sans-serif;
+  --search-font-size: 14px;
+  --search-container-background-color: var(--color-white);
+  --search-shadow-color: var(--color-black-opacity-30);
   --search-input-border-color: var(--color-grey-225-10-75);
-  --search-result-border-color: var(--color-grey-225-10-75);
-  --search-result-highlight-color: var(--color-black);
+  --search-input-focus-border-color: var(--color-blue-205-100-50);
+  --search-input-focus-background-color: var(--color-blue-205-100-95);
+  --search-result-hover-background-color: var(--color-grey-225-10-95);
+  --search-result-secondary-color: var(--color-grey-225-10-55);
   --search-result-selected-background-color: var(--color-blue-205-100-45-opacity-30);
   --search-result-selected-border-color: var(--color-blue-205-100-45);
 
@@ -533,7 +535,7 @@ svg.new-parent {
   width: 100%;
   box-sizing: border-box;
   font-size: var(--popup-font-size);
-  padding: 3px 6px 3px 25px;
+  padding: 3px 6px 3px 28px;
   border-radius: 2px;
   border: solid 1px var(--popup-search-border-color);
   line-height: 21px;
@@ -896,54 +898,55 @@ svg.new-parent {
   max-width: 400px;
   z-index: 10;
 
-  font-size: 1.05em;
-  opacity: 0.9;
-  background: var(--search-container-background-color);
-  border: solid 1px var(--search-container-border-color);
+  font-family: var(--search-font-family);
+  font-size: var(--search-font-size);
   border-radius: 2px;
-  box-shadow: 0 0 0 2px var(--search-container-box-shadow-color), 0 0 0 1px var(--search-container-box-shadow-inset-color) inset;
+  box-shadow: 0px 2px 6px var(--search-shadow-color);
 }
 
 .djs-search-container:not(.open) {
   display: none;
 }
 
+.djs-search-input {
+  position: relative;
+}
+
+.djs-search-input svg {
+  position: absolute;
+  left: 8px;
+  top: 7px;
+}
+
 .djs-search-input input {
-  font-size: 1.05em;
+  font-size: var(--search-font-size);
   width: 100%;
-  padding: 6px 10px;
+  padding: 3px 6px 3px 28px;
   border: 1px solid var(--search-input-border-color);
+  border-radius: 2px;
   box-sizing: border-box;
+  line-height: 21px;
 }
 
 .djs-search-input input:focus {
+  background-color: var(--search-input-focus-background-color);
+  border: solid 1px var(--search-input-focus-border-color);
   outline: none;
-  border-color: var(--search-input-border-color);
 }
 
 .djs-search-results {
   position: relative;
   overflow-y: auto;
   max-height: 200px;
-}
-
-.djs-search-results:hover {
-  cursor: pointer;
+  background: var(--search-container-background-color);
 }
 
 .djs-search-result {
-  padding: 6px 10px;
-  background: white;
-  border-bottom: solid 1px var(--search-result-border-color);
-  border-radius: 1px;
-}
-
-.djs-search-highlight {
-  color: var(--search-result-highlight-color);
+  padding: 6px 8px;
 }
 
 .djs-search-result-primary {
-  margin: 0 0 10px;
+  margin: 0 0 3px;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -955,18 +958,19 @@ svg.new-parent {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+  color: var(--search-result-secondary-color);
 }
 
 .djs-search-result:hover {
-  background: var(--search-result-selected-color);
+  background: var(--search-result-hover-background-color);
 }
 
 .djs-search-result-selected {
-  background: var(--search-result-selected-color);
+  background: var(--search-result-hover-background-color);
 }
 
 .djs-search-result-selected:hover {
-  background: var(--search-result-selected-color);
+  background: var(--search-result-hover-background-color);
 }
 
 .djs-search-overlay {

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -939,7 +939,6 @@ svg.new-parent {
 }
 
 .djs-search-result {
-  width: 100%;
   padding: 6px 10px;
   background: white;
   border-bottom: solid 1px var(--search-result-border-color);

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -185,6 +185,10 @@ SearchPad.prototype._search = function(pattern) {
 
   var searchResults = this._searchProvider.find(pattern);
 
+  searchResults = searchResults.filter(function(searchResult) {
+    return !self._canvas.getRootElements().includes(searchResult.element);
+  });
+
   if (!searchResults.length) {
     return;
   }

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -56,8 +56,13 @@ export default function SearchPad(canvas, eventBus, selection, translate) {
   // attach search pad
   this._canvas.getContainer().appendChild(this._container);
 
-  // cleanup on destroy
-  eventBus.on([ 'canvas.destroy', 'diagram.destroy' ], this.close, this);
+  // cleanup whenever appropriate
+  eventBus.on([
+    'canvas.destroy',
+    'diagram.destroy',
+    'drag.init',
+    'elements.changed'
+  ], this.close, this);
 }
 
 

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -573,12 +573,15 @@ SearchPad.RESULT_HIGHLIGHT_CLASS = 'djs-search-highlight';
 SearchPad.OVERLAY_CLASS = 'djs-search-overlay';
 
 SearchPad.BOX_HTML =
-  '<div class="djs-search-container djs-scrollable">' +
-    '<div class="djs-search-input">' +
-      '<input type="text"/>' +
-    '</div>' +
-    '<div class="djs-search-results"></div>' +
-  '</div>';
+`<div class="djs-search-container djs-scrollable">
+  <div class="djs-search-input">
+    <svg class="djs-search-icon" width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path fill-rule="evenodd" clip-rule="evenodd" d="M9.0325 8.5H9.625L13.3675 12.25L12.25 13.3675L8.5 9.625V9.0325L8.2975 8.8225C7.4425 9.5575 6.3325 10 5.125 10C2.4325 10 0.25 7.8175 0.25 5.125C0.25 2.4325 2.4325 0.25 5.125 0.25C7.8175 0.25 10 2.4325 10 5.125C10 6.3325 9.5575 7.4425 8.8225 8.2975L9.0325 8.5ZM1.75 5.125C1.75 6.9925 3.2575 8.5 5.125 8.5C6.9925 8.5 8.5 6.9925 8.5 5.125C8.5 3.2575 6.9925 1.75 5.125 1.75C3.2575 1.75 1.75 3.2575 1.75 5.125Z" fill="#22242A"/>
+    </svg>
+    <input type="text" spellcheck="false" />
+  </div>
+  <div class="djs-search-results" />
+</div>`;
 
 SearchPad.RESULT_HTML =
   '<div class="djs-search-result"></div>';

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -483,7 +483,7 @@ function constructOverlay(box) {
     height: h + 'px'
   };
 
-  var html = domify('<div class="' + SearchPad.OVERLAY_CLASS + '"></div>');
+  var html = domify('<div><div class="' + SearchPad.OVERLAY_CLASS + '"></div></div>');
 
   assignStyle(html, styles);
 

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -573,7 +573,7 @@ SearchPad.RESULT_HIGHLIGHT_CLASS = 'djs-search-highlight';
 SearchPad.OVERLAY_CLASS = 'djs-search-overlay';
 
 SearchPad.BOX_HTML =
-  '<div class="djs-search-container djs-draggable djs-scrollable">' +
+  '<div class="djs-search-container djs-scrollable">' +
     '<div class="djs-search-input">' +
       '<input type="text"/>' +
     '</div>' +

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -48,6 +48,10 @@ export default function SearchPad(canvas, eventBus, overlays, selection, transla
   this._results = [];
   this._eventMaps = [];
 
+  this._cachedRootElement = null;
+  this._cachedSelection = null;
+  this._cachedViewbox = null;
+
   this._canvas = canvas;
   this._eventBus = eventBus;
   this._overlays = overlays;
@@ -328,6 +332,10 @@ SearchPad.prototype.open = function() {
     return;
   }
 
+  this._cachedRootElement = this._canvas.getRootElement();
+  this._cachedSelection = this._selection.get();
+  this._cachedViewbox = this._canvas.viewbox();
+
   this._bindEvents();
 
   this._open = true;
@@ -346,6 +354,18 @@ SearchPad.prototype.open = function() {
 SearchPad.prototype.close = function() {
   if (!this.isOpen()) {
     return;
+  }
+
+  if (this._cachedRootElement) {
+    this._canvas.setRootElement(this._cachedRootElement);
+  }
+
+  if (this._cachedSelection) {
+    this._selection.select(this._cachedSelection);
+  }
+
+  if (this._cachedViewbox) {
+    this._canvas.viewbox(this._cachedViewbox);
   }
 
   this._unbindEvents();
@@ -406,6 +426,7 @@ SearchPad.prototype._preselect = function(node) {
 
   this._resetOverlay(element);
 
+  this._canvas.zoom(1);
   this._canvas.scrollToElement(element, { top: 400 });
 
   this._selection.select(element);
@@ -422,6 +443,9 @@ SearchPad.prototype._preselect = function(node) {
 SearchPad.prototype._select = function(node) {
   var id = domAttr(node, SearchPad.RESULT_ID_ATTRIBUTE);
   var element = this._results[id].element;
+
+  this._cachedSelection = null;
+  this._cachedViewbox = null;
 
   this.close();
 

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -1,5 +1,4 @@
 import {
-  assignStyle,
   clear as domClear,
   delegate as domDelegate,
   query as domQuery,
@@ -7,10 +6,6 @@ import {
   attr as domAttr,
   domify as domify
 } from 'min-dom';
-
-import {
-  getBBox as getBoundingBox
-} from '../../util/Elements';
 
 import {
   escapeHTML
@@ -21,11 +16,8 @@ import { isKey } from '../keyboard/KeyboardUtil';
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/EventBus').default} EventBus
- * @typedef {import('../overlays/Overlays').default} Overlays
  * @typedef {import('../selection/Selection').default} Selection
  * @typedef {import('../../i18n/translate/translate.js').default} Translate
- *
- * @typedef {import('../overlays/Overlays').OverlayAttrs} OverlayAttrs
  *
  * @typedef {import('../../util/Types').Dimensions} Dimensions
  *
@@ -39,11 +31,10 @@ import { isKey } from '../keyboard/KeyboardUtil';
  *
  * @param {Canvas} canvas
  * @param {EventBus} eventBus
- * @param {Overlays} overlays
  * @param {Selection} selection
  * @param {Translate} translate
  */
-export default function SearchPad(canvas, eventBus, overlays, selection, translate) {
+export default function SearchPad(canvas, eventBus, selection, translate) {
   this._open = false;
   this._results = [];
   this._eventMaps = [];
@@ -54,7 +45,6 @@ export default function SearchPad(canvas, eventBus, overlays, selection, transla
 
   this._canvas = canvas;
   this._eventBus = eventBus;
-  this._overlays = overlays;
   this._selection = selection;
   this._translate = translate;
 
@@ -74,7 +64,6 @@ export default function SearchPad(canvas, eventBus, overlays, selection, transla
 SearchPad.$inject = [
   'canvas',
   'eventBus',
-  'overlays',
   'selection',
   'translate'
 ];
@@ -262,8 +251,6 @@ SearchPad.prototype._clearResults = function() {
 
   this._results = [];
 
-  this._resetOverlay();
-
   this._eventBus.fire('searchPad.cleared');
 };
 
@@ -340,6 +327,7 @@ SearchPad.prototype.open = function() {
 
   this._open = true;
 
+  domClasses(this._canvas.getContainer()).add('djs-search-open');
   domClasses(this._container).add('open');
 
   this._searchInput.focus();
@@ -372,14 +360,13 @@ SearchPad.prototype.close = function() {
 
   this._open = false;
 
+  domClasses(this._canvas.getContainer()).remove('djs-search-open');
   domClasses(this._container).remove('open');
 
   this._clearResults();
 
   this._searchInput.value = '';
   this._searchInput.blur();
-
-  this._resetOverlay();
 
   this._eventBus.fire('searchPad.closed');
 };
@@ -424,8 +411,6 @@ SearchPad.prototype._preselect = function(node) {
 
   domClasses(node).add(SearchPad.RESULT_SELECTED_CLASS);
 
-  this._resetOverlay(element);
-
   this._canvas.zoom(1);
   this._canvas.scrollToElement(element, { top: 400 });
 
@@ -449,8 +434,6 @@ SearchPad.prototype._select = function(node) {
 
   this.close();
 
-  this._resetOverlay();
-
   this._canvas.scrollToElement(element, { top: 400 });
 
   this._selection.select(element);
@@ -458,24 +441,6 @@ SearchPad.prototype._select = function(node) {
   this._eventBus.fire('searchPad.selected', element);
 };
 
-
-/**
- * Reset overlay removes and, optionally, set
- * overlay to a new element.
- *
- * @param {HTMLElement} element
- */
-SearchPad.prototype._resetOverlay = function(element) {
-  if (this._overlayId) {
-    this._overlays.remove(this._overlayId);
-  }
-
-  if (element) {
-    var box = getBoundingBox(element);
-    var overlay = constructOverlay(box);
-    this._overlayId = this._overlays.add(element, overlay);
-  }
-};
 
 SearchPad.prototype._getBoxHtml = function() {
   const box = domify(SearchPad.BOX_HTML);
@@ -487,39 +452,6 @@ SearchPad.prototype._getBoxHtml = function() {
 
   return box;
 };
-
-
-/**
- * Construct overlay object for the given bounding box.
- *
- * @param {Dimensions} box
- *
- * @return {OverlayAttrs}
- */
-function constructOverlay(box) {
-
-  var offset = 6;
-  var w = box.width + offset * 2;
-  var h = box.height + offset * 2;
-
-  var styles = {
-    width: w + 'px',
-    height: h + 'px'
-  };
-
-  var html = domify('<div><div class="' + SearchPad.OVERLAY_CLASS + '"></div></div>');
-
-  assignStyle(html, styles);
-
-  return {
-    position: {
-      bottom: h - offset,
-      right: w - offset
-    },
-    show: true,
-    html: html
-  };
-}
 
 
 /**
@@ -570,7 +502,6 @@ SearchPad.RESULT_SELECTED_CLASS = 'djs-search-result-selected';
 SearchPad.RESULT_SELECTED_SELECTOR = '.' + SearchPad.RESULT_SELECTED_CLASS;
 SearchPad.RESULT_ID_ATTRIBUTE = 'data-result-id';
 SearchPad.RESULT_HIGHLIGHT_CLASS = 'djs-search-highlight';
-SearchPad.OVERLAY_CLASS = 'djs-search-overlay';
 
 SearchPad.BOX_HTML =
 `<div class="djs-search-container djs-scrollable">

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -549,7 +549,7 @@ function createHtmlText(tokens) {
 
   tokens.forEach(function(t) {
     if (t.matched) {
-      htmlText += '<strong class="' + SearchPad.RESULT_HIGHLIGHT_CLASS + '">' + escapeHTML(t.matched) + '</strong>';
+      htmlText += '<b class="' + SearchPad.RESULT_HIGHLIGHT_CLASS + '">' + escapeHTML(t.matched) + '</b>';
     } else {
       htmlText += escapeHTML(t.normal);
     }

--- a/lib/features/search-pad/SearchPadProvider.ts
+++ b/lib/features/search-pad/SearchPadProvider.ts
@@ -1,8 +1,8 @@
 import type { Element } from '../../model/Types';
 
 export type Token = {
-  matched: string;
-  normal: string;
+  matched?: string;
+  normal?: string;
 };
 
 export type SearchResult = {

--- a/test/spec/features/search-pad/SearchPadSpec.js
+++ b/test/spec/features/search-pad/SearchPadSpec.js
@@ -278,6 +278,17 @@ describe('features/searchPad', function() {
     });
 
 
+    it('should not display root elements', inject(function(canvas) {
+
+      // when
+      typeText(input_node, 'root');
+
+      // then
+      var result_nodes = domQueryAll(SearchPad.RESULT_SELECTOR, canvas.getContainer());
+      expect(result_nodes).length(0);
+    }));
+
+
     it('should display results', inject(function(canvas) {
 
       // given

--- a/test/spec/features/search-pad/SearchPadSpec.js
+++ b/test/spec/features/search-pad/SearchPadSpec.js
@@ -207,6 +207,34 @@ describe('features/searchPad', function() {
   }));
 
 
+  it('should close on <drag.init>', inject(function(eventBus, searchPad) {
+
+    // given
+    searchPad.open();
+
+    // when
+    eventBus.fire('drag.init');
+
+    // then
+    expect(searchPad.isOpen()).to.equal(false);
+    expect(capturedEvents).to.eql([ EVENTS.opened, EVENTS.closed ]);
+  }));
+
+
+  it('should close on <elements.changed>', inject(function(eventBus, searchPad) {
+
+    // given
+    searchPad.open();
+
+    // when
+    eventBus.fire('elements.changed');
+
+    // then
+    expect(searchPad.isOpen()).to.equal(false);
+    expect(capturedEvents).to.eql([ EVENTS.opened, EVENTS.closed ]);
+  }));
+
+
   it('should toggle open/close', inject(function(searchPad) {
 
     // when

--- a/test/spec/features/search-pad/SearchPadSpec.js
+++ b/test/spec/features/search-pad/SearchPadSpec.js
@@ -36,15 +36,15 @@ describe('features/searchPad', function() {
 
   beforeEach(inject(function(searchPad, eventBus, canvas) {
 
-    canvas.setRootElement({ id: 'FOO' });
+    canvas.setRootElement({ id: 'root' });
 
     elements = {
       one: {
-        a: canvas.addShape({ id: 'one-a', x: 0, y: 0, width: 100, height: 80 })
+        a: canvas.addShape({ id: 'one-a', x: 0, y: 0, width: 100, height: 100 })
       },
       two: {
-        a: canvas.addShape({ id: 'two-a', x: 0, y: 0, width: 100, height: 80 }),
-        b: canvas.addShape({ id: 'two-b', x: 0, y: 0, width: 100, height: 80 })
+        a: canvas.addShape({ id: 'two-a', x: 200, y: 0, width: 100, height: 100 }),
+        b: canvas.addShape({ id: 'two-b', x: 400, y: 0, width: 100, height: 100 })
       }
     };
 
@@ -63,12 +63,13 @@ describe('features/searchPad', function() {
         if (pattern === 'one') {
           return [ {
             primaryTokens: [
-              { normal: 'one' }
+              { matched: 'One' },
+              { normal: ' A' }
             ],
             secondaryTokens: [
-              { normal: 'some_' },
-              { matched: 'DataStore' },
-              { normal: '_123456_id' }
+              { normal: 'Shape_' },
+              { matched: 'one' },
+              { normal: '-a' }
             ],
             element: elements.one.a
           } ];
@@ -77,22 +78,24 @@ describe('features/searchPad', function() {
         if (pattern === 'two') {
           return [ {
             primaryTokens: [
-              { normal: 'one' }
+              { matched: 'Two' },
+              { normal: ' A' }
             ],
             secondaryTokens: [
-              { normal: 'some_' },
-              { matched: 'DataStore' },
-              { normal: '_123456_id' }
+              { normal: 'Shape_' },
+              { matched: 'two' },
+              { normal: '-a' }
             ],
             element: elements.two.a
           },{
             primaryTokens: [
-              { normal: 'two' }
+              { matched: 'Two' },
+              { normal: ' B' }
             ],
             secondaryTokens: [
-              { normal: 'some_' },
-              { matched: 'DataStore' },
-              { normal: '_123456_id' }
+              { normal: 'Shape_' },
+              { matched: 'two' },
+              { normal: '-b' }
             ],
             element: elements.two.b
           } ];

--- a/test/spec/features/search-pad/SearchPadSpec.js
+++ b/test/spec/features/search-pad/SearchPadSpec.js
@@ -133,14 +133,14 @@ describe('features/searchPad', function() {
   }));
 
 
-  it('should be closed by default', inject(function(canvas, eventBus, searchPad) {
+  it('should be closed by default', inject(function(searchPad) {
 
     // then
     expect(searchPad.isOpen()).to.equal(false);
   }));
 
 
-  it('should open', inject(function(canvas, eventBus, searchPad) {
+  it('should open', inject(function(searchPad) {
 
     // when
     searchPad.open();
@@ -151,7 +151,7 @@ describe('features/searchPad', function() {
   }));
 
 
-  it('should error on open when provider not registered', inject(function(canvas, eventBus, searchPad) {
+  it('should error on open when provider not registered', inject(function(searchPad) {
 
     // given
     searchPad.registerProvider(undefined);
@@ -167,7 +167,7 @@ describe('features/searchPad', function() {
   }));
 
 
-  it('should close', inject(function(canvas, eventBus, searchPad) {
+  it('should close', inject(function(searchPad) {
 
     // given
     searchPad.open();
@@ -181,7 +181,7 @@ describe('features/searchPad', function() {
   }));
 
 
-  it('should toggle open/close', inject(function(canvas, eventBus, searchPad) {
+  it('should toggle open/close', inject(function(searchPad) {
 
     // when
     searchPad.toggle();
@@ -204,7 +204,7 @@ describe('features/searchPad', function() {
 
     var element;
 
-    beforeEach(inject(function(searchPad, eventBus) {
+    beforeEach(inject(function(searchPad) {
 
       // given
       element = searchProvider.find('one')[0].element;
@@ -212,7 +212,7 @@ describe('features/searchPad', function() {
     }));
 
 
-    it('should not search on empty string', inject(function(canvas, eventBus, searchPad) {
+    it('should not search on empty string', function() {
 
       // given
       var find = sinon.spy(searchProvider, 'find');
@@ -222,10 +222,10 @@ describe('features/searchPad', function() {
 
       // then
       expect(find).callCount(0);
-    }));
+    });
 
 
-    it('should display results', inject(function(canvas, eventBus, searchPad) {
+    it('should display results', inject(function(canvas) {
 
       // given
       var find = sinon.spy(searchProvider, 'find');
@@ -240,7 +240,7 @@ describe('features/searchPad', function() {
     }));
 
 
-    it('should escape displayed results', inject(function(canvas, eventBus, searchPad) {
+    it('should escape displayed results', inject(function(canvas) {
 
       // when
       typeText(input_node, 'html');
@@ -253,7 +253,7 @@ describe('features/searchPad', function() {
     }));
 
 
-    it('should preselect first result', inject(function(canvas, eventBus, searchPad) {
+    it('should preselect first result', inject(function(canvas) {
 
       // when
       typeText(input_node, 'two');
@@ -265,7 +265,7 @@ describe('features/searchPad', function() {
     }));
 
 
-    it('should select result on enter', inject(function(canvas, eventBus, searchPad) {
+    it('should select result on enter', function() {
 
       // given
       typeText(input_node, 'two');
@@ -280,10 +280,10 @@ describe('features/searchPad', function() {
         EVENTS.closed,
         EVENTS.selected
       ]);
-    }));
+    });
 
 
-    it('should set overlay on an highlighted element', inject(function(searchPad, overlays) {
+    it('should set overlay on an highlighted element', inject(function(overlays) {
 
       // when
       typeText(input_node, 'one');
@@ -294,7 +294,7 @@ describe('features/searchPad', function() {
     }));
 
 
-    it('should remove overlay from an element on enter', inject(function(searchPad, overlays) {
+    it('should remove overlay from an element on enter', inject(function(overlays) {
 
       // given
       typeText(input_node, 'one');
@@ -308,7 +308,7 @@ describe('features/searchPad', function() {
     }));
 
 
-    it('select should scroll element into view', inject(function(searchPad, canvas) {
+    it('select should scroll element into view', inject(function(canvas) {
 
       // given
       typeText(input_node, 'one');
@@ -334,7 +334,7 @@ describe('features/searchPad', function() {
     }));
 
 
-    it('select should keep zoom level', inject(function(searchPad, canvas) {
+    it('select should keep zoom level', inject(function(canvas) {
 
       // given
       canvas.zoom(0.4);
@@ -350,7 +350,7 @@ describe('features/searchPad', function() {
     }));
 
 
-    it('select should apply selection on an element', inject(function(searchPad, selection) {
+    it('select should apply selection on an element', inject(function(selection) {
 
       // given
       typeText(input_node, 'one');
@@ -363,7 +363,7 @@ describe('features/searchPad', function() {
     }));
 
 
-    it('should close on escape', inject(function(canvas, eventBus, searchPad) {
+    it('should close on escape', inject(function(searchPad) {
 
       // when
       triggerKeyEvent(input_node, 'keyup', 'Escape');
@@ -374,7 +374,7 @@ describe('features/searchPad', function() {
     }));
 
 
-    it('should preselect next/previus results on arrow down/up', inject(function(canvas, eventBus, searchPad) {
+    it('should preselect next/previus results on arrow down/up', inject(function(canvas) {
 
       // given
       typeText(input_node, 'two');
@@ -403,7 +403,7 @@ describe('features/searchPad', function() {
     }));
 
 
-    it('should not move input cursor on arrow down', inject(function(canvas, eventBus, searchPad) {
+    it('should not move input cursor on arrow down', function() {
 
       // given
       typeText(input_node, 'two');
@@ -411,10 +411,10 @@ describe('features/searchPad', function() {
       // when press 'down'
       var e = triggerKeyEvent(input_node, 'keydown', 'ArrowDown');
       expect(e.defaultPrevented).to.be.true;
-    }));
+    });
 
 
-    it('should not move input cursor on arrow up', inject(function(canvas, eventBus, searchPad) {
+    it('should not move input cursor on arrow up', function() {
 
       // given
       typeText(input_node, 'two');
@@ -422,10 +422,10 @@ describe('features/searchPad', function() {
       // when press 'up'
       var e = triggerKeyEvent(input_node, 'keydown', 'ArrowUp');
       expect(e.defaultPrevented).to.be.true;
-    }));
+    });
 
 
-    it('should not search while navigating text in input box left', inject(function(canvas, eventBus, searchPad) {
+    it('should not search while navigating text in input box left', function() {
 
       // given
       var find = sinon.spy(searchProvider, 'find');
@@ -436,10 +436,10 @@ describe('features/searchPad', function() {
 
       // then
       expect(find).callCount('two'.length);
-    }));
+    });
 
 
-    it('should not search while navigating text in input box right', inject(function(canvas, eventBus, searchPad) {
+    it('should not search while navigating text in input box right', function() {
 
       // given
       var find = sinon.spy(searchProvider, 'find');
@@ -450,7 +450,7 @@ describe('features/searchPad', function() {
 
       // then
       expect(find).callCount('two'.length);
-    }));
+    });
 
   });
 

--- a/test/spec/features/search-pad/SearchPadSpec.js
+++ b/test/spec/features/search-pad/SearchPadSpec.js
@@ -325,31 +325,6 @@ describe('features/searchPad', function() {
     }));
 
 
-    it('should set overlay on an highlighted element', inject(function(overlays) {
-
-      // when
-      typeText(input_node, 'one');
-
-      // then
-      var overlay = overlays.get({ element: elements.one.a });
-      expect(overlay).length(1);
-    }));
-
-
-    it('should remove overlay from an element on enter', inject(function(overlays) {
-
-      // given
-      typeText(input_node, 'one');
-
-      // when
-      triggerKeyEvent(input_node, 'keyup', 'Enter');
-
-      // then
-      var overlay = overlays.get({ element: elements.one.a });
-      expect(overlay).length(0);
-    }));
-
-
     it('select should scroll element into view', inject(function(canvas) {
 
       // given


### PR DESCRIPTION
Improves search by

* treating search as truly intermediate (root element, selection and viewbox reset on escape without click or enter)
* aligning styles with other popups
* simplifying selection visuals when "pre-selecting" elements before selecting (click or enter)
  * simply use existing outline
  * don't show context pad during pre-select

![brave_MvTovcBG1j](https://github.com/bpmn-io/diagram-js/assets/7633572/f2b69c2b-880e-4ecf-91f2-e10dc09221b2)

Related to https://github.com/bpmn-io/bpmn-js/pull/2187