### PR TITLE
fix(keyboard): bind-method typing still requires EventTarget

### DIFF
--- a/lib/features/keyboard/Keyboard.js
+++ b/lib/features/keyboard/Keyboard.js
@@ -126,7 +126,7 @@ Keyboard.prototype._isEventIgnored = function(event) {
  * Bind keyboard events to the given DOM node.
  *
  * @overlord
- * @deprecated
+ * @deprecated No longer in use since version 15.0.0.
  *
  * @param {EventTarget} node
  */

--- a/lib/features/keyboard/Keyboard.js
+++ b/lib/features/keyboard/Keyboard.js
@@ -49,7 +49,7 @@ var compatMessage = 'Keyboard binding is now implicit; explicit binding to an el
  * `keyboard.bind=true|false` configuration option.
  *
  * @param {Object} config
- * @param {EventTarget} [config.bindTo]
+ * @param {boolean} [config.bind]
  * @param {EventBus} eventBus
  */
 export default function Keyboard(config, eventBus) {
@@ -125,10 +125,17 @@ Keyboard.prototype._isEventIgnored = function(event) {
 /**
  * Bind keyboard events to the given DOM node.
  *
+ * @overlord
+ * @deprecated
+ *
  * @param {EventTarget} node
+ */
+/**
+ * Bind keyboard events to the canvas node.
  */
 Keyboard.prototype.bind = function(node) {
 
+  // legacy <node> argument provided
   if (node) {
     console.error('unsupported argument <node>', new Error(compatMessage));
   }

--- a/lib/features/keyboard/Keyboard.spec.ts
+++ b/lib/features/keyboard/Keyboard.spec.ts
@@ -1,0 +1,12 @@
+import Diagram from '../../Diagram';
+import Keyboard from './Keyboard';
+
+const diagram = new Diagram();
+
+let keyboard = diagram.get<Keyboard>('keyboard');
+
+keyboard.bind();
+
+keyboard.unbind();
+
+keyboard.bind(document);


### PR DESCRIPTION
### Proposed Changes

In a previous update the ability to bind the keyboard to a specific node has been removed. The current JS-doc resulted in a generated type definition still requiring an `EventTarget` as parameter for the `bind` method even though supplying this parameter leads to an error and has no effect.

Prior (generated `Keyboard.d.ts`):

```
  /**
   * Bind keyboard events to the given DOM node.
   *
   * @param node
   */
  bind(node: EventTarget): void;
```

After:

```
  /**
   * Bind keyboard events to the given DOM node.
   *
   * @param node
   */
  bind(node: undefined): void;
```

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached: See comparison above
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr): Just use type generation
* [x] Related issue linked: I've not filed an issue yet


---

Related to https://github.com/bpmn-io/diagram-js/pull/662