### PR TITLE
chore: simplify viewbox cloning

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -1153,7 +1153,7 @@ Canvas.prototype._viewboxChanged = function() {
 Canvas.prototype.viewbox = function(box) {
 
   if (box === undefined && this._cachedViewbox) {
-    return JSON.parse(JSON.stringify(this._cachedViewbox));
+    return structuredClone(this._cachedViewbox);
   }
 
   const viewport = this._viewport,

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -869,20 +869,11 @@ describe('Canvas', function() {
 
       it('should return copy of viewbox', inject(function(canvas) {
 
-        // given
-        canvas.addShape({ id: 's0', x: 0, y: 0, width: 300, height: 300 });
-
-        var shape = canvas.addShape({ id: 's1', x: 10000, y: 0, width: 300, height: 300 });
-
-        var viewbox = canvas.viewbox(),
-            viewboxStringified = JSON.stringify(viewbox);
-
         // when
-        canvas.scrollToElement(shape);
+        var viewbox = canvas.viewbox();
 
         // then
-        expect(JSON.stringify(viewbox)).to.eql(viewboxStringified);
-        expect(JSON.stringify(canvas.viewbox())).not.to.eql(viewboxStringified);
+        expect(viewbox).to.not.equal(canvas.viewbox());
       }));
 
 


### PR DESCRIPTION
### Proposed Changes

Uses `structuredClone` to clone viewbox and simplifies test.

Previously code like [this](https://github.com/bpmn-io/diagram-js/blob/develop/lib/core/Canvas.js#L1284) would get a reference to `_cachedViewbox` and then modify it.

Follow-up to https://github.com/bpmn-io/diagram-js/pull/931

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
