### PR TITLE
Do not query DOM for `Canvas#hasMarker` check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+* `CHORE`: do not query DOM for `Canvas#hasMarker` check ([919](https://github.com/bpmn-io/diagram-js/pull/919))
+
 ## 14.7.2
 
 * `FIX`: remove incorrect attribute in popup menu item ([#918](https://github.com/bpmn-io/diagram-js/pull/918))

--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -561,6 +561,8 @@ Canvas.prototype._updateMarker = function(element, marker, add) {
     element = this._elementRegistry.get(element);
   }
 
+  element.markers = element.markers || new Set();
+
   // we need to access all
   container = this._elementRegistry._elements[element.id];
 
@@ -573,8 +575,10 @@ Canvas.prototype._updateMarker = function(element, marker, add) {
 
       // invoke either addClass or removeClass based on mode
       if (add) {
+        element.markers.add(marker);
         svgClasses(gfx).add(marker);
       } else {
+        element.markers.delete(marker);
         svgClasses(gfx).remove(marker);
       }
     }
@@ -642,9 +646,11 @@ Canvas.prototype.hasMarker = function(element, marker) {
     element = this._elementRegistry.get(element);
   }
 
-  const gfx = this.getGraphics(element);
+  if (!element.markers) {
+    return false;
+  }
 
-  return svgClasses(gfx).has(marker);
+  return element.markers.has(marker);
 };
 
 /**


### PR DESCRIPTION
### Proposed Changes

As implemented by @marstamm and discussed in https://github.com/bpmn-io/diagram-js/pull/915#issuecomment-2183924816 we want marker querying to not be a DOM operation (costly).

Related to https://github.com/camunda/camunda-modeler/issues/4335

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
