### PR TITLE
Improve search (make fuzzy again and more robust)

### DIFF
--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -22,6 +22,7 @@ import PopupMenuComponent from './PopupMenuComponent';
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/EventBus').default} EventBus
+ * @typedef {import('../search/search').default} search
  *
  * @typedef {import('../../util/Types').Point} Point
  *
@@ -59,10 +60,12 @@ var DEFAULT_PRIORITY = 1000;
  * @param {PopupMenuConfig} config
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
+ * @param {search} search
  */
-export default function PopupMenu(config, eventBus, canvas) {
+export default function PopupMenu(config, eventBus, canvas, search) {
   this._eventBus = eventBus;
   this._canvas = canvas;
+  this._search = search;
 
   this._current = null;
 
@@ -94,7 +97,8 @@ export default function PopupMenu(config, eventBus, canvas) {
 PopupMenu.$inject = [
   'config.popupMenu',
   'eventBus',
-  'canvas'
+  'canvas',
+  'search'
 ];
 
 PopupMenu.prototype._render = function() {
@@ -138,6 +142,7 @@ PopupMenu.prototype._render = function() {
         scale=${ scale }
         onOpened=${ this._onOpened.bind(this) }
         onClosed=${ this._onClosed.bind(this) }
+        searchFn=${ this._search }
         ...${{ ...options }}
       />
     `,
@@ -550,7 +555,6 @@ PopupMenu.prototype._getHeaderEntries = function(target, providers) {
 
 
 PopupMenu.prototype._getEmptyPlaceholder = function(providers) {
-
   const provider = providers.find(
     provider => isFunction(provider.getEmptyPlaceholder)
   );

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -23,6 +23,8 @@ import { isDefined, isFunction } from 'min-dash';
  * @typedef {import('./PopupMenuProvider').PopupMenuHeaderEntry} PopupMenuHeaderEntry
  * @typedef {import('./PopupMenuProvider').PopupMenuEmptyPlaceholderProvider | import('./PopupMenuProvider').PopupMenuEmptyPlaceholder} PopupMenuEmptyPlaceholder
  *
+ * @typedef {import('../search/search').default} search
+ *
  * @typedef {import('../../util/Types').Point} Point
  */
 
@@ -41,6 +43,7 @@ import { isDefined, isFunction } from 'min-dash';
  * @param {boolean} [props.search]
  * @param {PopupMenuEmptyPlaceholder} [props.emptyPlaceholder]
  * @param {number} [props.width]
+ * @param {search} props.searchFn
  */
 export default function PopupMenuComponent(props) {
   const {
@@ -54,6 +57,7 @@ export default function PopupMenuComponent(props) {
     scale,
     search,
     emptyPlaceholder,
+    searchFn,
     entries: originalEntries,
     onOpened,
     onClosed
@@ -75,29 +79,19 @@ export default function PopupMenuComponent(props) {
       return originalEntries;
     }
 
-    const filter = entry => {
-      if (!value) {
-        return (entry.rank || 0) >= 0;
-      }
+    if (!value) {
+      return originalEntries.filter(({ rank = 0 }) => rank >= 0);
+    }
 
-      if (entry.searchable === false) {
-        return false;
-      }
+    const searchableEntries = originalEntries.filter(({ searchable }) => searchable !== false);
 
-      const searchableFields = [
-        entry.description || '',
-        entry.label || '',
-        entry.search || ''
-      ].map(string => string.toLowerCase());
-
-      // every word of `value` should be included in one of the searchable fields
-      return value
-        .toLowerCase()
-        .split(/\s/g)
-        .every(word => searchableFields.some(field => field.includes(word)));
-    };
-
-    return originalEntries.filter(filter);
+    return searchFn(searchableEntries, value, {
+      keys: [
+        'label',
+        'description',
+        'search'
+      ]
+    }).map(({ item }) => item);
   }, [ searchable ]);
 
   const [ entries, setEntries ] = useState(filterEntries(originalEntries, value));

--- a/lib/features/popup-menu/index.js
+++ b/lib/features/popup-menu/index.js
@@ -1,10 +1,13 @@
 import PopupMenu from './PopupMenu';
 
+import Search from '../search';
+
 
 /**
  * @type { import('didi').ModuleDeclaration }
  */
 export default {
+  __depends__: [ Search ],
   __init__: [ 'popupMenu' ],
   popupMenu: [ 'type', PopupMenu ]
 };

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -523,10 +523,13 @@ function createHtmlText(tokens) {
   var htmlText = '';
 
   tokens.forEach(function(t) {
-    if (t.matched) {
-      htmlText += '<b class="' + SearchPad.RESULT_HIGHLIGHT_CLASS + '">' + escapeHTML(t.matched) + '</b>';
+    var text = escapeHTML(t.value || t.matched || t.normal);
+    var match = t.match || t.matched;
+
+    if (match) {
+      htmlText += '<b class="' + SearchPad.RESULT_HIGHLIGHT_CLASS + '">' + text + '</b>';
     } else {
-      htmlText += escapeHTML(t.normal);
+      htmlText += text;
     }
   });
 

--- a/lib/features/search-pad/SearchPadProvider.ts
+++ b/lib/features/search-pad/SearchPadProvider.ts
@@ -1,9 +1,16 @@
 import type { Element } from '../../model/Types';
 
-export type Token = {
+type LegacyToken = {
   matched?: string;
   normal?: string;
 };
+
+type ModernToken = {
+  match: boolean;
+  value: string;
+};
+
+export type Token = LegacyToken | ModernToken;
 
 export type SearchResult = {
   primaryTokens: Token[];

--- a/lib/features/search-pad/SearchProvider.spec.ts
+++ b/lib/features/search-pad/SearchProvider.spec.ts
@@ -14,12 +14,20 @@ export class FooSearchProvider implements SearchProvider {
           {
             matched: pattern,
             normal: pattern
+          },
+          {
+            match: true,
+            value: 'bar'
           }
         ],
         secondaryTokens: [
           {
             matched: 'bar',
             normal: 'bar'
+          },
+          {
+            match: false,
+            value: 'foo'
           }
         ],
         element: create('shape')

--- a/lib/features/search/search.js
+++ b/lib/features/search/search.js
@@ -36,9 +36,12 @@ export default function search(items, pattern, options) {
   pattern = pattern.trim();
 
   return items.flatMap((item) => {
-    const tokens = getTokens(item, pattern, keys);
+    const {
+      __matches: matches,
+      ...tokens
+    } = getTokens(item, pattern, keys);
 
-    if (!Object.keys(tokens).length) {
+    if (!matches) {
       return [];
     }
 
@@ -64,12 +67,12 @@ function getTokens(item, pattern, keys) {
 
     const tokens = getMatchingTokens(string, pattern);
 
-    if (hasMatch(tokens)) {
-      results[ key ] = tokens;
-    }
-
-    return results;
-  }, {});
+    return {
+      ...results,
+      [ key ]: tokens,
+      __matches: results.__matches || hasMatch(tokens)
+    };
+  }, { });
 }
 
 /**

--- a/lib/features/search/search.js
+++ b/lib/features/search/search.js
@@ -110,16 +110,19 @@ function createResultSorter(keys) {
 
     for (const key of keys) {
 
-      const tokensA = resultA.tokens[key];
-      const tokensB = resultB.tokens[key];
-
-      const tokenComparison = compareTokens(tokensA, tokensB);
+      const tokenComparison = compareTokens(
+        resultA.tokens[key],
+        resultB.tokens[key]
+      );
 
       if (tokenComparison !== 0) {
         return tokenComparison;
       }
 
-      const stringComparison = compareStrings(resultA.item[ key ], resultB.item[ key ]);
+      const stringComparison = compareStrings(
+        resultA.item[ key ],
+        resultB.item[ key ]
+      );
 
       if (stringComparison !== 0) {
         return stringComparison;

--- a/lib/features/search/search.js
+++ b/lib/features/search/search.js
@@ -32,16 +32,12 @@ export default function search(items, pattern, options) {
     keys
   } = options;
 
-  // drop leading and trailing whitespace
-  pattern = pattern.trim();
+  const words = pattern.trim().toLowerCase().split(/\s+/);
 
   return items.flatMap((item) => {
-    const {
-      __matches: matches,
-      ...tokens
-    } = getTokens(item, pattern, keys);
+    const tokens = matchItem(item, words, keys);
 
-    if (!matches) {
+    if (!tokens) {
       return [];
     }
 
@@ -53,26 +49,48 @@ export default function search(items, pattern, options) {
 }
 
 /**
- * Get tokens for item.
+ * Match an item and return tokens in case of a match.
  *
  * @param {Object} item
- * @param {string} pattern
+ * @param {string[]} words
  * @param {string[]} keys
  *
  * @returns {Record<string, Tokens>}
  */
-function getTokens(item, pattern, keys) {
-  return keys.reduce((results, key) => {
+function matchItem(item, words, keys) {
+
+  const {
+    matchedWords,
+    tokens
+  } = keys.reduce((result, key) => {
     const string = item[ key ];
 
-    const tokens = getMatchingTokens(string, pattern);
+    const {
+      tokens,
+      matchedWords
+    } = matchString(string, words);
 
     return {
-      ...results,
-      [ key ]: tokens,
-      __matches: results.__matches || hasMatch(tokens)
+      tokens: {
+        ...result.tokens,
+        [ key ]: tokens,
+      },
+      matchedWords: {
+        ...result.matchedWords,
+        ...matchedWords
+      }
     };
-  }, { });
+  }, {
+    matchedWords: {},
+    tokens: {}
+  });
+
+  // only return result if every word got matched
+  if (Object.keys(matchedWords).length !== words.length) {
+    return null;
+  }
+
+  return tokens;
 }
 
 /**
@@ -118,119 +136,128 @@ function createResultSorter(keys) {
 }
 
 /**
-* @param {Token} token
-*
-* @return {boolean}
-*/
-export function isMatch(token) {
-  return token.match;
+ * Compares two token arrays.
+ *
+ * @param {Token[]} [tokensA]
+ * @param {Token[]} [tokensB]
+ *
+ * @returns {number}
+ */
+function compareTokens(tokensA, tokensB) {
+  return scoreTokens(tokensB) - scoreTokens(tokensA);
 }
 
 /**
-* @param {Token[]} tokens
-*
-* @return {boolean}
-*/
-export function hasMatch(tokens) {
-  return tokens.find(isMatch);
+ * @param { Token[] } tokens
+ * @returns { number }
+ */
+function scoreTokens(tokens) {
+  return tokens.reduce((sum, token) => sum + scoreToken(token), 0);
 }
 
 /**
-* Compares two token arrays.
-*
-* @param {Token[]} [tokensA]
-* @param {Token[]} [tokensB]
-*
-* @returns {number}
-*/
-export function compareTokens(tokensA, tokensB) {
-
-  const tokensAHasMatch = tokensA && hasMatch(tokensA),
-        tokensBHasMatch = tokensB && hasMatch(tokensB);
-
-  if (tokensAHasMatch && !tokensBHasMatch) {
-    return -1;
-  }
-
-  if (!tokensAHasMatch && tokensBHasMatch) {
-    return 1;
-  }
-
-  if (!tokensAHasMatch && !tokensBHasMatch) {
+ * Score a token.
+ *
+ * @param { Token } token
+ *
+ * @returns { number }
+ */
+function scoreToken(token) {
+  if (!token.match) {
     return 0;
   }
 
-  const tokensAFirstMatch = tokensA.find(isMatch),
-        tokensBFirstMatch = tokensB.find(isMatch);
-
-  if (tokensAFirstMatch.index < tokensBFirstMatch.index) {
-    return -1;
-  }
-
-  if (tokensAFirstMatch.index > tokensBFirstMatch.index) {
-    return 1;
-  }
-
-  return 0;
+  return token.start
+    ? 1.37
+    : token.wordStart
+      ? 1.13
+      : 1;
 }
 
 /**
-* Compares two strings.
-*
-* @param {string} [a = '']
-* @param {string} [b = '']
-*
-* @returns {number}
-*/
-export function compareStrings(a = '', b = '') {
+ * Compares two strings.
+ *
+ * @param {string} [a = '']
+ * @param {string} [b = '']
+ *
+ * @returns {number}
+ */
+function compareStrings(a = '', b = '') {
   return a.localeCompare(b);
 }
 
 /**
-* @param {string} string
-* @param {string} pattern
-*
-* @return {Token[]}
-*/
-export function getMatchingTokens(string, pattern) {
-  var tokens = [],
-      originalString = string;
+ * Match a given string against a set of words,
+ * and return the result.
+ *
+ * @param {string} string
+ * @param {string[]} words
+ *
+ * @return { {
+ *   tokens: Token[],
+ *   matchedWords: Record<string, boolean>
+ * } }
+ */
+function matchString(string, words) {
 
   if (!string) {
-    return tokens;
+    return {
+      tokens: [],
+      matchedWords: {}
+    };
   }
 
-  string = string.toLowerCase();
-  pattern = pattern.toLowerCase();
+  const tokens = [];
+  const matchedWords = {};
 
-  var index = string.indexOf(pattern);
+  const regexpString = words.map(escapeRegexp).flatMap(str => [ '(?<wordStart>\\b' + str + ')', str ]).join('|');
 
-  if (index > -1) {
-    if (index !== 0) {
+  const regexp = new RegExp(regexpString, 'ig');
+
+  let match;
+  let lastIndex = 0;
+
+  while ((match = regexp.exec(string))) {
+
+    const [ value ] = match;
+
+    if (match.index > lastIndex) {
+
+      // add previous token (NO match)
       tokens.push({
-        value: originalString.slice(0, index),
-        index: 0
+        value: string.slice(lastIndex, match.index),
+        index: lastIndex
       });
     }
 
+    // add current token (match)
     tokens.push({
-      value: originalString.slice(index, index + pattern.length),
-      index: index,
-      match: true
+      value,
+      index: match.index,
+      match: true,
+      wordStart: !!match.groups.wordStart,
+      start: match.index === 0
     });
 
-    if (pattern.length + index < string.length) {
-      tokens.push({
-        value: originalString.slice(index + pattern.length),
-        index: index + pattern.length
-      });
-    }
-  } else {
+    matchedWords[value.toLowerCase()] = true;
+
+    lastIndex = match.index + value.length;
+  }
+
+  // add after token (NO match)
+  if (lastIndex < string.length) {
     tokens.push({
-      value: originalString,
-      index: 0
+      value: string.slice(lastIndex),
+      index: lastIndex
     });
   }
 
-  return tokens;
+  return {
+    tokens,
+    matchedWords
+  };
+}
+
+function escapeRegexp(string) {
+  return string.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
 }

--- a/lib/features/search/search.js
+++ b/lib/features/search/search.js
@@ -6,25 +6,29 @@
  * } } Token
  *
  * @typedef {Token[]} Tokens
+ */
+
+/**
+ * @template R
  *
  * @typedef { {
- *   item: Object,
+ *   item: R,
  *   tokens: Record<string, Tokens>
  * } } SearchResult
- *
- * @typedef {SearchResult[]} SearchResults
  */
 
 /**
  * Search items by query.
  *
- * @param {Object[]} items
+ * @template T
+ *
+ * @param {T[]} items
  * @param {string} pattern
  * @param { {
  *   keys: string[];
  * } } options
  *
- * @returns {SearchResults}
+ * @returns {SearchResult<T>[]}
  */
 export default function search(items, pattern, options) {
 

--- a/lib/features/search/search.js
+++ b/lib/features/search/search.js
@@ -27,22 +27,23 @@
  * @returns {SearchResults}
  */
 export default function search(items, pattern, options) {
-  return items.reduce((results, item) => {
-    const tokens = getTokens(item, pattern, options.keys);
 
-    if (Object.keys(tokens).length) {
-      const result = {
-        item,
-        tokens
-      };
+  const {
+    keys
+  } = options;
 
-      const index = getIndex(result, results, options.keys);
+  return items.flatMap((item) => {
+    const tokens = getTokens(item, pattern, keys);
 
-      results.splice(index, 0, result);
+    if (!Object.keys(tokens).length) {
+      return [];
     }
 
-    return results;
-  }, []);
+    return {
+      item,
+      tokens
+    };
+  }).sort(createResultSorter(keys));
 }
 
 /**
@@ -71,59 +72,43 @@ function getTokens(item, pattern, keys) {
 /**
  * Get index of result in list of results.
  *
- * @param {SearchResult} result
- * @param {SearchResults} results
  * @param {string[]} keys
  *
- * @returns {number}
+ * @returns { (resultA: SearchResult, resultB: SearchResult) => number}
  */
-function getIndex(result, results, keys) {
-  if (!results.length) {
-    return 0;
-  }
+function createResultSorter(keys) {
 
-  let index = 0;
+  /**
+   * @param {SearchResult} resultA
+   * @param {SearchResult} resultB
+   */
+  return (resultA, resultB) => {
 
-  do {
     for (const key of keys) {
-      const tokens = result.tokens[ key ],
-            tokensOther = results[ index ].tokens[ key ];
 
-      if (tokens && !tokensOther) {
-        return index;
-      } else if (!tokens && tokensOther) {
-        index++;
+      const tokensA = resultA.tokens[key];
+      const tokensB = resultB.tokens[key];
 
-        break;
-      } else if (!tokens && !tokensOther) {
-        continue;
+      const tokenComparison = compareTokens(tokensA, tokensB);
+
+      if (tokenComparison !== 0) {
+        return tokenComparison;
       }
 
-      const tokenComparison = compareTokens(tokens, tokensOther);
+      const stringComparison = compareStrings(resultA.item[ key ], resultB.item[ key ]);
 
-      if (tokenComparison === -1) {
-        return index;
-      } else if (tokenComparison === 1) {
-        index++;
-
-        break;
-      } else {
-        const stringComparison = compareStrings(result.item[ key ], results[ index ].item[ key ]);
-
-        if (stringComparison === -1) {
-          return index;
-        } else if (stringComparison === 1) {
-          index++;
-
-          break;
-        } else {
-          continue;
-        }
+      if (stringComparison !== 0) {
+        return stringComparison;
       }
+
+      // fall back to next key
+      continue;
     }
-  } while (index < results.length);
 
-  return index;
+    // eventually call equality
+    return 0;
+  };
+
 }
 
 /**
@@ -147,14 +132,15 @@ export function hasMatch(tokens) {
 /**
 * Compares two token arrays.
 *
-* @param {Token[]} tokensA
-* @param {Token[]} tokensB
+* @param {Token[]} [tokensA]
+* @param {Token[]} [tokensB]
 *
 * @returns {number}
 */
 export function compareTokens(tokensA, tokensB) {
-  const tokensAHasMatch = hasMatch(tokensA),
-        tokensBHasMatch = hasMatch(tokensB);
+
+  const tokensAHasMatch = tokensA && hasMatch(tokensA),
+        tokensBHasMatch = tokensB && hasMatch(tokensB);
 
   if (tokensAHasMatch && !tokensBHasMatch) {
     return -1;
@@ -185,12 +171,12 @@ export function compareTokens(tokensA, tokensB) {
 /**
 * Compares two strings.
 *
-* @param {string} a
-* @param {string} b
+* @param {string} [a = '']
+* @param {string} [b = '']
 *
 * @returns {number}
 */
-export function compareStrings(a, b) {
+export function compareStrings(a = '', b = '') {
   return a.localeCompare(b);
 }
 

--- a/lib/features/search/search.js
+++ b/lib/features/search/search.js
@@ -32,6 +32,9 @@ export default function search(items, pattern, options) {
     keys
   } = options;
 
+  // drop leading and trailing whitespace
+  pattern = pattern.trim();
+
   return items.flatMap((item) => {
     const tokens = getTokens(item, pattern, keys);
 

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -17,6 +17,8 @@ import {
   queryAll as domQueryAll
 } from 'min-dom';
 
+import searchFn from 'lib/features/search/search';
+
 
 const TEST_IMAGE_URL = `data:image/svg+xml;utf8,${
   encodeURIComponent(`
@@ -739,6 +741,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
     const props = {
       entries: [],
       headerEntries: [],
+      searchFn: searchFn,
       position() {
         return { x: 0, y: 0 };
       },

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -741,7 +741,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
     const props = {
       entries: [],
       headerEntries: [],
-      searchFn: searchFn,
+      searchFn,
       position() {
         return { x: 0, y: 0 };
       },

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -1509,6 +1509,28 @@ describe('features/popup-menu', function() {
     }));
 
 
+    it('should show search results (matching label & search)', inject(async function(popupMenu) {
+
+      // given
+      popupMenu.registerProvider('test-menu', testMenuProvider);
+      popupMenu.open({}, 'test-menu', { x: 100, y: 100 }, { search: true });
+
+      // when
+      await triggerSearch('delta search');
+
+      // then
+      var shownEntries;
+
+      await waitFor(() => {
+        shownEntries = queryPopupAll('.entry');
+
+        expect(shownEntries).to.have.length(1);
+      });
+
+      expect(shownEntries[0].querySelector('.djs-popup-label').textContent).to.eql('Delta');
+    }));
+
+
     describe('ranking', function() {
 
       it('should hide rank < 0 items', inject(async function(popupMenu) {

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -1509,28 +1509,6 @@ describe('features/popup-menu', function() {
     }));
 
 
-    it('should show search results (matching label & search)', inject(async function(popupMenu) {
-
-      // given
-      popupMenu.registerProvider('test-menu', testMenuProvider);
-      popupMenu.open({}, 'test-menu', { x: 100, y: 100 }, { search: true });
-
-      // when
-      await triggerSearch('delta search');
-
-      // then
-      var shownEntries;
-
-      await waitFor(() => {
-        shownEntries = queryPopupAll('.entry');
-
-        expect(shownEntries).to.have.length(1);
-      });
-
-      expect(shownEntries[0].querySelector('.djs-popup-label').textContent).to.eql('Delta');
-    }));
-
-
     describe('ranking', function() {
 
       it('should hide rank < 0 items', inject(async function(popupMenu) {

--- a/test/spec/features/search/searchSpec.js
+++ b/test/spec/features/search/searchSpec.js
@@ -15,7 +15,7 @@ describe('search', function() {
   }));
 
 
-  it('complex', inject(function(search) {
+  it('should search complex', inject(function(search) {
 
     // given
     const items = [
@@ -63,7 +63,7 @@ describe('search', function() {
   }));
 
 
-  it('should by match', inject(function(search) {
+  it('should sort by match', inject(function(search) {
 
     // given
     const items = [
@@ -96,7 +96,7 @@ describe('search', function() {
   }));
 
 
-  it('should by match location', inject(function(search) {
+  it('should sort by match location', inject(function(search) {
 
     // given
     const items = [
@@ -193,6 +193,38 @@ describe('search', function() {
     expect(results).to.have.length(2);
     expect(results[0].item).to.eql(items[2]);
     expect(results[1].item).to.eql(items[0]);
+  }));
+
+
+  it('should handle duplicate entries', inject(function(search) {
+
+    // given
+    const items = [
+      {
+        title: 'baz',
+        description: 'baz'
+      },
+      {
+        title: 'Kafka message',
+        description: 'Nope'
+      },
+      {
+        title: 'Kafka message',
+        description: 'Nope'
+      }
+    ];
+
+    // when
+    const results = search(items, 'g', {
+      keys: [
+        'title',
+        'description',
+        'search'
+      ]
+    });
+
+    // then
+    expect(results).to.have.length(2);
   }));
 
 });

--- a/test/spec/features/search/searchSpec.js
+++ b/test/spec/features/search/searchSpec.js
@@ -15,6 +15,66 @@ describe('search', function() {
   }));
 
 
+
+
+  describe('result', function() {
+
+    it('should provide <item>', inject(function(search) {
+
+      // given
+      const items = [
+        {
+          title: 'foo',
+          description: 'woop'
+        },
+        {
+          title: 'foobar'
+        }
+      ];
+
+      // when
+      const result = search(items, 'foo', {
+        keys: [
+          'title',
+          'description'
+        ]
+      });
+
+      // then
+      expect(result[0].item).to.equal(items[0]);
+      expect(result[1].item).to.equal(items[1]);
+    }));
+
+
+    it('should provide <tokens>', inject(function(search) {
+
+      // given
+      const items = [
+        {
+          title: 'foo',
+          description: 'woop'
+        },
+        {
+          title: 'foobar'
+        }
+      ];
+
+      // when
+      const result = search(items, 'foo', {
+        keys: [
+          'title',
+          'description'
+        ]
+      });
+
+      // then
+      expect(result[0].tokens).to.have.keys([ 'title', 'description' ]);
+      expect(result[1].tokens).to.have.keys([ 'title', 'description' ]);
+
+      expect(result[1].tokens.description).to.be.empty;
+    }));
+
+  });
   it('should search complex', inject(function(search) {
 
     // given

--- a/test/spec/features/search/searchSpec.js
+++ b/test/spec/features/search/searchSpec.js
@@ -264,6 +264,27 @@ describe('search', function() {
     expect(results[1].item).to.eql(items[1]);
   }));
 
+
+  it('should search with whitespace', inject(function(search) {
+
+    // given
+    const items = [
+      {
+        title: 'bar foo bar'
+      }
+    ];
+
+    // when
+    const results = search(items, ' foo   bar ', {
+      keys: [
+        'title'
+      ]
+    });
+
+    // then
+    expect(results).to.have.length(1);
+  }));
+
 });
 
 

--- a/test/spec/features/search/searchSpec.js
+++ b/test/spec/features/search/searchSpec.js
@@ -15,6 +15,31 @@ describe('search', function() {
   }));
 
 
+  it('should search simple', inject(function(search) {
+
+    // given
+    const items = [
+      {
+        title: 'foo',
+        description: 'woop'
+      },
+      {
+        title: 'foobar'
+      }
+    ];
+
+    const searchItems = (items, term) => search(items, term, {
+      keys: [
+        'title',
+        'description'
+      ]
+    });
+
+    // then
+    expect(searchItems(items, 'foo')).to.have.length(2);
+    expect(searchItems(items, 'bar')).to.have.length(1);
+    expect(searchItems(items, 'other')).to.have.length(0);
+  }));
 
 
   describe('result', function() {
@@ -75,6 +100,8 @@ describe('search', function() {
     }));
 
   });
+
+
   it('should search complex', inject(function(search) {
 
     // given
@@ -156,7 +183,7 @@ describe('search', function() {
   }));
 
 
-  it('should sort by match location', inject(function(search) {
+  it('should prioritize start of word', inject(function(search) {
 
     // given
     const items = [
@@ -185,8 +212,34 @@ describe('search', function() {
     // then
     expect(results).to.have.length(3);
     expect(results[0].item).to.eql(items[1]);
-    expect(results[1].item).to.eql(items[2]);
-    expect(results[2].item).to.eql(items[0]);
+    expect(results[1].item).to.eql(items[0]);
+    expect(results[2].item).to.eql(items[2]);
+  }));
+
+
+  it('should prioritize start of term', inject(function(search) {
+
+    // given
+    const items = [
+      {
+        title: 'yes barfoo'
+      },
+      {
+        title: 'yes foowoo'
+      }
+    ];
+
+    // when
+    const results = search(items, 'foo', {
+      keys: [
+        'title'
+      ]
+    });
+
+    // then
+    expect(results).to.have.length(2);
+    expect(results[0].item).to.eql(items[1]);
+    expect(results[1].item).to.eql(items[0]);
   }));
 
 
@@ -288,24 +341,42 @@ describe('search', function() {
   }));
 
 
+  it('should match case insensitive', inject(function(search) {
+
+    // given
+    const items = [
+      {
+        title: 'KAFKAF'
+      }
+    ];
+
+    // when
+    const results = search(items, 'kaf', {
+      keys: [
+        'title'
+      ]
+    });
+
+    // then
+    expect(results).to.have.length(1);
+    expect(results[0].item).to.eql(items[0]);
+  }));
+
+
   it('should match partial tokens', inject(function(search) {
 
     // given
     const items = [
       {
-        title: 'baz',
-        description: 'baz'
-      },
-      {
         title: 'Kafka amess',
         description: 'Nope'
       },
       {
-        title: 'Kaboom'
+        title: 'mess',
+        description: 'kafka'
       },
       {
-        title: 'Kafka message',
-        description: 'Nope'
+        title: 'mess'
       }
     ];
 
@@ -320,7 +391,35 @@ describe('search', function() {
 
     // then
     expect(results).to.have.length(2);
-    expect(results[0].item).to.eql(items[3]);
+    expect(results[0].item).to.eql(items[0]);
+    expect(results[1].item).to.eql(items[1]);
+  }));
+
+
+  it('should match with spaces', inject(function(search) {
+
+    // given
+    const items = [
+      {
+        title: 'bar foo bar'
+      },
+      {
+        title: 'other bar foo'
+      }
+    ];
+
+    // when
+    const results = search(items, 'foo bar', {
+      keys: [
+        'title',
+        'description',
+        'search'
+      ]
+    });
+
+    // then
+    expect(results).to.have.length(2);
+    expect(results[0].item).to.eql(items[0]);
     expect(results[1].item).to.eql(items[1]);
   }));
 

--- a/test/spec/features/search/searchSpec.js
+++ b/test/spec/features/search/searchSpec.js
@@ -227,6 +227,43 @@ describe('search', function() {
     expect(results).to.have.length(2);
   }));
 
+
+  it('should match partial tokens', inject(function(search) {
+
+    // given
+    const items = [
+      {
+        title: 'baz',
+        description: 'baz'
+      },
+      {
+        title: 'Kafka amess',
+        description: 'Nope'
+      },
+      {
+        title: 'Kaboom'
+      },
+      {
+        title: 'Kafka message',
+        description: 'Nope'
+      }
+    ];
+
+    // when
+    const results = search(items, 'Kaf mess', {
+      keys: [
+        'title',
+        'description',
+        'search'
+      ]
+    });
+
+    // then
+    expect(results).to.have.length(2);
+    expect(results[0].item).to.eql(items[3]);
+    expect(results[1].item).to.eql(items[1]);
+  }));
+
 });
 
 

--- a/test/spec/features/search/searchSpec.js
+++ b/test/spec/features/search/searchSpec.js
@@ -5,7 +5,8 @@ import {
 
 import search from '../../../../lib/features/search';
 
-describe('search', function() {
+
+describe('features/search', function() {
 
   beforeEach(bootstrapDiagram({ modules: [ search ] }));
 
@@ -447,7 +448,7 @@ describe('search', function() {
 });
 
 
-describe('overriding search', function() {
+describe('features/search - overrides', function() {
 
   beforeEach(bootstrapDiagram({
     modules: [


### PR DESCRIPTION
### Proposed Changes

We found various issues with our existing search, both in terms of robustness and behavior:

* Under certain circumstances searching loops infinitely (https://github.com/camunda/web-modeler/pull/10940)
* Search is no longer fuzzy, i.e. matches terms across all fields, and hence is overly strict (https://github.com/bpmn-io/diagram-js/pull/932#issuecomment-2368956271)
* Search does not return _all_ tokens for matched entries, making it hard to integrate it properly (https://github.com/bpmn-io/bpmn-js/pull/2235)
* Lack of test coverage around contract and other crucial aspects

This PR solves these issues, while keeping the generally desirable properties:

* We sort search results semantically, preferring
  * start of word
  * start of term (in word)
  * we sort alphabetically (where items are equal in semantics)

The overall goal is to offer a snappy, robust, and intuitive search behavior, and I'd like to put up to a test if we accomplished that:

![capture iz7QYp_optimized](https://github.com/user-attachments/assets/c6c75371-1f4d-411f-93df-220b45388f06)


Try it out via 

```
npx @bpmn-io/sr bpmn-io/bpmn-js#use-search -l bpmn-io/diagram-js#fix-search
```

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
