### PR TITLE
Handle empty search queries (ignore it)

### DIFF
--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -79,7 +79,7 @@ export default function PopupMenuComponent(props) {
       return originalEntries;
     }
 
-    if (!value) {
+    if (!value.trim()) {
       return originalEntries.filter(({ rank = 0 }) => rank >= 0);
     }
 

--- a/lib/features/search-pad/SearchPad.js
+++ b/lib/features/search-pad/SearchPad.js
@@ -181,7 +181,7 @@ SearchPad.prototype._search = function(pattern) {
   this._clearResults();
 
   // do not search on empty query
-  if (!pattern || pattern === '') {
+  if (!pattern.trim()) {
     return;
   }
 

--- a/lib/features/search/search.js
+++ b/lib/features/search/search.js
@@ -36,6 +36,12 @@ export default function search(items, pattern, options) {
     keys
   } = options;
 
+  pattern = pattern.trim().toLowerCase();
+
+  if (!pattern) {
+    throw new Error('<pattern> must not be empty');
+  }
+
   const words = pattern.trim().toLowerCase().split(/\s+/);
 
   return items.flatMap((item) => {

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -1531,6 +1531,25 @@ describe('features/popup-menu', function() {
     }));
 
 
+    it('should handle whitespace only search', inject(async function(popupMenu) {
+
+      // given
+      popupMenu.registerProvider('test-menu', testMenuProvider);
+      popupMenu.open({}, 'test-menu', { x: 100, y: 100 }, { search: true });
+
+      // when
+      await triggerSearch('   ');
+
+      // then
+      await waitFor(() => {
+        const shownEntries = queryPopupAll('.entry');
+
+        // just ignores it
+        expect(shownEntries).to.have.length(5);
+      });
+    }));
+
+
     describe('ranking', function() {
 
       it('should hide rank < 0 items', inject(async function(popupMenu) {

--- a/test/spec/features/search-pad/SearchPadSpec.js
+++ b/test/spec/features/search-pad/SearchPadSpec.js
@@ -450,6 +450,19 @@ describe('features/search-pad', function() {
     }));
 
 
+    it('should ignore whitespace only', inject(function(canvas) {
+
+      // given
+      var find = sinon.spy(searchProvider, 'find');
+
+      // when
+      typeText(input_node, '  ');
+
+      // then
+      expect(find).callCount(0);
+    }));
+
+
     it('should search per key stroke', inject(function(canvas) {
 
       // given

--- a/test/spec/features/search/searchSpec.js
+++ b/test/spec/features/search/searchSpec.js
@@ -475,6 +475,22 @@ describe('features/search', function() {
     expect(results).to.have.length(1);
   }));
 
+
+  it('should error on whitespace pattern', inject(function(search) {
+
+    // given
+    const fn = () => {
+      search([], ' ', {
+        keys: [
+          'title'
+        ]
+      });
+    };
+
+    // then
+    expect(fn).to.throw(/<pattern> must not be empty/);
+  }));
+
 });
 
 


### PR DESCRIPTION
### Proposed Changes

This ensures that search only handles non-empty search queries, components integrating with it need to ensure that non-empty search is provided:

_Whitespace only ignored by global search:_

![capture GwTb2G_optimized](https://github.com/user-attachments/assets/9828f18c-d3f9-4397-a4c3-ad4b396d5969)

_Whitespace only ignored by popup menu search:_

![capture kXsF2w_optimized](https://github.com/user-attachments/assets/254c83fe-55fe-4c97-a64a-a83fee66a34a)


Related to https://github.com/camunda/camunda-modeler/pull/4711#issuecomment-2491044304


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
