### PR TITLE
Generate declaration maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 tmp/
 coverage/
 lib/**/*.d.ts
+lib/**/*.d.ts.map
 .idea/
 .vscode/
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@testing-library/preact": "^3.2.4",
         "babel-loader": "^10.1.1",
         "babel-plugin-istanbul": "^8.0.0",
-        "bio-dts": "^0.14.1",
+        "bio-dts": "^0.15.2",
         "chai": "^6.0.0",
         "del-cli": "^7.0.0",
         "eslint": "^9.39.4",
@@ -2130,13 +2130,15 @@
       }
     },
     "node_modules/bio-dts": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/bio-dts/-/bio-dts-0.14.1.tgz",
-      "integrity": "sha512-JmmB6BcDptuYoMcEPkyqPV1/PmOXdSAhU0ZQkPVQXQ4hmfN4q8zp/UsFH36nQsNgMCK5z2eLMYc/Bx13mjM2qA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/bio-dts/-/bio-dts-0.15.2.tgz",
+      "integrity": "sha512-e0GduoNz3vpG0Gk4oDgB70eRtgN0BgKn1QuaChrFQzYuERAechBxzoethzGsn5Reo37rou5h3l6AtXWXiGgeog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
+        "@babel/parser": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "@jridgewell/source-map": "^0.3.11",
         "recast": "^0.23.11",
         "tiny-glob": "^0.2.9"
       },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@testing-library/preact": "^3.2.4",
     "babel-loader": "^10.1.1",
     "babel-plugin-istanbul": "^8.0.0",
-    "bio-dts": "^0.14.1",
+    "bio-dts": "^0.15.2",
     "chai": "^6.0.0",
     "del-cli": "^7.0.0",
     "eslint": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint .",
     "dev": "npm test -- --auto-watch --no-single-run",
     "generate-types": "run-s generate-types:*",
-    "generate-types:generate": "del-cli \"lib/**/*.d.ts\" && npx bio-dts -r lib",
+    "generate-types:generate": "del-cli \"lib/**/*.d.ts\" \"lib/**/*.d.ts.map\" && npx bio-dts -r lib --declarationMap",
     "generate-types:test": "tsc --noEmit --noImplicitAny",
     "test": "karma start",
     "prepublishOnly": "run-s generate-types"


### PR DESCRIPTION
### Proposed Changes

Generates types with [declaration maps](https://www.typescriptlang.org/tsconfig/#declarationMap), the [recommended practice](https://github.com/microsoft/TypeScript/issues/49003) for library authors that ship source code.

Once generated, "Go to definition" (`F12` in Sublime Text) will no longer jump to types, but to the actual source file:

![capture 7xaQLT_optimized](https://github.com/user-attachments/assets/25e0af88-8297-43f2-94d4-411235193617)


### Try out

* `git checkout generate-declaration-maps`
* `npm run generate-types`
* Navigate within your IDE

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->

----

Related to [discussion](https://camunda.slack.com/archives/GP70M0J6M/p1749806850696559)
