### PR TITLE
chore: unbuild search integration in popup menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+## 14.11.1
+
+_Partially reverts v14.11.0._
+
+* `FIX`: revert `search` integration into popup menu
+
 ## 14.11.0
 
 * `FEAT`: add `search` utility

--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -60,10 +60,9 @@ var DEFAULT_PRIORITY = 1000;
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
  */
-export default function PopupMenu(config, eventBus, canvas, search) {
+export default function PopupMenu(config, eventBus, canvas) {
   this._eventBus = eventBus;
   this._canvas = canvas;
-  this._search = search;
 
   this._current = null;
 
@@ -95,8 +94,7 @@ export default function PopupMenu(config, eventBus, canvas, search) {
 PopupMenu.$inject = [
   'config.popupMenu',
   'eventBus',
-  'canvas',
-  'search'
+  'canvas'
 ];
 
 PopupMenu.prototype._render = function() {
@@ -140,7 +138,6 @@ PopupMenu.prototype._render = function() {
         scale=${ scale }
         onOpened=${ this._onOpened.bind(this) }
         onClosed=${ this._onClosed.bind(this) }
-        searchFn=${ this._search }
         ...${{ ...options }}
       />
     `,
@@ -551,6 +548,7 @@ PopupMenu.prototype._getHeaderEntries = function(target, providers) {
 
 
 PopupMenu.prototype._getEmptyPlaceholder = function(providers) {
+
   const provider = providers.find(
     provider => isFunction(provider.getEmptyPlaceholder)
   );

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -54,7 +54,6 @@ export default function PopupMenuComponent(props) {
     scale,
     search,
     emptyPlaceholder,
-    searchFn,
     entries: originalEntries,
     onOpened,
     onClosed
@@ -76,19 +75,29 @@ export default function PopupMenuComponent(props) {
       return originalEntries;
     }
 
-    if (!value) {
-      return originalEntries.filter(({ rank = 0 }) => rank >= 0);
-    }
+    const filter = entry => {
+      if (!value) {
+        return (entry.rank || 0) >= 0;
+      }
 
-    const searchableEntries = originalEntries.filter(({ searchable }) => searchable !== false);
+      if (entry.searchable === false) {
+        return false;
+      }
 
-    return searchFn(searchableEntries, value, {
-      keys: [
-        'label',
-        'description',
-        'search'
-      ]
-    }).map(({ item }) => item);
+      const searchableFields = [
+        entry.description || '',
+        entry.label || '',
+        entry.search || ''
+      ].map(string => string.toLowerCase());
+
+      // every word of `value` should be included in one of the searchable fields
+      return value
+        .toLowerCase()
+        .split(/\s/g)
+        .every(word => searchableFields.some(field => field.includes(word)));
+    };
+
+    return originalEntries.filter(filter);
   }, [ searchable ]);
 
   const [ entries, setEntries ] = useState(filterEntries(originalEntries, value));

--- a/lib/features/popup-menu/index.js
+++ b/lib/features/popup-menu/index.js
@@ -1,13 +1,10 @@
 import PopupMenu from './PopupMenu';
 
-import Search from '../search';
-
 
 /**
  * @type { import('didi').ModuleDeclaration }
  */
 export default {
-  __depends__: [ Search ],
   __init__: [ 'popupMenu' ],
   popupMenu: [ 'type', PopupMenu ]
 };

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -17,8 +17,6 @@ import {
   queryAll as domQueryAll
 } from 'min-dom';
 
-import searchFn from 'lib/features/search/search';
-
 
 const TEST_IMAGE_URL = `data:image/svg+xml;utf8,${
   encodeURIComponent(`
@@ -741,7 +739,6 @@ describe('features/popup-menu - <PopupMenu>', function() {
     const props = {
       entries: [],
       headerEntries: [],
-      searchFn: searchFn,
       position() {
         return { x: 0, y: 0 };
       },

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -1495,6 +1495,28 @@ describe('features/popup-menu', function() {
     }));
 
 
+    it('should show search results (matching label & search)', inject(async function(popupMenu) {
+
+      // given
+      popupMenu.registerProvider('test-menu', testMenuProvider);
+      popupMenu.open({}, 'test-menu', { x: 100, y: 100 }, { search: true });
+
+      // when
+      await triggerSearch('delta search');
+
+      // then
+      var shownEntries;
+
+      await waitFor(() => {
+        shownEntries = queryPopupAll('.entry');
+
+        expect(shownEntries).to.have.length(1);
+      });
+
+      expect(shownEntries[0].querySelector('.djs-popup-label').textContent).to.eql('Delta');
+    }));
+
+
     describe('ranking', function() {
 
       it('should hide rank < 0 items', inject(async function(popupMenu) {


### PR DESCRIPTION

### Proposed Changes

This reverts the integration of the (partially broken) search into the popup menu.

The feature needs further refinement, cf. https://github.com/bpmn-io/diagram-js/pull/932, https://github.com/bpmn-io/diagram-js/pull/932#issuecomment-2368956271.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
