### PR TITLE
fix(ZoomScroll): fix horizontal scroll

### DIFF
--- a/lib/navigation/zoomscroll/ZoomScroll.js
+++ b/lib/navigation/zoomscroll/ZoomScroll.js
@@ -128,8 +128,6 @@ ZoomScroll.prototype._handleWheel = function handleWheel(event) {
 
   var isZoom = event.ctrlKey || (isMac() && event.metaKey);
 
-  var isHorizontalScroll = event.shiftKey;
-
   var factor = -1 * this._scale,
       delta;
 
@@ -158,17 +156,10 @@ ZoomScroll.prototype._handleWheel = function handleWheel(event) {
     this.zoom(delta, offset);
   } else {
 
-    if (isHorizontalScroll) {
-      delta = {
-        dx: factor * event.deltaY,
-        dy: 0
-      };
-    } else {
-      delta = {
-        dx: factor * event.deltaX,
-        dy: factor * event.deltaY
-      };
-    }
+    delta = {
+      dx: factor * event.deltaX,
+      dy: factor * event.deltaY
+    };
 
     this.scroll(delta);
   }

--- a/test/spec/navigation/zoomscoll/ZoomScrollSpec.js
+++ b/test/spec/navigation/zoomscoll/ZoomScrollSpec.js
@@ -318,13 +318,13 @@ describe('navigation/zoomscroll', function() {
 
       it('axis inverted via shiftKey', expectScroll({
         expectedDelta: {
-          dx: -10.5,
+          dx: -25.5,
           dy: 0
         },
         onWheel: {
           deltaMode: 0,
           deltaX: 34,
-          deltaY: 14,
+          deltaY: -0,
           shiftKey: true
         }
       }));


### PR DESCRIPTION
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

We have a horizontal scroll feature when scrolling while holding Shift, but it seemed to be broken. This should fix it.

It seems we don't need to detect the Shift key and manually revert mouse wheel axis. When the Shift key is pressed, the mouse wheel event correctly sends `deltaX` instead of `deltaY`. 

I tested it in all major browsers and it works. Perhaps the implementation of some DOM events has changed since this was built 7 years ago? 🤔

Try it:
```sh
npx @bpmn-io/sr -l="bpmn-io/diagram-js#horizontal-scroll-fix" bpmn-io/bpmn-js
```

https://github.com/user-attachments/assets/5d0895cc-f563-4121-8ce8-70e4e18f8191



### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
