### PR TITLE
fix(context-pad): only update visibility once per frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+* `FEAT`: add `scheduler` service ([#915](https://github.com/bpmn-io/diagram-js/pull/915))
+* `CHORE`: update `contextPad` visibility only once per frame ([#https://github.com/bpmn-io/diagram-js/pull/915](https://github.com/bpmn-io/diagram-js/pull/915))
 * `CHORE`: do not query DOM for `Canvas#hasMarker` check ([919](https://github.com/bpmn-io/diagram-js/pull/919))
 
 ## 14.7.2

--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -31,6 +31,7 @@ var MARKER_HIDDEN = 'djs-element-hidden';
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/ElementRegistry').default} ElementRegistry
  * @typedef {import('../../core/EventBus').default} EventBus
+ * @typedef {import('../../scheduler/Scheduler').default} Scheduler
  *
  * @typedef {import('./ContextPadProvider').default} ContextPadProvider
  * @typedef {import('./ContextPadProvider').ContextPadEntries} ContextPadEntries
@@ -56,12 +57,14 @@ var HOVER_DELAY = 300;
  * @param {Canvas} canvas
  * @param {ElementRegistry} elementRegistry
  * @param {EventBus} eventBus
+ * @param {Scheduler} scheduler
  */
-export default function ContextPad(canvas, elementRegistry, eventBus) {
+export default function ContextPad(canvas, elementRegistry, eventBus, scheduler) {
 
   this._canvas = canvas;
   this._elementRegistry = elementRegistry;
   this._eventBus = eventBus;
+  this._scheduler = scheduler;
 
   this._current = null;
 
@@ -71,7 +74,8 @@ export default function ContextPad(canvas, elementRegistry, eventBus) {
 ContextPad.$inject = [
   'canvas',
   'elementRegistry',
-  'eventBus'
+  'eventBus',
+  'scheduler'
 ];
 
 
@@ -637,25 +641,30 @@ ContextPad.prototype._updatePosition = function() {
  * using the `djs-element-hidden` or `djs-label-hidden` markers.
  */
 ContextPad.prototype._updateVisibility = function() {
-  if (!this.isOpen()) {
-    return;
-  }
 
-  var self = this;
+  const updateFn = () => {
+    if (!this.isOpen()) {
+      return;
+    }
 
-  var target = this._current.target;
+    var self = this;
 
-  var targets = isArray(target) ? target : [ target ];
+    var target = this._current.target;
 
-  var isHidden = targets.some(function(target) {
-    return self._canvas.hasMarker(target, MARKER_HIDDEN);
-  });
+    var targets = isArray(target) ? target : [ target ];
 
-  if (isHidden) {
-    self.hide();
-  } else {
-    self.show();
-  }
+    var isHidden = targets.some(function(target) {
+      return self._canvas.hasMarker(target, MARKER_HIDDEN);
+    });
+
+    if (isHidden) {
+      self.hide();
+    } else {
+      self.show();
+    }
+  };
+
+  this._scheduler.schedule(updateFn, 'ContextPad#_updateVisibility');
 };
 
 /**

--- a/lib/features/context-pad/index.js
+++ b/lib/features/context-pad/index.js
@@ -1,5 +1,6 @@
 import InteractionEventsModule from '../interaction-events';
 import OverlaysModule from '../overlays';
+import SchedulerModule from '../scheduler';
 
 import ContextPad from './ContextPad';
 
@@ -10,6 +11,7 @@ import ContextPad from './ContextPad';
 export default {
   __depends__: [
     InteractionEventsModule,
+    SchedulerModule,
     OverlaysModule
   ],
   contextPad: [ 'type', ContextPad ]

--- a/lib/features/scheduler/Scheduler.js
+++ b/lib/features/scheduler/Scheduler.js
@@ -1,0 +1,124 @@
+import IdGenerator from '../../util/IdGenerator';
+
+const Ids = new IdGenerator();
+
+
+/**
+ * @typedef { {
+ *   promise: Promise<unknown>,
+ *   executionId: number
+ * } } ScheduledTask
+ */
+
+/**
+ * A utility that allows you to schedule async tasks.
+ *
+ * @class
+ * @constructor
+ *
+ * @param { import('../core/EventBus').default } eventBus
+ */
+export default function Scheduler(eventBus) {
+
+  /**
+   * @type { Record<string, ScheduledTask> }
+   */
+  this._scheduled = {};
+
+  eventBus.on('diagram.destroy', () => {
+    Object.keys(this._scheduled).forEach(id => {
+      this.cancel(id);
+    });
+  });
+}
+
+Scheduler.$inject = [ 'eventBus' ];
+
+/**
+ * Schedule execution of a task in the next tick.
+ *
+ * Call with an id to ensure only the latest call will be executed.
+ *
+ * @template T
+
+ * @param {(...args: any[]) => T} taskFn function to be executed
+ * @param {string} [id] identifying the task to ensure uniqueness
+ *
+ * @return Promise<T> result of the executed task
+ */
+Scheduler.prototype.schedule = function(taskFn, id = Ids.next()) {
+
+  this.cancel(id);
+
+  const newScheduled = this._schedule(taskFn, id);
+
+  this._scheduled[id] = newScheduled;
+
+  return newScheduled.promise;
+};
+
+Scheduler.prototype._schedule = function(taskFn, id) {
+
+  const {
+    promise,
+    resolve,
+    reject
+  } = defer();
+
+  const executionId = requestAnimationFrame(() => {
+    try {
+      resolve(taskFn());
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+  return {
+    executionId,
+    promise
+  };
+};
+
+/**
+ * Cancel a previously scheduled task.
+ *
+ * @param {string} id
+ */
+Scheduler.prototype.cancel = function(id) {
+
+  const scheduled = this._scheduled[id];
+
+  if (scheduled) {
+    this._cancel(scheduled);
+
+    this._scheduled[id] = null;
+  }
+};
+
+Scheduler.prototype._cancel = function(scheduled) {
+  cancelAnimationFrame(scheduled.executionId);
+};
+
+/**
+ * @return { {
+ *   promise: Promise,
+ *   resolve: Function,
+ *   reject: Function
+ * } }
+ */
+function defer() {
+
+  let resolve;
+  let reject;
+
+  const promise = new Promise((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  });
+
+  return {
+    promise,
+    resolve,
+    reject
+  };
+}

--- a/lib/features/scheduler/index.js
+++ b/lib/features/scheduler/index.js
@@ -1,0 +1,5 @@
+import Scheduler from './Scheduler';
+
+export default {
+  scheduler: [ 'type', Scheduler ]
+};

--- a/test/spec/features/scheduler/SchedulerSpec.js
+++ b/test/spec/features/scheduler/SchedulerSpec.js
@@ -1,0 +1,138 @@
+import schedulerModule from 'lib/features/scheduler';
+
+import {
+  bootstrapDiagram,
+  getDiagramJS,
+  inject
+} from 'test/TestHelper';
+
+
+describe('features/scheduler', function() {
+
+  beforeEach(bootstrapDiagram({
+    modules: [ schedulerModule ]
+  }));
+
+
+  it('should schedule task', inject(async function(scheduler) {
+
+    // given
+    const fn = sinon.spy();
+
+    // when
+    const promise = scheduler.schedule(fn);
+
+    // assume
+    expect(fn).not.to.have.been.called;
+
+    // when
+    await promise;
+
+    // then
+    expect(fn).to.have.been.calledOnce;
+  }));
+
+
+  it('should cancel task', inject(async function(scheduler) {
+
+    // given
+    const fn = sinon.spy();
+
+    const promise = scheduler.schedule(fn, 'myId');
+
+    // when
+    scheduler.cancel('myId');
+
+    await Promise.race([
+      wait(200),
+      promise
+    ]);
+
+    // then
+    expect(fn).not.to.have.been.called;
+  }));
+
+
+  describe('execution behavior', function() {
+
+    it('should only execute latest task', inject(async function(scheduler) {
+
+      // given
+      const fn = sinon.spy();
+      const fn2 = sinon.spy();
+
+      // when
+      await Promise.race([
+        scheduler.schedule(fn, 'myId'),
+        scheduler.schedule(fn2, 'myId')
+      ]);
+
+      // then
+      expect(fn).not.to.have.been.called;
+      expect(fn2).to.have.been.calledOnce;
+    }));
+
+
+    it('should return task result', inject(async function(scheduler) {
+
+      // given
+      const fn = () => 10;
+
+      // when
+      const result = await scheduler.schedule(fn);
+
+      // then
+      expect(result).to.eql(10);
+    }));
+
+
+    it('should catch task error', inject(async function(scheduler) {
+
+      // given
+      const fn = () => {
+        throw new Error('expected error');
+      };
+
+      let error;
+
+      // when
+      try {
+        await scheduler.schedule(fn);
+      } catch (_error) {
+        error = _error;
+      }
+
+      // then
+      expect(error).to.exist;
+      expect(error.message).to.match(/expected error/);
+    }));
+
+
+    it('should cancel when diagram is destroyed', inject(
+      async function(scheduler) {
+
+        // given
+        const fn = sinon.spy();
+        const promise = scheduler.schedule(fn);
+
+        // when
+        getDiagramJS().destroy();
+
+        await Promise.race([
+          wait(200),
+          promise
+        ]);
+
+        // then
+        expect(fn).not.to.have.been.called;
+      }
+    ));
+
+  });
+
+});
+
+
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Significantly improves deselection performance

related to https://github.com/camunda/camunda-modeler/issues/4335
![Recording 2024-06-05 at 15 06 13](https://github.com/bpmn-io/diagram-js/assets/21984219/a4cee69d-bf54-4de1-9fe9-eebd6242a236)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
