### PR TITLE
fix(search): prioritize start of word and exact match more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+* `FIX`: do not search/filter on whitespace only ([#954](https://github.com/bpmn-io/diagram-js/pull/954))
+
 ## 15.2.2
 
 * `FIX`: correct `Keyboard#bind` and config types ([#948](https://github.com/bpmn-io/diagram-js/pull/948))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
-* `FIX`: do not search/filter on whitespace only ([#954](https://github.com/bpmn-io/diagram-js/pull/954))
+* `FIX`: adjust search to prioritize start of word and exact matches ([#953](https://github.com/bpmn-io/diagram-js/pull/953))
+* `FIX`: ignore whitespace when searching ([#954](https://github.com/bpmn-io/diagram-js/pull/954))
 
 ## 15.2.2
 

--- a/lib/features/search/search.js
+++ b/lib/features/search/search.js
@@ -181,10 +181,16 @@ function scoreToken(token) {
   }
 
   return token.start
-    ? 1.37
-    : token.wordStart
-      ? 1.13
-      : 1;
+    ? (
+      token.end
+        ? 131.9
+        : 7.87
+    )
+    : (
+      token.wordStart
+        ? 2.19
+        : 1
+    );
 }
 
 /**
@@ -223,7 +229,12 @@ function matchString(string, words) {
   const tokens = [];
   const matchedWords = {};
 
-  const regexpString = words.map(escapeRegexp).flatMap(str => [ '(?<wordStart>\\b' + str + ')', str ]).join('|');
+  const wordsEscaped = words.map(escapeRegexp);
+
+  const regexpString = [
+    `(?<all>${wordsEscaped.join('\\s+')})`,
+    ...wordsEscaped
+  ].join('|');
 
   const regexp = new RegExp(regexpString, 'ig');
 
@@ -233,6 +244,17 @@ function matchString(string, words) {
   while ((match = regexp.exec(string))) {
 
     const [ value ] = match;
+
+    const startIndex = match.index;
+    const endIndex = match.index + value.length;
+
+    const start = startIndex === 0;
+    const end = endIndex === string.length;
+
+    const all = !!match.groups.all;
+
+    const wordStart = start || /\s/.test(string.charAt(startIndex - 1));
+    const wordEnd = end || /\s/.test(string.charAt(endIndex + 1));
 
     if (match.index > lastIndex) {
 
@@ -248,11 +270,18 @@ function matchString(string, words) {
       value,
       index: match.index,
       match: true,
-      wordStart: !!match.groups.wordStart,
-      start: match.index === 0
+      wordStart,
+      wordEnd,
+      start,
+      end,
+      all
     });
 
-    matchedWords[value.toLowerCase()] = true;
+    const newMatchedWords = all ? words : [ value ];
+
+    for (const word of newMatchedWords) {
+      matchedWords[word.toLowerCase()] = true;
+    }
 
     lastIndex = match.index + value.length;
   }

--- a/lib/features/search/search.js
+++ b/lib/features/search/search.js
@@ -169,28 +169,33 @@ function scoreTokens(tokens) {
 }
 
 /**
- * Score a token.
+ * Score a token based on its characteristics
+ * and the length of the matched content.
  *
  * @param { Token } token
  *
  * @returns { number }
  */
 function scoreToken(token) {
+  const modifier = Math.log(token.value.length);
+
   if (!token.match) {
-    return 0;
+    return -0.07 * modifier;
   }
 
-  return token.start
-    ? (
-      token.end
-        ? 131.9
-        : 7.87
-    )
-    : (
-      token.wordStart
-        ? 2.19
-        : 1
-    );
+  return (
+    token.start
+      ? (
+        token.end
+          ? 131.9
+          : 7.87
+      )
+      : (
+        token.wordStart
+          ? 2.19
+          : 1
+      )
+  ) * modifier;
 }
 
 /**

--- a/test/spec/features/search/searchSpec.js
+++ b/test/spec/features/search/searchSpec.js
@@ -189,16 +189,13 @@ describe('features/search', function() {
     // given
     const items = [
       {
-        title: 'bar baz foo',
-        description: 'bar'
+        title: 'foobar'
       },
       {
-        title: 'foo',
-        description: 'bar'
+        title: 'bar baz ofoo foo -+ofoo woofoo foo'
       },
       {
-        title: 'baz foo',
-        description: 'bar'
+        title: 'baz foo'
       }
     ];
 
@@ -212,8 +209,8 @@ describe('features/search', function() {
 
     // then
     expect(results).to.have.length(3);
-    expect(results[0].item).to.eql(items[1]);
-    expect(results[1].item).to.eql(items[0]);
+    expect(results[0].item).to.eql(items[0]);
+    expect(results[1].item).to.eql(items[1]);
     expect(results[2].item).to.eql(items[2]);
   }));
 
@@ -223,13 +220,19 @@ describe('features/search', function() {
     // given
     const items = [
       {
-        title: 'baz foo bar'
+        title: 'foo bar'
+      },
+      {
+        title: 'foo baz and very long additional text\nalso foo bar'
+      },
+      {
+        title: 'baz and very long foo bar bar bar\nalso foo bar'
       },
       {
         title: 'foo bar baz'
       },
       {
-        title: 'foo bar'
+        title: 'baz foo bar'
       }
     ];
 
@@ -241,10 +244,12 @@ describe('features/search', function() {
     });
 
     // then
-    expect(results).to.have.length(3);
-    expect(results[0].item).to.eql(items[2]);
+    expect(results).to.have.length(5);
+    expect(results[0].item).to.eql(items[0]);
     expect(results[1].item).to.eql(items[1]);
-    expect(results[2].item).to.eql(items[0]);
+    expect(results[2].item).to.eql(items[2]);
+    expect(results[3].item).to.eql(items[3]);
+    expect(results[4].item).to.eql(items[4]);
   }));
 
 
@@ -253,10 +258,13 @@ describe('features/search', function() {
     // given
     const items = [
       {
-        title: 'yes barfoo'
+        title: 'yes foowoo'
       },
       {
-        title: 'yes foowoo'
+        title: 'yesfoo woofoo'
+      },
+      {
+        title: 'yes barfoo'
       }
     ];
 
@@ -268,9 +276,10 @@ describe('features/search', function() {
     });
 
     // then
-    expect(results).to.have.length(2);
-    expect(results[0].item).to.eql(items[1]);
-    expect(results[1].item).to.eql(items[0]);
+    expect(results).to.have.length(3);
+    expect(results[0].item).to.eql(items[0]);
+    expect(results[1].item).to.eql(items[1]);
+    expect(results[2].item).to.eql(items[2]);
   }));
 
 
@@ -399,12 +408,12 @@ describe('features/search', function() {
     // given
     const items = [
       {
-        title: 'Kafka amess',
-        description: 'Nope'
-      },
-      {
         title: 'mess',
         description: 'kafka'
+      },
+      {
+        title: 'Kafka amess',
+        description: 'Nope'
       },
       {
         title: 'mess'
@@ -460,7 +469,7 @@ describe('features/search', function() {
     // given
     const items = [
       {
-        title: 'bar foo bar'
+        title: 'bar foo   bar'
       }
     ];
 

--- a/test/spec/features/search/searchSpec.js
+++ b/test/spec/features/search/searchSpec.js
@@ -223,13 +223,13 @@ describe('features/search', function() {
         title: 'foo bar'
       },
       {
-        title: 'foo baz and very long additional text\nalso foo bar'
+        title: 'foo bar baz'
       },
       {
         title: 'baz and very long foo bar bar bar\nalso foo bar'
       },
       {
-        title: 'foo bar baz'
+        title: 'foo baz and very long additional text\nalso foo bar'
       },
       {
         title: 'baz foo bar'
@@ -250,6 +250,32 @@ describe('features/search', function() {
     expect(results[2].item).to.eql(items[2]);
     expect(results[3].item).to.eql(items[3]);
     expect(results[4].item).to.eql(items[4]);
+  }));
+
+
+  it('should prioritize longest match', inject(function(search) {
+
+    // given
+    const items = [
+      {
+        title: 'yes foowoo'
+      },
+      {
+        title: 'yeskay foowoo'
+      }
+    ];
+
+    // when
+    const results = search(items, 'yes foo', {
+      keys: [
+        'title'
+      ]
+    });
+
+    // then
+    expect(results).to.have.length(2);
+    expect(results[0].item).to.eql(items[0]);
+    expect(results[1].item).to.eql(items[1]);
   }));
 
 


### PR DESCRIPTION
Test via `npx @bpmn-io/sr bpmn-io/bpmn-js -l bpmn-io/diagram-js#search-start`

### Proposed Changes

This prioritizes start of term and exact matches more aggressively.

_This yields more substantial results in large popup (append) menus:_

![capture SO2PNd_optimized](https://github.com/user-attachments/assets/fbd38b35-db27-4bf4-b88f-8908449a6d03)

_This yields better search results when querying larger data pools, where exact matches would otherwise de-prioritized:_

![capture 5sTQ3Y_optimized](https://github.com/user-attachments/assets/25968d5f-b157-4fa2-9cae-bb755d2ac38b)


Related to https://github.com/camunda/camunda-modeler/issues/4122, https://github.com/camunda/camunda-modeler/issues/3439.


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
