### PR TITLE
Increase closeBy position to accommodate higher screen resolutions

### DIFF
--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -2108,7 +2108,7 @@ describe('features/popup-menu', function() {
       };
 
       // then
-      expect(menu.offsetTop).to.be.closeTo(y - menuDimensions.height, 3);
+      expect(menu.offsetTop).to.be.closeTo(y - menuDimensions.height, 4);
     }));
 
 
@@ -2130,7 +2130,7 @@ describe('features/popup-menu', function() {
       };
 
       // then
-      expect(menu.offsetTop).to.be.closeTo(documentBounds.top + menuDimensions.height, 3);
+      expect(menu.offsetTop).to.be.closeTo(documentBounds.top + menuDimensions.height, 4);
     }));
 
 

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -2112,7 +2112,7 @@ describe('features/popup-menu', function() {
     }));
 
 
-    it('should open within bounds bellow', inject(function(popupMenu) {
+    it('should open within bounds below', inject(function(popupMenu) {
 
       // given
       var documentBounds = document.documentElement.getBoundingClientRect();


### PR DESCRIPTION
### Proposed Changes

On systems with high resolution screens, one test fails as it is of by a slightly higher number the higher the screen resolution is. This is a hotfix to accomodate more screen sizes. Other suggestions to fix this test are welcome.

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
