### PR TITLE
Improve search in large diagrams

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -83,6 +83,7 @@
   --search-input-focus-background-color: var(--color-blue-205-100-95);
   --search-result-hover-background-color: var(--color-grey-225-10-95);
   --search-result-secondary-color: var(--color-grey-225-10-55);
+  --search-preselected-background-color: var(--color-blue-205-100-50-opacity-15);
 
   --shape-attach-allowed-stroke-color: var(--color-blue-205-100-50);
   --shape-connect-allowed-fill-color: var(--color-grey-225-10-97);
@@ -977,6 +978,10 @@ svg.new-parent {
 
 .djs-search-result-selected:hover {
   background: var(--search-result-hover-background-color);
+}
+
+.djs-element.djs-search-preselected .djs-outline {
+  fill: var(--search-preselected-background-color) !important;
 }
 
 /**

--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -1153,7 +1153,7 @@ Canvas.prototype._viewboxChanged = function() {
 Canvas.prototype.viewbox = function(box) {
 
   if (box === undefined && this._cachedViewbox) {
-    return this._cachedViewbox;
+    return JSON.parse(JSON.stringify(this._cachedViewbox));
   }
 
   const viewport = this._viewport,

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -26,6 +26,8 @@ import { isKey } from '../keyboard/KeyboardUtil';
  * @typedef {import('./SearchPadProvider').Token} Token
  */
 
+var SCROLL_TO_ELEMENT_PADDING = 300;
+
 /**
  * Provides searching infrastructure.
  *
@@ -446,7 +448,7 @@ SearchPad.prototype._preselect = function(node) {
   domClasses(node).add(SearchPad.RESULT_SELECTED_CLASS);
 
   this._canvas.scrollToElement(element, {
-    top: 300
+    top: SCROLL_TO_ELEMENT_PADDING
   });
 
   this._selection.select(element);
@@ -471,7 +473,9 @@ SearchPad.prototype._select = function(node) {
 
   this.close(false);
 
-  this._canvas.scrollToElement(element, { top: 400 });
+  this._canvas.scrollToElement(element, {
+    top: SCROLL_TO_ELEMENT_PADDING
+  });
 
   this._selection.select(element);
 

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -36,7 +36,7 @@ import { isKey } from '../keyboard/KeyboardUtil';
  */
 export default function SearchPad(canvas, eventBus, selection, translate) {
   this._open = false;
-  this._results = [];
+  this._results = {};
   this._eventMaps = [];
 
   this._cachedRootElement = null;
@@ -258,7 +258,7 @@ SearchPad.prototype._scrollToNode = function(node) {
 SearchPad.prototype._clearResults = function() {
   domClear(this._resultsContainer);
 
-  this._results = [];
+  this._results = {};
 
   this._eventBus.fire('searchPad.cleared');
 };

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -445,8 +445,6 @@ SearchPad.prototype._preselect = function(node) {
 
   domClasses(node).add(SearchPad.RESULT_SELECTED_CLASS);
 
-  this._canvas.zoom(1);
-
   this._canvas.scrollToElement(element, {
     top: 300
   });

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -190,6 +190,9 @@ SearchPad.prototype._search = function(pattern) {
   });
 
   if (!searchResults.length) {
+    this._clearMarkers();
+    this._selection.select(null);
+
     return;
   }
 
@@ -261,6 +264,16 @@ SearchPad.prototype._clearResults = function() {
   this._results = {};
 
   this._eventBus.fire('searchPad.cleared');
+};
+
+
+/**
+ * Clears all markers.
+ */
+SearchPad.prototype._clearMarkers = function() {
+  for (var id in this._results) {
+    this._canvas.removeMarker(this._results[id].element, 'djs-search-preselected');
+  }
 };
 
 
@@ -380,6 +393,8 @@ SearchPad.prototype.close = function(restoreCached = true) {
   domClasses(this._canvas.getContainer()).remove('djs-search-open');
   domClasses(this._container).remove('open');
 
+  this._clearMarkers();
+
   this._clearResults();
 
   this._searchInput.value = '';
@@ -418,6 +433,8 @@ SearchPad.prototype._preselect = function(node) {
     return;
   }
 
+  this._clearMarkers();
+
   // removing preselection from current node
   if (selectedNode) {
     domClasses(selectedNode).remove(SearchPad.RESULT_SELECTED_CLASS);
@@ -435,6 +452,8 @@ SearchPad.prototype._preselect = function(node) {
   });
 
   this._selection.select(element);
+
+  this._canvas.addMarker(element, 'djs-search-preselected');
 
   this._eventBus.fire('searchPad.preselected', element);
 };

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -867,6 +867,25 @@ describe('Canvas', function() {
       }));
 
 
+      it('should return copy of viewbox', inject(function(canvas) {
+
+        // given
+        canvas.addShape({ id: 's0', x: 0, y: 0, width: 300, height: 300 });
+
+        var shape = canvas.addShape({ id: 's1', x: 10000, y: 0, width: 300, height: 300 });
+
+        var viewbox = canvas.viewbox(),
+            viewboxStringified = JSON.stringify(viewbox);
+
+        // when
+        canvas.scrollToElement(shape);
+
+        // then
+        expect(JSON.stringify(viewbox)).to.eql(viewboxStringified);
+        expect(JSON.stringify(canvas.viewbox())).not.to.eql(viewboxStringified);
+      }));
+
+
       it('should provide default viewbox / overflowing diagram', inject(function(canvas) {
 
         // given

--- a/test/spec/features/search-pad/SearchPadSpec.js
+++ b/test/spec/features/search-pad/SearchPadSpec.js
@@ -438,7 +438,7 @@ describe('features/searchPad', function() {
       // then
       var newViewbox = canvas.viewbox();
       expect(newViewbox).to.have.property('x', -100);
-      expect(newViewbox).to.have.property('y', -400);
+      expect(newViewbox).to.have.property('y', -300);
     }));
 
 

--- a/test/spec/features/search-pad/SearchPadSpec.js
+++ b/test/spec/features/search-pad/SearchPadSpec.js
@@ -442,21 +442,6 @@ describe('features/searchPad', function() {
     }));
 
 
-    it('select set zoom level to 1', inject(function(canvas) {
-
-      // given
-      canvas.zoom(0.4);
-
-      typeText(input_node, 'one');
-
-      // when
-      triggerKeyEvent(input_node, 'keyup', 'Enter');
-
-      // then
-      expect(canvas.zoom()).to.equal(1);
-    }));
-
-
     it('select reset viewbox on escape without enter', inject(function(canvas) {
 
       // given

--- a/test/spec/features/search-pad/SearchPadSpec.js
+++ b/test/spec/features/search-pad/SearchPadSpec.js
@@ -362,7 +362,7 @@ describe('features/searchPad', function() {
     }));
 
 
-    it('should preselect first result', inject(function(canvas) {
+    it('should preselect first result', inject(function(canvas, selection) {
 
       // when
       typeText(input_node, 'two');
@@ -371,10 +371,12 @@ describe('features/searchPad', function() {
       var result_nodes = domQueryAll(SearchPad.RESULT_SELECTOR, canvas.getContainer());
       expect(domClasses(result_nodes[0]).has(SearchPad.RESULT_SELECTED_CLASS)).to.be.true;
       expect(capturedEvents).to.eql([ EVENTS.opened, EVENTS.preselected ]);
+      expect(selection.isSelected(elements.two.a)).to.be.true;
+      expect(domClasses(canvas.getGraphics(elements.two.a)).has('djs-search-preselected')).to.be.true;
     }));
 
 
-    it('should select result on enter', function() {
+    it('should select result on enter', inject(function(canvas, selection) {
 
       // given
       typeText(input_node, 'two');
@@ -389,10 +391,13 @@ describe('features/searchPad', function() {
         EVENTS.closed,
         EVENTS.selected
       ]);
-    });
+
+      expect(selection.isSelected(elements.two.a)).to.be.true;
+      expect(domClasses(canvas.getGraphics(elements.two.a)).has('djs-search-preselected')).to.be.false;
+    }));
 
 
-    it('should reset selection on escape without enter', inject(function(selection) {
+    it('should reset selection on escape without enter', inject(function(canvas, selection) {
 
       // given
       selection.select(elements.one.a);
@@ -406,6 +411,8 @@ describe('features/searchPad', function() {
 
       // then
       expect(selection.isSelected(elements.one.a)).to.be.true;
+
+      expect(domClasses(canvas.getGraphics(elements.two.a)).has('djs-search-preselected')).to.be.false;
     }));
 
 


### PR DESCRIPTION
### Proposed Changes

* do not set zoom to 1
* reduce padding below search
* add custom marker to preselected element

Related to https://github.com/bpmn-io/bpmn-js/issues/2233
Related to https://github.com/camunda/camunda-modeler/issues/4538

![brave_cwSIL4Oz5C](https://github.com/user-attachments/assets/c85b65c3-a6fb-4d8c-b8bf-2094415f4635)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
