### PR TITLE
Move multi selection outline into separate feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+* `FEAT`: make multi-selection outline an outline concern ([#944](https://github.com/bpmn-io/diagram-js/issues/944)
+
+### Breaking Changes
+
+* The `selection` feature does not provide visual outline by default anymore. Use the `outline` feature to re-enable it.
+
 ## 14.11.3
 
 * `CHORE`: simplify viewbox cloning ([#935](https://github.com/bpmn-io/diagram-js/pull/935))

--- a/lib/features/outline/MultiSelectionOutline.js
+++ b/lib/features/outline/MultiSelectionOutline.js
@@ -1,0 +1,93 @@
+import {
+  append as svgAppend,
+  attr as svgAttr,
+  create as svgCreate,
+  classes as svgClasses,
+  clear as svgClear
+} from 'tiny-svg';
+
+import { assign } from 'min-dash';
+
+import { getBBox } from '../../util/Elements';
+
+var SELECTION_OUTLINE_PADDING = 6;
+
+/**
+ * @typedef {import('../../model/Types').Element} Element
+ *
+ * @typedef {import('../../core/EventBus').default} EventBus
+ * @typedef {import('../selection/Selection').default} Selection
+ * @typedef {import('../../core/Canvas').default} Canvas
+ */
+
+/**
+ * @class
+ *
+ * A plugin that adds an outline to shapes and connections that may be activated and styled
+ * via CSS classes.
+ *
+ * @param {EventBus} eventBus
+ * @param {Canvas} canvas
+ * @param {Selection} selection
+ */
+export default function MultiSelectionOutline(eventBus, canvas, selection) {
+  this._canvas = canvas;
+
+  var self = this;
+
+  eventBus.on('element.changed', function(event) {
+    if (selection.isSelected(event.element)) {
+      self._updateMultiSelectionOutline(selection.get());
+    }
+  });
+
+  eventBus.on('selection.changed', function(event) {
+    var newSelection = event.newSelection;
+
+    self._updateMultiSelectionOutline(newSelection);
+  });
+}
+
+
+
+MultiSelectionOutline.prototype._updateMultiSelectionOutline = function(selection) {
+  var layer = this._canvas.getLayer('selectionOutline');
+
+  svgClear(layer);
+
+  var enabled = selection.length > 1;
+
+  var container = this._canvas.getContainer();
+
+  svgClasses(container)[enabled ? 'add' : 'remove']('djs-multi-select');
+
+  if (!enabled) {
+    return;
+  }
+
+  var bBox = addSelectionOutlinePadding(getBBox(selection));
+
+  var rect = svgCreate('rect');
+
+  svgAttr(rect, assign({
+    rx: 3
+  }, bBox));
+
+  svgClasses(rect).add('djs-selection-outline');
+
+  svgAppend(layer, rect);
+};
+
+
+MultiSelectionOutline.$inject = [ 'eventBus', 'canvas', 'selection' ];
+
+// helpers //////////
+
+function addSelectionOutlinePadding(bBox) {
+  return {
+    x: bBox.x - SELECTION_OUTLINE_PADDING,
+    y: bBox.y - SELECTION_OUTLINE_PADDING,
+    width: bBox.width + SELECTION_OUTLINE_PADDING * 2,
+    height: bBox.height + SELECTION_OUTLINE_PADDING * 2
+  };
+}

--- a/lib/features/outline/index.js
+++ b/lib/features/outline/index.js
@@ -1,10 +1,17 @@
+import SelectionModule from '../selection';
+
 import Outline from './Outline';
+import MultiSelectionOutline from './MultiSelectionOutline';
 
 
 /**
  * @type { import('didi').ModuleDeclaration }
  */
 export default {
-  __init__: [ 'outline' ],
-  outline: [ 'type', Outline ]
+  __depends__: [
+    SelectionModule
+  ],
+  __init__: [ 'outline', 'multiSelectionOutline' ],
+  outline: [ 'type', Outline ],
+  multiSelectionOutline: [ 'type', MultiSelectionOutline ]
 };

--- a/lib/features/selection/SelectionVisuals.js
+++ b/lib/features/selection/SelectionVisuals.js
@@ -1,29 +1,14 @@
 import {
-  assign,
   forEach
 } from 'min-dash';
-
-import {
-  append as svgAppend,
-  attr as svgAttr,
-  classes as svgClasses,
-  clear as svgClear,
-  create as svgCreate
-} from 'tiny-svg';
-
-import { getBBox } from '../../util/Elements';
 
 /**
  * @typedef {import('../../core/Canvas').default} Canvas
  * @typedef {import('../../core/EventBus').default} EventBus
- * @typedef {import('./Selection').default} Selection
  */
 
 var MARKER_HOVER = 'hover',
     MARKER_SELECTED = 'selected';
-
-var SELECTION_OUTLINE_PADDING = 6;
-
 
 /**
  * A plugin that adds a visible selection UI to shapes and connections
@@ -35,14 +20,9 @@ var SELECTION_OUTLINE_PADDING = 6;
  *
  * @param {Canvas} canvas
  * @param {EventBus} eventBus
- * @param {Selection} selection
  */
-export default function SelectionVisuals(canvas, eventBus, selection) {
+export default function SelectionVisuals(canvas, eventBus) {
   this._canvas = canvas;
-
-  var self = this;
-
-  this._multiSelectionBox = null;
 
   function addMarker(e, cls) {
     canvas.addMarker(e, cls);
@@ -84,59 +64,10 @@ export default function SelectionVisuals(canvas, eventBus, selection) {
         select(e);
       }
     });
-
-    self._updateSelectionOutline(newSelection);
-  });
-
-
-  eventBus.on('element.changed', function(event) {
-    if (selection.isSelected(event.element)) {
-      self._updateSelectionOutline(selection.get());
-    }
   });
 }
 
 SelectionVisuals.$inject = [
   'canvas',
-  'eventBus',
-  'selection'
+  'eventBus'
 ];
-
-SelectionVisuals.prototype._updateSelectionOutline = function(selection) {
-  var layer = this._canvas.getLayer('selectionOutline');
-
-  svgClear(layer);
-
-  var enabled = selection.length > 1;
-
-  var container = this._canvas.getContainer();
-
-  svgClasses(container)[enabled ? 'add' : 'remove']('djs-multi-select');
-
-  if (!enabled) {
-    return;
-  }
-
-  var bBox = addSelectionOutlinePadding(getBBox(selection));
-
-  var rect = svgCreate('rect');
-
-  svgAttr(rect, assign({
-    rx: 3
-  }, bBox));
-
-  svgClasses(rect).add('djs-selection-outline');
-
-  svgAppend(layer, rect);
-};
-
-// helpers //////////
-
-function addSelectionOutlinePadding(bBox) {
-  return {
-    x: bBox.x - SELECTION_OUTLINE_PADDING,
-    y: bBox.y - SELECTION_OUTLINE_PADDING,
-    width: bBox.width + SELECTION_OUTLINE_PADDING * 2,
-    height: bBox.height + SELECTION_OUTLINE_PADDING * 2
-  };
-}

--- a/lib/features/selection/index.js
+++ b/lib/features/selection/index.js
@@ -1,5 +1,4 @@
 import InteractionEventsModule from '../interaction-events';
-import OutlineModule from '../outline';
 
 import Selection from './Selection';
 import SelectionVisuals from './SelectionVisuals';
@@ -13,7 +12,6 @@ export default {
   __init__: [ 'selectionVisuals', 'selectionBehavior' ],
   __depends__: [
     InteractionEventsModule,
-    OutlineModule
   ],
   selection: [ 'type', Selection ],
   selectionVisuals: [ 'type', SelectionVisuals ],

--- a/test/spec/features/outline/MultiSelectionOutlineSpec.js
+++ b/test/spec/features/outline/MultiSelectionOutlineSpec.js
@@ -1,0 +1,190 @@
+import {
+  bootstrapDiagram,
+  inject,
+  getDiagramJS
+} from 'test/TestHelper';
+
+import outlineModule from 'lib/features/outline';
+import modelingModule from 'lib/features/modeling';
+
+import {
+  classes as domClasses,
+  query as domQuery
+} from 'min-dom';
+
+import { getBBox } from 'lib/util/Elements';
+
+
+describe('features/outline - MultiSelectionOutline', function() {
+
+  beforeEach(bootstrapDiagram({
+    modules: [
+      outlineModule,
+      modelingModule
+    ]
+  }));
+
+
+  var shape1, shape2;
+
+  beforeEach(inject(function(elementFactory, canvas, selection) {
+    shape1 = elementFactory.createShape({
+      id: 'shape1',
+      x: 100, y: 100, width: 100, height: 100
+    });
+
+    shape2 = elementFactory.createShape({
+      id: 'shape2',
+      x: 300, y: 100, width: 100, height: 100
+    });
+
+    canvas.addShape(shape1);
+    canvas.addShape(shape2);
+  }));
+
+
+  describe('container marker', function() {
+
+    it('should add <djs-multi-select> on multi-selection', inject(
+      function(selection, canvas) {
+
+        // given
+        var container = canvas.getContainer();
+
+        // when
+        selection.select([ shape1, shape2 ]);
+
+        // then
+        expect(domClasses(container).has('djs-multi-select')).to.be.true;
+
+        // but when
+        selection.select(null);
+
+        // then
+        expect(domClasses(container).has('djs-multi-select')).to.be.false;
+      }
+    ));
+
+
+    it('should not add <djs-multi-select> for single selection', inject(
+      function(selection, canvas) {
+
+        // given
+        var element = canvas.getContainer();
+
+        // when
+        selection.select([ shape1 ]);
+
+        // then
+        expect(domClasses(element).has('djs-multi-select'));
+      }
+    ));
+
+  });
+
+
+  describe('selection box', function() {
+
+    it('should show on multi-selection', inject(function(selection) {
+
+      // when
+      selection.select([ shape1, shape2 ]);
+
+      // then
+      expect(getOutlineGfx()).to.exist;
+    }));
+
+
+    it('should contain all selected elements', inject(function(selection) {
+
+      // when
+      selection.select([ shape1, shape2 ]);
+
+      // then
+      expectWithinOutlineBounds([ shape1, shape2 ]);
+    }));
+
+
+    it('should react to element changes', inject(function(selection, modeling) {
+
+      // given
+      selection.select([ shape1, shape2 ]);
+
+      // when
+      modeling.moveElements([ shape1 ], { x: 30, y: 50 });
+
+      // then
+      expectWithinOutlineBounds([ shape1, shape2 ]);
+    }));
+
+
+    it('should react to undo/redo', inject(
+      function(modeling, commandStack, selection) {
+
+        // given
+        selection.select([ shape1, shape2 ]);
+
+        modeling.moveElements([ shape1 ], { x: 30, y: 50 });
+
+        // when
+        commandStack.undo();
+
+        // then
+        expectWithinOutlineBounds([ shape1, shape2 ]);
+      }
+    ));
+
+  });
+
+});
+
+
+// helpers /////
+
+function getBounds(outline) {
+  return {
+    width: parseInt(outline.getAttribute('width')),
+    height: parseInt(outline.getAttribute('height')),
+    x: parseInt(outline.getAttribute('x')),
+    y: parseInt(outline.getAttribute('y'))
+  };
+}
+
+function expectShapeToBeWithinLimits(shape, limits) {
+  var bbox = getBBox(shape);
+
+  expect(bbox.x).to.be.at.least(limits.x);
+  expect(bbox.y).to.be.at.least(limits.y);
+  expect(bbox.x + bbox.width).to.be.at.most(limits.x + limits.width);
+  expect(bbox.y + bbox.height).to.be.at.most(limits.y + limits.height);
+}
+
+function expectWithinOutlineBounds(shapes) {
+  if (!Array.isArray(shapes)) {
+    shapes = [ shapes ];
+  }
+
+  const outlineBounds = getOutlineBounds();
+
+  // then
+  for (const shape of shapes) {
+    expectShapeToBeWithinLimits(shape, outlineBounds);
+  }
+}
+
+function getOutlineGfx() {
+
+  return getDiagramJS().invoke(function(canvas) {
+    const container = canvas.getContainer();
+
+    const gfx = domQuery('.djs-selection-outline', container);
+
+    expect(gfx, 'selection outline').to.exist;
+
+    return gfx;
+  });
+}
+
+function getOutlineBounds() {
+  return getBounds(getOutlineGfx());
+}

--- a/test/spec/features/outline/OutlineSpec.js
+++ b/test/spec/features/outline/OutlineSpec.js
@@ -3,25 +3,24 @@ import {
   inject
 } from 'test/TestHelper';
 
-import selectionModule from 'lib/features/selection';
+import outlineModule from 'lib/features/outline';
 
 import {
   query as domQuery
 } from 'min-dom';
 
 import {
-  classes as svgClasses,
   create as svgCreate,
   attr as svgAttr
 } from 'tiny-svg';
 
 
-describe('features/outline/Outline', function() {
+describe('features/outline - Outline', function() {
 
-  beforeEach(bootstrapDiagram({ modules: [ selectionModule ] }));
+  beforeEach(bootstrapDiagram({ modules: [ outlineModule ] }));
+
 
   it('should expose API', inject(function(outline) {
-
     expect(outline).to.exist;
     expect(outline.updateShapeOutline).to.exist;
   }));
@@ -50,9 +49,6 @@ describe('features/outline/Outline', function() {
       expect(outline).to.exist;
 
       expect(svgAttr(outline, 'x')).to.exist;
-
-      // outline class is set
-      expect(svgClasses(gfx).has('selected')).to.be.true;
     }));
 
 
@@ -71,9 +67,23 @@ describe('features/outline/Outline', function() {
       expect(outline).to.exist;
 
       expect(svgAttr(outline, 'x')).to.exist;
+    }));
 
-      // outline class is set
-      expect(svgClasses(gfx).has('selected')).to.be.true;
+
+    it('should not show box for connection', inject(function(selection, canvas, elementRegistry) {
+
+      // given
+      var connection = canvas.addConnection({ id: 'select1', waypoints: [ { x: 25, y: 25 }, { x: 115, y: 115 } ] });
+
+      // when
+      selection.select(connection);
+
+      // then
+      var gfx = elementRegistry.getGraphics(connection);
+      var outline = domQuery('.djs-outline', gfx);
+
+      expect(outline).to.exist;
+      expect(getComputedStyle(outline).display).to.equal('none');
     }));
 
   });
@@ -101,8 +111,8 @@ describe('features/outline/Outline', function() {
       var outline = domQuery('.djs-outline', gfx);
 
       expect(outline).to.exist;
-      expect(svgClasses(gfx).has('selected')).to.be.false; // Outline class is not set
     }));
+
   });
 
 
@@ -189,8 +199,8 @@ describe('features/outline/Outline', function() {
 
       var gfx = elementRegistry.getGraphics(shape);
       var outlineShape = domQuery('.djs-outline', gfx);
+
       expect(outlineShape).to.exist;
-      expect(svgClasses(gfx).has('selected')).to.be.true;
     }));
 
 
@@ -216,5 +226,7 @@ describe('features/outline/Outline', function() {
       // then
       expect(outlineElement.tagName).to.equal('rect');
     }));
+
   });
+
 });

--- a/test/spec/features/selection/SelectionBehaviorSpec.js
+++ b/test/spec/features/selection/SelectionBehaviorSpec.js
@@ -22,7 +22,7 @@ import {
 } from '../../../util/MockEvents';
 
 
-describe('features/selection/Selection', function() {
+describe('features/selection/SelectionBehavior', function() {
 
   beforeEach(bootstrapDiagram({
     modules: [

--- a/test/spec/features/selection/SelectionVisualsSpec.js
+++ b/test/spec/features/selection/SelectionVisualsSpec.js
@@ -4,36 +4,22 @@ import {
 } from 'test/TestHelper';
 
 import selectionModule from 'lib/features/selection';
-import modelingModule from 'lib/features/modeling';
 
 import {
-  classes as domClasses,
-  query as domQuery
-} from 'min-dom';
-
-import { getBBox } from 'lib/util/Elements';
-
-import {
-  resizeBounds
-} from 'lib/features/resize/ResizeUtil';
+  classes as svgClasses,
+} from 'tiny-svg';
 
 
 describe('features/selection/SelectionVisuals', function() {
 
-  beforeEach(bootstrapDiagram({ modules: [ selectionModule, modelingModule ] }));
-
-  describe('bootstrap', function() {
-
-    beforeEach(bootstrapDiagram({ modules: [ selectionModule ] }));
-
-    it('should bootstrap diagram with component', inject(function() {
-
-    }));
-
-  });
+  beforeEach(bootstrapDiagram({
+    modules: [
+      selectionModule
+    ]
+  }));
 
 
-  describe('selection box', function() {
+  describe('selection markers', function() {
 
     var shape, shape2, connection;
 
@@ -64,181 +50,106 @@ describe('features/selection/SelectionVisuals', function() {
     }));
 
 
-    describe('single element', function() {
+    it('should mark selected shape', inject(function(selection, canvas, elementRegistry) {
 
-      it('should show box on select', inject(function(selection, canvas) {
+      // given
+      var shape = canvas.addShape({
+        id: 'test',
+        x: 10,
+        y: 10,
+        width: 100,
+        height: 100
+      });
 
-        // when
-        selection.select(shape);
+      // when
+      selection.select(shape);
 
-        // then
-        var gfx = canvas.getGraphics(shape),
-            outline = domQuery('.djs-outline', gfx);
+      // then
+      var gfx = elementRegistry.getGraphics(shape);
 
-        expect(outline).to.exist;
-      }));
-
-
-      it('should not add djs-multi-select marker', inject(function(canvas) {
-
-        // when
-        var element = canvas.getContainer();
-
-        // then
-        expect(domClasses(element).has('djs-multi-select'));
-      }));
+      expect(svgClasses(gfx).has('selected')).to.be.true;
+    }));
 
 
-      it('should not show box for connection', inject(function(selection, canvas) {
+    it('should mark selected connection', inject(function(selection, canvas, elementRegistry) {
 
-        // when
-        // debugger;
-        selection.select(connection);
+      // given
+      var connection = canvas.addConnection({ id: 'select1', waypoints: [ { x: 25, y: 25 }, { x: 115, y: 115 } ] });
 
-        // then
-        var gfx = canvas.getGraphics(connection),
-            outline = domQuery('.djs-outline', gfx);
+      // when
+      selection.select(connection);
 
-        expect(outline).to.exist;
-        expect(getComputedStyle(outline).display).to.equal('none');
-      }));
+      // then
+      var gfx = elementRegistry.getGraphics(connection);
 
-    });
+      expect(svgClasses(gfx).has('selected')).to.be.true;
+    }));
 
 
-    describe('multi element', function() {
+    it('should unmark deselected shape', inject(function(selection, canvas, elementRegistry) {
 
-      var selectedShapes, outline, bounds;
+      // given
+      var shape = canvas.addShape({
+        id: 'test',
+        x: 10,
+        y: 10,
+        width: 100,
+        height: 100
+      });
 
-      beforeEach(inject(function(selection) {
+      // when
+      selection.select(shape);
+      selection.deselect(shape);
 
-        selectedShapes = [ connection, shape2 ];
-        selection.select(selectedShapes);
+      // then
+      var gfx = elementRegistry.getGraphics(shape);
 
-        outline = domQuery('.djs-selection-outline');
-
-        bounds = getBounds(outline);
-      }));
-
-
-      it('should show box', inject(function() {
-        expect(outline).to.exist;
-      }));
-
-
-      it('should add djs-multi-select marker', inject(function(selection, canvas) {
-
-        // when
-        var element = canvas.getContainer();
-
-        // then
-        expect(domClasses(element).has('djs-multi-select')).to.be.true;
-
-        // but when
-        selection.select(null);
-
-        // then
-        expect(domClasses(element).has('djs-multi-select')).to.be.false;
-      }));
+      expect(svgClasses(gfx).has('selected')).to.be.false;
+    }));
 
 
-      it('selection box should contain all selected elements', inject(function() {
+    it('should mark hovered shape', inject(function(canvas, elementRegistry, eventBus) {
 
-        // then
-        selectedShapes.forEach(function(shape) {
-          var bbox = getBBox(shape);
+      // given
+      var shape = canvas.addShape({
+        id: 'test',
+        x: 10,
+        y: 10,
+        width: 100,
+        height: 100
+      });
 
-          expect(bbox.x).to.be.at.least(bounds.x);
-          expect(bbox.y).to.be.at.least(bounds.y);
-          expect(bbox.x + bbox.width).to.be.at.most(bounds.x + bounds.width);
-          expect(bbox.y + bbox.height).to.be.at.most(bounds.y + bounds.height);
-        });
-      }));
+      // when
+      eventBus.fire('element.hover', { element: shape, gfx: canvas.getGraphics(shape) });
 
+      // then
+      var gfx = elementRegistry.getGraphics(shape);
 
-      it('selection box should react to element changes', inject(function(modeling) {
-
-        // when
-        modeling.resizeShape(shape2, resizeBounds(bounds, 'nw', { x: 10, y: 20 }));
-
-        outline = domQuery('.djs-selection-outline');
-
-        var newBounds = getBounds(outline);
-
-        // then
-        expect(newBounds).to.not.eql(bounds);
-
-        // then
-        selectedShapes.forEach(function(shape) {
-          var bbox = getBBox(shape);
-
-          expect(bbox.x).to.be.at.least(newBounds.x);
-          expect(bbox.y).to.be.at.least(newBounds.y);
-          expect(bbox.x + bbox.width).to.be.at.most(newBounds.x + newBounds.width);
-          expect(bbox.y + bbox.height).to.be.at.most(newBounds.y + newBounds.height);
-        });
-
-      }));
+      expect(svgClasses(gfx).has('hover')).to.be.true;
+    }));
 
 
-      it('selection box should react to undo/redo', inject(function(modeling, commandStack) {
+    it('should unmark unhovered shape', inject(function(canvas, elementRegistry, eventBus) {
 
-        // given
-        modeling.resizeShape(shape2, resizeBounds(shape, 'nw', { x: 10, y: 20 }));
+      // given
+      var shape = canvas.addShape({
+        id: 'test',
+        x: 10,
+        y: 10,
+        width: 100,
+        height: 100
+      });
 
-        var outline = domQuery('.djs-selection-outline');
+      // when
+      eventBus.fire('element.hover', { element: shape, gfx: canvas.getGraphics(shape) });
+      eventBus.fire('element.out', { element: shape, gfx: canvas.getGraphics(shape) });
 
-        var bounds = getBounds(outline);
+      // then
+      var gfx = elementRegistry.getGraphics(shape);
 
-        // when
-        commandStack.undo();
-
-        outline = domQuery('.djs-selection-outline');
-
-        var newBounds = getBounds(outline);
-
-        // then
-        expect(bounds).to.not.eql(newBounds);
-
-        // then
-        selectedShapes.forEach(function(shape) {
-          expectShapeToBeWithinLimits(shape, newBounds);
-        });
-
-      }));
-
-
-      it('should show box for connection', inject(function(canvas) {
-        var gfx = canvas.getGraphics(connection),
-            outlineShape = domQuery('.djs-outline', gfx);
-
-        expect(outlineShape).to.exist;
-        expect(getComputedStyle(outlineShape).display).to.not.equal('none');
-      }));
-
-    });
+      expect(svgClasses(gfx).has('hover')).to.be.false;
+    }));
 
   });
 
 });
-
-
-// helpers /////
-
-function getBounds(outline) {
-  return {
-    width: parseInt(outline.getAttribute('width')),
-    height: parseInt(outline.getAttribute('height')),
-    x: parseInt(outline.getAttribute('x')),
-    y: parseInt(outline.getAttribute('y'))
-  };
-}
-
-function expectShapeToBeWithinLimits(shape, limits) {
-  var bbox = getBBox(shape);
-
-  expect(bbox.x).to.be.at.least(limits.x);
-  expect(bbox.y).to.be.at.least(limits.y);
-  expect(bbox.x + bbox.width).to.be.at.most(limits.x + limits.width);
-  expect(bbox.y + bbox.height).to.be.at.most(limits.y + limits.height);
-}


### PR DESCRIPTION
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

This PR moves multi selection outline logic from `selection` to `outline`. As a result selection is a non-UI component, and outline builds (optionally) on top of it.

Closes #944 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
