### PR TITLE
FIx undo/redo for collapsed subprocesses

### DIFF
--- a/lib/core/GraphicsFactory.js
+++ b/lib/core/GraphicsFactory.js
@@ -192,6 +192,11 @@ GraphicsFactory.prototype.updateContainments = function(elements) {
     forEach(children.slice().reverse(), function(child) {
       var childGfx = elementRegistry.getGraphics(child);
 
+      // shape was removed
+      if (!childGfx) {
+        return;
+      }
+
       prependTo(childGfx.parentNode, childrenGfx);
     });
   });

--- a/lib/features/modeling/cmd/MoveConnectionHandler.js
+++ b/lib/features/modeling/cmd/MoveConnectionHandler.js
@@ -58,7 +58,7 @@ MoveConnectionHandler.prototype.revert = function(context) {
       delta = context.delta;
 
   // remove from newParent
-  collectionRemove(newParent.children, connection);
+  newParent && collectionRemove(newParent.children, connection);
 
   // restore previous location in old parent
   collectionAdd(oldParent.children, connection, oldParentIndex);


### PR DESCRIPTION
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

Related to https://github.com/bpmn-io/bpmn-js/issues/2269

Add some null checks to prevent crashes when undo/redo adds or removes a collapsed subprocess.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
