### PR TITLE
fix(core/Canvas): explicitly enable autoFocus

### DIFF
--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -49,6 +49,7 @@ import { createMatrix as createMatrix } from 'tiny-svg';
  *   deferUpdate?: boolean;
  *   width?: number;
  *   height?: number;
+ *   autoFocus?: boolean;
  * } } CanvasConfig
  * @typedef { {
  *   group: SVGElement;
@@ -235,7 +236,7 @@ Canvas.prototype._init = function(config) {
 
   domAttr(svg, 'tabindex', 0);
 
-  eventBus.on('element.hover', () => {
+  config.autoFocus && eventBus.on('element.hover', () => {
     this.restoreFocus();
   });
 

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -20,7 +20,7 @@ import {
 import { getChildren as getChildrenGfx } from 'lib/util/GraphicsUtil';
 
 
-describe('Canvas', function() {
+describe('core/Canvas', function() {
 
   var container;
 
@@ -112,7 +112,7 @@ describe('Canvas', function() {
       });
 
 
-      it('should focus if body is focused', inject(function(canvas, eventBus) {
+      it('should NOT focus if body is focused', inject(function(canvas, eventBus) {
 
         // given
         var svg = container.querySelector('svg');
@@ -124,7 +124,7 @@ describe('Canvas', function() {
         });
 
         // then
-        expect(document.activeElement).to.equal(svg);
+        expect(document.activeElement).to.not.equal(svg);
       }));
 
 
@@ -170,6 +170,37 @@ describe('Canvas', function() {
       }));
 
     });
+
+  });
+
+
+  describe('focus handling <config.autoFocus>', function() {
+
+    beforeEach(function() {
+      container = TestContainer.get(this);
+    });
+
+    beforeEach(createDiagram({
+      canvas: {
+        autoFocus: true
+      }
+    }));
+
+
+    it('should focus if body is focused', inject(function(canvas, eventBus) {
+
+      // given
+      var svg = container.querySelector('svg');
+
+      // when
+      eventBus.fire('element.hover', {
+        element: canvas.getRootElement(),
+        gfx: svg
+      });
+
+      // then
+      expect(document.activeElement).to.equal(svg);
+    }));
 
   });
 


### PR DESCRIPTION
### Proposed Changes

This ensures we're _NOT_ automatically auto-focusing the canvas on any hover. Instead integrators must explicitly decide if this is desired, i.e. because the diagram is embedded as a "full page editor". We'll otherwise break embedding with existing applications, cf. https://github.com/bpmn-io/bpmn-js-examples/pull/302.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
