### PR TITLE
chore(context-pad): update position once per frame

### DIFF
--- a/lib/features/context-pad/ContextPad.js
+++ b/lib/features/context-pad/ContextPad.js
@@ -611,29 +611,34 @@ ContextPad.prototype._getPosition = function(target) {
  * Update context pad position.
  */
 ContextPad.prototype._updatePosition = function() {
-  if (!this.isOpen()) {
-    return;
-  }
 
-  var html = this._current.html;
+  const updateFn = () => {
+    if (!this.isOpen()) {
+      return;
+    }
 
-  var position = this._getPosition(this._current.target);
+    var html = this._current.html;
 
-  if ('x' in position && 'y' in position) {
-    html.style.left = position.x + 'px';
-    html.style.top = position.y + 'px';
-  } else {
-    [
-      'top',
-      'right',
-      'bottom',
-      'left'
-    ].forEach(function(key) {
-      if (key in position) {
-        html.style[ key ] = position[ key ] + 'px';
-      }
-    });
-  }
+    var position = this._getPosition(this._current.target);
+
+    if ('x' in position && 'y' in position) {
+      html.style.left = position.x + 'px';
+      html.style.top = position.y + 'px';
+    } else {
+      [
+        'top',
+        'right',
+        'bottom',
+        'left'
+      ].forEach(function(key) {
+        if (key in position) {
+          html.style[ key ] = position[ key ] + 'px';
+        }
+      });
+    }
+  };
+
+  this._scheduler.schedule(updateFn, 'ContextPad#_updatePosition');
 };
 
 /**


### PR DESCRIPTION
### Proposed Changes

As shown in this flame graph, in a huge diagram, we spend substantial amount of time to re-compute canvas viewport (after select) and determine context pad position (to update it):

![capture GJzwNS_optimized](https://github.com/bpmn-io/diagram-js/assets/58601/e69e5c89-18a5-4a1c-b107-e5a8bf3b59b3)

All this happens within the user transaction, and blocks UI interactivity.

With this PR we batch position updates as we batch visibility updates; we'll otherwise force the browser into expensive in-frame repaints:

![image](https://github.com/bpmn-io/diagram-js/assets/58601/191e7493-0872-41d9-9eaf-d977dd384e3c)


Related to https://github.com/bpmn-io/diagram-js/pull/915, https://github.com/camunda/camunda-modeler/issues/4335.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
