### PR TITLE
Simplify search pad preselect

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -984,7 +984,7 @@
   background: var(--search-result-hover-background-color);
 }
 
-.djs-element.djs-search-preselected .djs-outline {
+.djs-search-open .djs-element .djs-outline {
   fill: var(--search-preselected-background-color) !important;
 }
 

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -336,6 +336,8 @@ SearchPad.prototype.open = function() {
   this._cachedSelection = this._selection.get();
   this._cachedViewbox = this._canvas.viewbox();
 
+  this._selection.select(null);
+
   this._bindEvents();
 
   this._open = true;

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -192,7 +192,6 @@ SearchPad.prototype._search = function(pattern) {
   });
 
   if (!searchResults.length) {
-    this._clearMarkers();
     this._selection.select(null);
 
     return;
@@ -266,16 +265,6 @@ SearchPad.prototype._clearResults = function() {
   this._results = {};
 
   this._eventBus.fire('searchPad.cleared');
-};
-
-
-/**
- * Clears all markers.
- */
-SearchPad.prototype._clearMarkers = function() {
-  for (var id in this._results) {
-    this._canvas.removeMarker(this._results[id].element, 'djs-search-preselected');
-  }
 };
 
 
@@ -395,8 +384,6 @@ SearchPad.prototype.close = function(restoreCached = true) {
   domClasses(this._canvas.getContainer()).remove('djs-search-open');
   domClasses(this._container).remove('open');
 
-  this._clearMarkers();
-
   this._clearResults();
 
   this._searchInput.value = '';
@@ -437,8 +424,6 @@ SearchPad.prototype._preselect = function(node) {
     return;
   }
 
-  this._clearMarkers();
-
   // removing preselection from current node
   if (selectedNode) {
     domClasses(selectedNode).remove(SearchPad.RESULT_SELECTED_CLASS);
@@ -454,8 +439,6 @@ SearchPad.prototype._preselect = function(node) {
   });
 
   this._selection.select(element);
-
-  this._canvas.addMarker(element, 'djs-search-preselected');
 
   this._eventBus.fire('searchPad.preselected', element);
 };

--- a/test/spec/features/search-pad/SearchPadSpec.js
+++ b/test/spec/features/search-pad/SearchPadSpec.js
@@ -445,7 +445,6 @@ describe('features/search-pad', function() {
       expect(domClasses(result_nodes[0]).has(SearchPad.RESULT_SELECTED_CLASS)).to.be.true;
       expect(capturedEvents).to.eql([ EVENTS.opened, EVENTS.preselected ]);
       expect(selection.isSelected(elements.two.a)).to.be.true;
-      expect(domClasses(canvas.getGraphics(elements.two.a)).has('djs-search-preselected')).to.be.true;
     }));
 
 
@@ -466,7 +465,6 @@ describe('features/search-pad', function() {
       ]);
 
       expect(selection.isSelected(elements.two.a)).to.be.true;
-      expect(domClasses(canvas.getGraphics(elements.two.a)).has('djs-search-preselected')).to.be.false;
     }));
 
 
@@ -484,8 +482,6 @@ describe('features/search-pad', function() {
 
       // then
       expect(selection.isSelected(elements.one.a)).to.be.true;
-
-      expect(domClasses(canvas.getGraphics(elements.two.a)).has('djs-search-preselected')).to.be.false;
     }));
 
 

--- a/test/spec/features/search-pad/SearchPadSpec.js
+++ b/test/spec/features/search-pad/SearchPadSpec.js
@@ -179,31 +179,35 @@ describe('features/search-pad', function() {
   }));
 
 
-  it('should open', inject(function(searchPad) {
+  describe('open', function() {
 
-    // when
-    searchPad.open();
+    it('should open', inject(function(searchPad) {
 
-    // then
-    expect(searchPad.isOpen()).to.equal(true);
-    expect(capturedEvents).to.eql([ EVENTS.opened ]);
-  }));
-
-
-  it('should error on open when provider not registered', inject(function(searchPad) {
-
-    // given
-    searchPad.registerProvider(undefined);
-
-    // when
-    expect(function() {
+      // when
       searchPad.open();
-    }).to.throw('no search provider registered');
 
-    // then
-    expect(searchPad.isOpen()).to.equal(false);
-    expect(capturedEvents).to.eql([]);
-  }));
+      // then
+      expect(searchPad.isOpen()).to.equal(true);
+      expect(capturedEvents).to.eql([ EVENTS.opened ]);
+    }));
+
+
+    it('should error when provider not registered', inject(function(searchPad) {
+
+      // given
+      searchPad.registerProvider(undefined);
+
+      // when
+      expect(function() {
+        searchPad.open();
+      }).to.throw('no search provider registered');
+
+      // then
+      expect(searchPad.isOpen()).to.equal(false);
+      expect(capturedEvents).to.eql([]);
+    }));
+
+  });
 
 
   describe('close', function() {

--- a/test/spec/features/search-pad/SearchPadSpec.js
+++ b/test/spec/features/search-pad/SearchPadSpec.js
@@ -25,6 +25,7 @@ var EVENTS = {
   selected: 'searchPad.selected'
 };
 
+var SEARCH_OPEN_MARKER_CLS = 'djs-search-open';
 
 describe('features/search-pad', function() {
 
@@ -205,6 +206,16 @@ describe('features/search-pad', function() {
     }));
 
 
+    it('should attach <open> marker to diagram container', inject(function(searchPad) {
+
+      // when
+      searchPad.open();
+
+      // then
+      expectOpenMarker(true);
+    }));
+
+
     it('should error when provider not registered', inject(function(searchPad) {
 
       // given
@@ -250,6 +261,19 @@ describe('features/search-pad', function() {
       // then
       expect(searchPad.isOpen()).to.equal(false);
       expect(capturedEvents).to.eql([ EVENTS.opened, EVENTS.closed ]);
+    }));
+
+
+    it('should remove <open> marker from diagram container', inject(function(searchPad) {
+
+      // given
+      searchPad.open();
+
+      // when
+      searchPad.close();
+
+      // then
+      expectOpenMarker(false);
     }));
 
 
@@ -744,5 +768,16 @@ function expectResultsHTML(expectedResults) {
         expectedResult.secondary
       );
     });
+  });
+}
+
+
+function expectOpenMarker(expected) {
+
+  return getDiagramJS().invoke((canvas) => {
+
+    const container = canvas.getContainer();
+
+    expect(domClasses(container).has(SEARCH_OPEN_MARKER_CLS)).to.equal(expected);
   });
 }

--- a/test/spec/features/search-pad/SearchPadSpec.js
+++ b/test/spec/features/search-pad/SearchPadSpec.js
@@ -192,6 +192,19 @@ describe('features/search-pad', function() {
     }));
 
 
+    it('should clear selection', inject(function(searchPad, selection) {
+
+      // given
+      selection.select(elements.one.a);
+
+      // when
+      searchPad.open();
+
+      // then
+      expect(selection.get()).to.be.empty;
+    }));
+
+
     it('should error when provider not registered', inject(function(searchPad) {
 
       // given


### PR DESCRIPTION
### Proposed Changes

I traced a bug that caused the `preselect` marker class not being removed from an element. In the process I found that the whole marker logic we introduced via https://github.com/bpmn-io/diagram-js/pull/913 is _not_ necessary, after all: We use standard selection, and attach a `djs-search-open` marker to the diagram container; this is enough for us to handle "special selection" using plain CSS:

![capture iCAZbM_optimized](https://github.com/user-attachments/assets/0d904a6a-0e6c-4d26-a5e3-61732477f0d7)

_The change in action, testing against [bpmn-js](https://github.com/bpmn-io/bpmn-js)._

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
