### PR TITLE
fix: remove interaction events registration from bendpoints

### DIFF
--- a/lib/features/bendpoints/Bendpoints.js
+++ b/lib/features/bendpoints/Bendpoints.js
@@ -379,12 +379,7 @@ export default function Bendpoints(
 
     if (element.waypoints) {
       addHandles(element);
-      interactionEvents.registerEvent(event.gfx, 'mousemove', 'element.mousemove');
     }
-  });
-
-  eventBus.on('element.out', function(event) {
-    interactionEvents.unregisterEvent(event.gfx, 'mousemove', 'element.mousemove');
   });
 
   // update bendpoint container data attribute on element ID change


### PR DESCRIPTION
### Proposed Changes

The PR removes interaction events registration and unregistration from the bendpoints module. This is already handled directly in the interaction events, and we do not want to unregister.

Try out via 

```
npx @bpmn-io/sr bpmn-io/bpmn-js -l bpmn-io/diagram-js#965-remove-interaction-events-registration
```

Closes #965

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
