### PR TITLE
fix: ensure keyboard entries navigation accounts for group order

### DIFF
--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -14,7 +14,7 @@ import {
 } from 'min-dom';
 
 import PopupMenuHeader from './PopupMenuHeader';
-import PopupMenuList, { groupEntries } from './PopupMenuList';
+import PopupMenuList from './PopupMenuList';
 import classNames from 'clsx';
 import { isDefined, isFunction } from 'min-dash';
 
@@ -22,6 +22,7 @@ import { isDefined, isFunction } from 'min-dash';
  * @typedef {import('./PopupMenuProvider').PopupMenuEntry} PopupMenuEntry
  * @typedef {import('./PopupMenuProvider').PopupMenuHeaderEntry} PopupMenuHeaderEntry
  * @typedef {import('./PopupMenuProvider').PopupMenuEmptyPlaceholderProvider | import('./PopupMenuProvider').PopupMenuEmptyPlaceholder} PopupMenuEmptyPlaceholder
+ * @typedef {import('./PopupMenuProvider').PopupMenuGroup} PopupMenuGroup
  *
  * @typedef {import('../search/search').default} search
  *
@@ -97,6 +98,8 @@ export default function PopupMenuComponent(props) {
   const [ entries, setEntries ] = useState(filterEntries(originalEntries, searchValue));
   const [ selectedEntry, setSelectedEntry ] = useState(entries[0]);
 
+  const groupedEntries = useMemo(() => groupEntries(entries), [ entries ]);
+
   const updateEntries = useCallback((newEntries) => {
 
     // always select first
@@ -112,22 +115,21 @@ export default function PopupMenuComponent(props) {
 
   // handle keyboard selection
   const keyboardSelect = useCallback(direction => {
-    const groupOrderedEntries = orderByGroup(entries);
-    const idx = groupOrderedEntries.indexOf(selectedEntry);
-
+    const entries = getOrderedEntries(groupedEntries);
+    const idx = entries.indexOf(selectedEntry);
 
     let nextIdx = idx + direction;
 
     if (nextIdx < 0) {
-      nextIdx = groupOrderedEntries.length - 1;
+      nextIdx = entries.length - 1;
     }
 
-    if (nextIdx >= groupOrderedEntries.length) {
+    if (nextIdx >= entries.length) {
       nextIdx = 0;
     }
 
-    setSelectedEntry(groupOrderedEntries[nextIdx]);
-  }, [ entries, selectedEntry, setSelectedEntry ]);
+    setSelectedEntry(entries[nextIdx]);
+  }, [ groupedEntries, selectedEntry, setSelectedEntry ]);
 
   const handleKeyDown = useCallback(event => {
     if (event.key === 'Enter' && selectedEntry) {
@@ -197,7 +199,7 @@ export default function PopupMenuComponent(props) {
           ` }
 
           <${PopupMenuList}
-            entries=${ entries }
+            groupedEntries=${ groupedEntries }
             selectedEntry=${ selectedEntry }
             setSelectedEntry=${ setSelectedEntry }
             onAction=${ onSelect }
@@ -297,6 +299,7 @@ function PopupMenuWrapper(props) {
   `;
 }
 
+
 // helpers //////////////////////
 
 function getPopupStyle(props) {
@@ -307,15 +310,45 @@ function getPopupStyle(props) {
   };
 }
 
-function orderByGroup(entries) {
-  const orderedByGroupEntries = [];
-  const groups = groupEntries(entries);
+function getOrderedEntries(groupedEntries) {
+  const entries = [];
 
-  groups.forEach(group => {
+  groupedEntries.forEach(group => {
     group.entries.forEach(entry => {
-      orderedByGroupEntries.push(entry);
+      entries.push(entry);
     });
   });
 
-  return orderedByGroupEntries;
+  return entries;
+}
+
+/**
+ * @param {PopupMenuEntry[]} entries
+ *
+ * @return {PopupMenuGroup[]}
+ */
+export function groupEntries(entries) {
+  const groups = [];
+
+  const getGroup = group => groups.find(elem => group.id === elem.id);
+
+  const containsGroup = group => !!getGroup(group);
+
+  // legacy support for provider built for the old popUp menu
+  const formatGroup = group =>
+    typeof group === 'string' ? { id: group } : group;
+
+  entries.forEach(entry => {
+
+    // assume a default group when none is provided
+    const group = entry.group ? formatGroup(entry.group) : { id: 'default' };
+
+    if (!containsGroup(group)) {
+      groups.push({ ...group, entries: [ entry ] });
+    } else {
+      getGroup(group).entries.push(entry);
+    }
+  });
+
+  return groups;
 }

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -14,7 +14,7 @@ import {
 } from 'min-dom';
 
 import PopupMenuHeader from './PopupMenuHeader';
-import PopupMenuList from './PopupMenuList';
+import PopupMenuList, { groupEntries } from './PopupMenuList';
 import classNames from 'clsx';
 import { isDefined, isFunction } from 'min-dash';
 
@@ -103,28 +103,30 @@ export default function PopupMenuComponent(props) {
     setSelectedEntry(newEntries[0]);
 
     setEntries(newEntries);
-  }, [ selectedEntry, setEntries, setSelectedEntry ]);
+  }, [ setEntries, setSelectedEntry ]);
 
   // filter entries on search value change
   useEffect(() => {
     updateEntries(filterEntries(originalEntries, searchValue));
   }, [ searchValue, originalEntries ]);
 
-  // handle keyboard seleciton
+  // handle keyboard selection
   const keyboardSelect = useCallback(direction => {
-    const idx = entries.indexOf(selectedEntry);
+    const groupOrderedEntries = orderByGroup(entries);
+    const idx = groupOrderedEntries.indexOf(selectedEntry);
+
 
     let nextIdx = idx + direction;
 
     if (nextIdx < 0) {
-      nextIdx = entries.length - 1;
+      nextIdx = groupOrderedEntries.length - 1;
     }
 
-    if (nextIdx >= entries.length) {
+    if (nextIdx >= groupOrderedEntries.length) {
       nextIdx = 0;
     }
 
-    setSelectedEntry(entries[nextIdx]);
+    setSelectedEntry(groupOrderedEntries[nextIdx]);
   }, [ entries, selectedEntry, setSelectedEntry ]);
 
   const handleKeyDown = useCallback(event => {
@@ -303,4 +305,17 @@ function getPopupStyle(props) {
     width: `${props.width}px`,
     'transform-origin': 'top left'
   };
+}
+
+function orderByGroup(entries) {
+  const orderedByGroupEntries = [];
+  const groups = groupEntries(entries);
+
+  groups.forEach(group => {
+    group.entries.forEach(entry => {
+      orderedByGroupEntries.push(entry);
+    });
+  });
+
+  return orderedByGroupEntries;
 }

--- a/lib/features/popup-menu/PopupMenuList.js
+++ b/lib/features/popup-menu/PopupMenuList.js
@@ -110,3 +110,5 @@ function scrollIntoView(el) {
     });
   }
 }
+
+export { groupEntries };

--- a/lib/features/popup-menu/PopupMenuList.js
+++ b/lib/features/popup-menu/PopupMenuList.js
@@ -1,6 +1,5 @@
 import {
   html,
-  useMemo,
   useLayoutEffect,
   useRef
 } from '../../ui';
@@ -9,13 +8,14 @@ import PopupMenuItem from './PopupMenuItem';
 
 /**
  * @typedef {import('./PopupMenuProvider').PopupMenuEntry} PopupMenuEntry
+ * @typedef {import('./PopupMenuProvider').PopupMenuGroup} PopupMenuGroup
  */
 
 /**
  * Component that renders a popup menu entry list.
  *
  * @param {Object} props
- * @param {PopupMenuEntry[]} props.entries
+ * @param {PopupMenuGroup[]} props.groupedEntries
  * @param {PopupMenuEntry} props.selectedEntry
  * @param {(entry: PopupMenuEntry | null) => void} props.setSelectedEntry
  */
@@ -23,13 +23,11 @@ export default function PopupMenuList(props) {
   const {
     selectedEntry,
     setSelectedEntry,
-    entries,
+    groupedEntries,
     ...restProps
   } = props;
 
   const resultsRef = useRef();
-
-  const groups = useMemo(() => groupEntries(entries), [ entries ]);
 
   // scroll to selected result
   useLayoutEffect(() => {
@@ -47,7 +45,7 @@ export default function PopupMenuList(props) {
 
   return html`
     <div class="djs-popup-results" ref=${ resultsRef }>
-      ${ groups.map(group => html`
+      ${ groupedEntries.map(group => html`
         ${ group.name && html`
           <div key=${ group.id } class="entry-header" title=${ group.name }>
             ${ group.name }
@@ -71,33 +69,6 @@ export default function PopupMenuList(props) {
 }
 
 
-// helpers
-function groupEntries(entries) {
-  const groups = [];
-
-  const getGroup = group => groups.find(elem => group.id === elem.id);
-
-  const containsGroup = group => !!getGroup(group);
-
-  // legacy support for provider built for the old popUp menu
-  const formatGroup = group =>
-    typeof group === 'string' ? { id: group } : group;
-
-  entries.forEach(entry => {
-
-    // assume a default group when none is provided
-    const group = entry.group ? formatGroup(entry.group) : { id: 'default' };
-
-    if (!containsGroup(group)) {
-      groups.push({ ...group, entries: [ entry ] });
-    } else {
-      getGroup(group).entries.push(entry);
-    }
-  });
-
-  return groups;
-}
-
 // helpers ////////////////
 
 function scrollIntoView(el) {
@@ -110,5 +81,3 @@ function scrollIntoView(el) {
     });
   }
 }
-
-export { groupEntries };

--- a/lib/features/popup-menu/PopupMenuProvider.ts
+++ b/lib/features/popup-menu/PopupMenuProvider.ts
@@ -23,6 +23,12 @@ export type PopupMenuEntriesProvider = (
   entries: PopupMenuEntries
 ) => PopupMenuEntries;
 
+export type PopupMenuGroup = {
+  id: string,
+  name?: string,
+  entries: PopupMenuEntry[]
+};
+
 export type PopupMenuHeaderEntryAction = (
   event: Event,
   entry: PopupMenuHeaderEntry,

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -1,5 +1,7 @@
 import { expectToBeAccessible } from '@bpmn-io/a11y';
 
+import { act } from '@testing-library/preact';
+
 import PopupMenuComponent from 'lib/features/popup-menu/PopupMenuComponent';
 
 import {
@@ -801,16 +803,14 @@ describe('features/popup-menu - <PopupMenu>', function() {
       cleanup = null;
     };
 
-    const result = render(
-      html`
-        <${PopupMenuComponent} ...${ props } />
-      `,
-      container
-    );
-
-    await whenStable(500);
-
-    return result;
+    return act(() => {
+      return render(
+        html`
+          <${PopupMenuComponent} ...${ props } />
+        `,
+        container
+      );
+    });
   }
 
 });
@@ -845,11 +845,5 @@ function dragStart() {
 }
 
 async function trigger(element, event) {
-  element.dispatchEvent(event);
-
-  return whenStable(500);
-}
-
-function whenStable(timeout = 50) {
-  return new Promise(resolve => setTimeout(resolve, timeout));
+  return act(() => element.dispatchEvent(event));
 }

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -692,6 +692,50 @@ describe('features/popup-menu - <PopupMenu>', function() {
       expect(domQuery('.selected', container).textContent).to.eql('Entry 6');
     });
 
+
+    it('should navigate through shuffled grouped entries in visual order', async function() {
+
+      // given
+      const shuffledGroupEntries = [
+        { id: '1', label: 'Group A - Entry 1', group: 'Group A' },
+        { id: '3', label: 'Group B - Entry 1', group: 'Group B' },
+        { id: '5', label: 'Group C - Entry 1', group: 'Group C' },
+        { id: '2', label: 'Group A - Entry 2', group: 'Group A' },
+        { id: '6', label: 'Group C - Entry 2', group: 'Group C' },
+        { id: '4', label: 'Group B - Entry 2', group: 'Group B' }
+      ];
+
+      await createPopupMenu({ container, entries: shuffledGroupEntries, search: true });
+
+      const popupEl = domQuery('.djs-popup', container);
+
+      // Visual order should be alphabetical by group: A1, A2, B1, B2, C1, C2
+      expect(domQuery('.selected', container).textContent).to.include('Group A - Entry 1');
+
+      await trigger(popupEl, keyDown('ArrowDown'));
+      expect(domQuery('.selected', container).textContent).to.include('Group A - Entry 2');
+
+      await trigger(popupEl, keyDown('ArrowDown'));
+      expect(domQuery('.selected', container).textContent).to.include('Group B - Entry 1');
+
+      await trigger(popupEl, keyDown('ArrowDown'));
+      expect(domQuery('.selected', container).textContent).to.include('Group B - Entry 2');
+
+      await trigger(popupEl, keyDown('ArrowDown'));
+      expect(domQuery('.selected', container).textContent).to.include('Group C - Entry 1');
+
+      await trigger(popupEl, keyDown('ArrowDown'));
+      expect(domQuery('.selected', container).textContent).to.include('Group C - Entry 2');
+
+      // Should wrap around to first entry
+      await trigger(popupEl, keyDown('ArrowDown'));
+      expect(domQuery('.selected', container).textContent).to.include('Group A - Entry 1');
+
+      // Should jump back to the last entry
+      await trigger(popupEl, keyDown('ArrowUp'));
+      expect(domQuery('.selected', container).textContent).to.include('Group C - Entry 2');
+    });
+
   });
 
 

--- a/test/spec/features/popup-menu/PopupMenuHeaderSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuHeaderSpec.js
@@ -1,3 +1,5 @@
+import { act } from '@testing-library/preact';
+
 import PopupMenuHeader from 'lib/features/popup-menu/PopupMenuHeader';
 
 import {
@@ -237,11 +239,5 @@ function mouseLeave() {
 }
 
 async function trigger(element, event) {
-  element.dispatchEvent(event);
-
-  return whenStable(500);
-}
-
-function whenStable(timeout = 50) {
-  return new Promise(resolve => setTimeout(resolve, timeout));
+  return act(() => element.dispatchEvent(event));
 }

--- a/test/spec/features/popup-menu/PopupMenuListSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuListSpec.js
@@ -43,7 +43,7 @@ function createPopupMenuList(options) {
   } = options;
 
   const props = {
-    entries: [ ],
+    groupedEntries: [ ],
     selectedEntry: null,
     setSelectedEntry: () => {},
     onSelect: () => {},


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js-create-append-anything/issues/53

### Proposed Changes

Ensure we use the post-grouping order when navigating the popup menu by keyboard.

[Screencast from 2025-09-19 10-48-42.webm](https://github.com/user-attachments/assets/d1cfd80c-08c9-4caf-9544-6e4e063f5ebb)

Ignore the disabled entries it's from another PR. 

To try it out:

```
npx @bpmn-io/sr bpmn-io/bpmn-js-element-templates -l bpmn-io/diagram-js#cr-app-an-53-match-keyboard-nav-to-visual-order
```

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
