### PR TITLE
chore: add "type" symbol to typescript imports to make package compatible with 'verbatimModuleSyntax'

### DIFF
--- a/lib/command/CommandHandler.ts
+++ b/lib/command/CommandHandler.ts
@@ -1,12 +1,11 @@
-import { ElementLike } from "../core/Types";
-import { CommandContext } from "./CommandStack";
+import type { ElementLike } from '../core/Types';
+import type { CommandContext } from './CommandStack';
 
 /**
  * A command handler that may be registered via
  * {@link CommandStack#registerHandler}.
  */
 export default interface CommandHandler {
-
   /**
    * Execute changes described in the passed action context.
    *

--- a/lib/draw/DefaultRenderer.spec.ts
+++ b/lib/draw/DefaultRenderer.spec.ts
@@ -1,9 +1,9 @@
-import Diagram from "../Diagram";
+import Diagram from '../Diagram';
 
-import DefaultRenderer from "./DefaultRenderer";
+import DefaultRenderer from './DefaultRenderer';
 
-import ElementFactory from "../core/ElementFactory";
-import GraphicsFactory from "../core/GraphicsFactory";
+import ElementFactory from '../core/ElementFactory';
+import GraphicsFactory from '../core/GraphicsFactory';
 
 const diagram = new Diagram();
 

--- a/lib/features/context-pad/ContextPadProvider.ts
+++ b/lib/features/context-pad/ContextPadProvider.ts
@@ -1,11 +1,17 @@
-import { Element } from '../../model/Types';
+import type { Element } from '../../model/Types';
 
-import { ContextPadTarget } from './ContextPad';
+import type { ContextPadTarget } from './ContextPad';
 
-export type ContextPadEntryAction<ElementType extends Element = Element> = (event: Event, target: ContextPadTarget<ElementType>, autoActivate: boolean) => any;
+export type ContextPadEntryAction<ElementType extends Element = Element> = (
+  event: Event,
+  target: ContextPadTarget<ElementType>,
+  autoActivate: boolean
+) => any;
 
 export type ContextPadEntry<ElementType extends Element = Element> = {
-  action: Record<string, ContextPadEntryAction<ElementType>> | ContextPadEntryAction<ElementType>;
+  action:
+    | Record<string, ContextPadEntryAction<ElementType>>
+    | ContextPadEntryAction<ElementType>;
   className?: string;
   group?: string;
   html?: string;
@@ -13,15 +19,21 @@ export type ContextPadEntry<ElementType extends Element = Element> = {
   title?: string;
 };
 
-export type ContextPadEntries<ElementType extends Element = Element> = Record<string, ContextPadEntry<ElementType>>;
+export type ContextPadEntries<ElementType extends Element = Element> = Record<
+  string,
+  ContextPadEntry<ElementType>
+>;
 
-export type ContextPadEntriesCallback<ElementType extends Element = Element> = (entries: ContextPadEntries<ElementType>) => ContextPadEntries<ElementType>;
+export type ContextPadEntriesCallback<ElementType extends Element = Element> = (
+  entries: ContextPadEntries<ElementType>
+) => ContextPadEntries<ElementType>;
 
 /**
  * An interface to be implemented by a context menu provider.
  */
-export default interface ContextPadProvider<ElementType extends Element = Element> {
-
+export default interface ContextPadProvider<
+  ElementType extends Element = Element
+> {
   /**
    * Returns a map of entries or a function that receives, modifies and returns
    * a map of entries for one element.
@@ -50,7 +62,9 @@ export default interface ContextPadProvider<ElementType extends Element = Elemen
    *
    * @param element
    */
-  getContextPadEntries?: (element: ElementType) => ContextPadEntriesCallback<ElementType> | ContextPadEntries<ElementType>;
+  getContextPadEntries?: (
+    element: ElementType
+  ) => ContextPadEntriesCallback<ElementType> | ContextPadEntries<ElementType>;
 
   /**
    * Returns a map of entries or a function that receives, modifies and returns
@@ -79,5 +93,7 @@ export default interface ContextPadProvider<ElementType extends Element = Elemen
    *
    * @param elements
    */
-  getMultiElementContextPadEntries?: (elements: ElementType[]) => ContextPadEntriesCallback<ElementType> | ContextPadEntries<ElementType>;
+  getMultiElementContextPadEntries?: (
+    elements: ElementType[]
+  ) => ContextPadEntriesCallback<ElementType> | ContextPadEntries<ElementType>;
 }

--- a/lib/features/outline/OutlineProvider.ts
+++ b/lib/features/outline/OutlineProvider.ts
@@ -1,4 +1,4 @@
-import { Element } from '../../model/Types';
+import type { Element } from '../../model/Types';
 
 export type Outline = SVGSVGElement | SVGCircleElement | SVGRectElement;
 
@@ -6,7 +6,6 @@ export type Outline = SVGSVGElement | SVGCircleElement | SVGRectElement;
  * An interface to be implemented by an outline provider.
  */
 export default interface OutlineProvider {
-
   /**
    * Returns outline shape for given element.
    *
@@ -49,13 +48,13 @@ export default interface OutlineProvider {
    *  } else if (element.type === 'Bar') {
    *    return true;
    *  }
-   * 
+   *
    *  return false;
    * }
    * ```
-   * 
+   *
    * @param element
    * @param outline
-  */
+   */
   updateOutline: (element: Element, outline: Outline) => boolean;
 }

--- a/lib/features/popup-menu/PopupMenuProvider.ts
+++ b/lib/features/popup-menu/PopupMenuProvider.ts
@@ -1,8 +1,12 @@
-import { VNode } from '@bpmn-io/diagram-js-ui';
+import type { VNode } from '@bpmn-io/diagram-js-ui';
 
-import { PopupMenuTarget } from './PopupMenu';
+import type { PopupMenuTarget } from './PopupMenu';
 
-export type PopupMenuEntryAction = (event: Event, entry: PopupMenuEntry, action?: string) => any;
+export type PopupMenuEntryAction = (
+  event: Event,
+  entry: PopupMenuEntry,
+  action?: string
+) => any;
 
 export type PopupMenuEntry = {
   action: PopupMenuEntryAction;
@@ -15,9 +19,15 @@ export type PopupMenuEntry = {
 
 export type PopupMenuEntries = Record<string, PopupMenuEntry>;
 
-export type PopupMenuEntriesProvider = (entries: PopupMenuEntries) => PopupMenuEntries;
+export type PopupMenuEntriesProvider = (
+  entries: PopupMenuEntries
+) => PopupMenuEntries;
 
-export type PopupMenuHeaderEntryAction = (event: Event, entry: PopupMenuHeaderEntry, action?: string) => any;
+export type PopupMenuHeaderEntryAction = (
+  event: Event,
+  entry: PopupMenuHeaderEntry,
+  action?: string
+) => any;
 
 export type PopupMenuHeaderEntry = {
   action: PopupMenuHeaderEntryAction;
@@ -33,17 +43,20 @@ export type PopupMenuHeaderEntry = {
 
 export type PopupMenuHeaderEntries = PopupMenuHeaderEntry[];
 
-export type PopupMenuProviderHeaderEntriesProvider = (entries: PopupMenuHeaderEntries) => PopupMenuHeaderEntries;
+export type PopupMenuProviderHeaderEntriesProvider = (
+  entries: PopupMenuHeaderEntries
+) => PopupMenuHeaderEntries;
 
 export type PopupMenuEmptyPlaceholder = VNode;
 
-export type PopupMenuEmptyPlaceholderProvider = (search: string) => PopupMenuEmptyPlaceholder;
+export type PopupMenuEmptyPlaceholderProvider = (
+  search: string
+) => PopupMenuEmptyPlaceholder;
 
 /**
  * An interface to be implemented by a popup menu provider.
  */
 export default interface PopupMenuProvider {
-
   /**
    * Returns a map of entries or a function that receives, modifies and returns
    * a map of entries.
@@ -72,7 +85,9 @@ export default interface PopupMenuProvider {
    *
    * @param target
    */
-  getPopupMenuEntries(target: PopupMenuTarget): PopupMenuEntriesProvider | PopupMenuEntries;
+  getPopupMenuEntries(
+    target: PopupMenuTarget
+  ): PopupMenuEntriesProvider | PopupMenuEntries;
 
   /**
    * Returns a list of header entries or a function that receives, modifies and
@@ -104,7 +119,9 @@ export default interface PopupMenuProvider {
    *
    * @param target
    */
-  getHeaderEntries?(target: PopupMenuTarget): PopupMenuProviderHeaderEntriesProvider | PopupMenuHeaderEntries;
+  getHeaderEntries?(
+    target: PopupMenuTarget
+  ): PopupMenuProviderHeaderEntriesProvider | PopupMenuHeaderEntries;
 
   /**
    * Returns a component to be displayed when no popup menu entries
@@ -120,5 +137,7 @@ export default interface PopupMenuProvider {
    * }
    * ```
    */
-  getEmptyPlaceholder?(): PopupMenuEmptyPlaceholderProvider | PopupMenuEmptyPlaceholder;
+  getEmptyPlaceholder?():
+    | PopupMenuEmptyPlaceholderProvider
+    | PopupMenuEmptyPlaceholder;
 }

--- a/lib/features/search-pad/SearchPadProvider.ts
+++ b/lib/features/search-pad/SearchPadProvider.ts
@@ -1,4 +1,4 @@
-import { Element } from '../../model/Types';
+import type { Element } from '../../model/Types';
 
 export type Token = {
   matched: string;


### PR DESCRIPTION
### Proposed Changes

Fixes #864 by changing `import { ... } from` to `import type { ... } from` in the typescript files at all locations where types are imported. This will make this package compatible with projects using the verbatimModuleSyntax flag in the tsconfig.

This is not a breaking change.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] ~~**Visual demo** attached~~
* [ ] ~~**Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)~~
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
