### PR TITLE
Fix(#975): prevent erroneous stopPropagation for async listeners in EventBus

### DIFF
--- a/lib/core/EventBus.js
+++ b/lib/core/EventBus.js
@@ -456,6 +456,12 @@ EventBus.prototype._invokeListener = function(event, args, listener) {
     // returning false prevents the default action
     returnValue = invokeFunction(listener.callback, args);
 
+    // Avoid stopping propagation if the listener is async
+    // Cause it calls async listener but do not wait for it
+    if (isPromise(returnValue)) {
+      returnValue = undefined;
+    }
+
     // stop propagation on return value
     if (returnValue !== undefined) {
       event.returnValue = returnValue;
@@ -612,4 +618,18 @@ InternalEvent.prototype.init = function(data) {
  */
 function invokeFunction(fn, args) {
   return fn.apply(null, args);
+}
+
+
+/**
+ * Checks if a given value is a Promise.
+ *
+ * A value is considered a Promise if it is an object or a function
+ * and has a `then` method of type function.
+ *
+ * @param {*} value - The value to check.
+ * @returns {boolean} `true` if the value is a Promise, otherwise `false`.
+ */
+function isPromise(value) {
+  return !!value && (typeof value === 'object' || typeof value === 'function') && typeof value.then === 'function';
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/bpmn-io/diagram-js"
   },
   "engines": {
-    "node": "*"
+    "node": ">=8"
   },
   "keywords": [
     "modeler",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "all": "run-s lint test generate-types",
     "lint": "eslint .",
     "dev": "npm test -- --auto-watch --no-single-run",
+    "dev:debug": "node --inspect-brk ./node_modules/karma/bin/karma start --auto-watch --no-single-run",
     "generate-types": "run-s generate-types:*",
     "generate-types:generate": "del-cli \"lib/**/*.d.ts\" && npx bio-dts -r lib",
     "generate-types:test": "tsc --noEmit --noImplicitAny",

--- a/test/spec/core/EventBusSpec.js
+++ b/test/spec/core/EventBusSpec.js
@@ -26,6 +26,79 @@ describe('core/EventBus', function() {
       expect(listener).to.have.been.called;
     });
 
+    it('should fire async listeners before sync listeners', function() {
+
+      // given
+      var listener = sinon.spy();
+      var asyncListener = sinon.spy(async function(params) {
+        return undefined;
+      });
+
+      eventBus.on('foo', asyncListener);
+      eventBus.on('foo', listener);
+
+      // when
+      eventBus.fire('foo', {});
+
+      // then
+      expect(listener).to.have.been.called;
+      expect(asyncListener).to.have.been.called;
+    });
+
+    it('should fire async listeners after sync listeners', function() {
+
+      // given
+      var listener = sinon.spy();
+      var asyncListener = sinon.spy(async function(params) {
+        return undefined;
+      });
+
+      eventBus.on('foo', listener);
+      eventBus.on('foo', asyncListener);
+
+      // when
+      eventBus.fire('foo', {});
+
+      // then
+      expect(listener).to.have.been.called;
+      expect(asyncListener).to.have.been.called;
+    });
+
+    it('should fire async listeners and do NOT stop propagation', function() {
+
+      // given
+      var listener = sinon.spy();
+      var asyncListener = sinon.spy(async function() {
+        return false;
+      });
+
+      eventBus.on('foo', asyncListener);
+      eventBus.on('foo', listener);
+
+      // when
+      eventBus.fire('foo', {});
+
+      // then
+      expect(asyncListener).to.have.been.called;
+      expect(listener).to.have.been.called;
+    });
+
+    it('should NOT fire async listeners by cancelBubble', function() {
+
+      // given
+      var listener = sinon.spy();
+      var asyncListener = sinon.spy(async function() {});
+
+      eventBus.on('foo', asyncListener);
+      eventBus.on('foo', listener);
+
+      // when
+      eventBus.fire('foo', { cancelBubble: true });
+
+      // then
+      expect(asyncListener).not.to.have.been.called;
+      expect(listener).not.to.have.been.called;
+    });
 
     it('should fire typed listener', function() {
 


### PR DESCRIPTION
### Proposed Changes

 Prevent erroneous stopPropagation for async listeners in EventBus.
 Closes #975 

When 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
