### PR TITLE
feat(dragging): restore canvas focus on drag end

### DIFF
--- a/lib/features/dragging/Dragging.js
+++ b/lib/features/dragging/Dragging.js
@@ -428,6 +428,10 @@ export default function Dragging(eventBus, canvas, selection, elementRegistry) {
       restoreSelection(previousSelection);
     }
 
+    if (restore !== false) {
+      canvas.restoreFocus();
+    }
+
     previousContext = context;
 
     context = null;


### PR DESCRIPTION
### Proposed Changes

As part of https://github.com/bpmn-io/diagram-js/pull/662 we made keyboard binding implicit; we rely on canvas focus to be restored (`Canvas#restoreFocus`) in any local modeling operations that may pull focus.

What I propose is to restore at the end of a dragging operation - alternative we can restore on drag over - that may be the more intuitive choice. I'm happy to explore options.


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
