### PR TITLE
feat: get element svg

### DIFF
--- a/lib/core/ElementRegistry.js
+++ b/lib/core/ElementRegistry.js
@@ -261,6 +261,42 @@ ElementRegistry.prototype.getGraphics = function(filter, secondary) {
 };
 
 /**
+ * Return the graphical SVG representation of an element.
+ *
+ * @example
+ *
+ * ```javascript
+ * elementRegistry.getGraphicsSvg('SomeElementId_1'); // <svg ...>
+ *
+ * elementRegistry.getGraphicsSvg(rootElement); // <svg ...>
+ * ```
+ *
+ * @param {ElementLike|string} filter The element or its ID.
+ *
+ * @return {SVGElement} The graphical SVG representation.
+ */
+ElementRegistry.prototype.getGraphicsSvg = function(filter) {
+  /**
+   * @type {SVGElement}
+   */
+  var gfx = this.getGraphics(filter).cloneNode(true);
+
+  gfx.removeAttribute('transform');
+
+  /**
+   * @type {SVGRectElement}
+   */
+  var rect = gfx.querySelector('rect').cloneNode(true);
+  
+  var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute('width', rect.getAttribute('width'));
+  svg.setAttribute('height', rect.getAttribute('height'));
+  svg.appendChild(gfx);
+
+  return svg;
+};
+
+/**
  * Validate an ID and throw an error if invalid.
  *
  * @param {string} id

--- a/lib/core/ElementRegistry.spec.ts
+++ b/lib/core/ElementRegistry.spec.ts
@@ -57,6 +57,10 @@ elementRegistry.getGraphics(shapeLike);
 
 elementRegistry.getGraphics(shape);
 
+elementRegistry.getGraphicsSvg(shapeLike);
+
+elementRegistry.getGraphicsSvg(shape);
+
 elementRegistry.updateGraphics('shape', shapeGfx1);
 
 elementRegistry.updateGraphics(shapeLike, shapeGfx1);


### PR DESCRIPTION
### Proposed Changes

This feature allows rendering a specific element from the diagram.

This pull request introduces a new method to the `ElementRegistry` class and updates the corresponding unit tests. The most important changes include the addition of the `getGraphicsSvg` method and its usage in the test file.

How I use it on my Angular application:

Component:
```ts
getElementById(id: string) {
    const elementRegistry: any = this.viewer.get('elementRegistry');
    const element = elementRegistry.get(id);
    return element ? elementRegistry.getGraphicsSvg(element).outerHTML : '';
}
```

Template:
```html
      <h2>
        <span
          [innerHTML]="
            domSanitizer.bypassSecurityTrustHtml(
              appViewer.getElementById(documentation.id)
            )
          "
        ></span>
        {{ documentation.name || documentation.id }}
      </h2>
```

My application looks like:

![image](https://github.com/user-attachments/assets/385035a9-c613-40b3-9323-a066ceb60112)
![image](https://github.com/user-attachments/assets/15e400cd-c566-46bb-8df6-5369d28470db)

Enhancements to `ElementRegistry`:

* [`lib/core/ElementRegistry.js`](diffhunk://#diff-badcbc14f9a4f7d6e58c80583de6e0df1305054ef5fd34515d104ba3d547e062R263-R298): Added the `getGraphicsSvg` method to return the graphical SVG representation of an element.

Unit test updates:

* [`lib/core/ElementRegistry.spec.ts`](diffhunk://#diff-6be1dbf4d1d702ed836dcb87c981db6d32796475ebb50e6e875277cc25156bdeR60-R63): Added calls to `getGraphicsSvg` to test the new method with different element types.

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

### Checklist

* [X] **Brief textual description** of the changes present
* [X] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

