### PR TITLE
adjust search scoring parameters

### DIFF
--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -91,9 +91,14 @@ export default function PopupMenuComponent(props) {
         'label',
         'search',
         'description'
-      ]
+      ],
+      keyWeights: {
+        label: 1,
+        search: 0.9,
+        description: 0
+      }
     }).map(({ item }) => item);
-  }, [ searchable ]);
+  }, [ searchable, searchFn ]);
 
   const entries = useMemo(() => filterEntries(originalEntries, searchValue), [ originalEntries, searchValue, filterEntries ]);
   const [ selectedEntry, setSelectedEntry ] = useState(entries[0]);

--- a/lib/features/search/search.js
+++ b/lib/features/search/search.js
@@ -5,6 +5,10 @@ import { isArray } from 'min-dash';
  *   index: number;
  *   match: boolean;
  *   value: string;
+ *   start?: boolean;
+ *   end?: boolean;
+ *   wordStart?: boolean;
+ *   wordEnd?: boolean;
  * } } Token
  *
  * @typedef {Token[]} Tokens
@@ -198,6 +202,15 @@ function scoreTokens(tokens) {
   return tokens.reduce((sum, token) => sum + scoreToken(token), 0);
 }
 
+const TOKEN_MATCH_SCORES = {
+  FULL_MATCH: 131.9,
+  START_FULL_WORD: 8.0,
+  START_PARTIAL_WORD: 7.87,
+  WORD_START: 2.19,
+  PARTIAL: 1,
+  NO_MATCH: -0.07
+};
+
 /**
  * Score a token based on its characteristics
  * and the length of the matched content.
@@ -214,20 +227,22 @@ function scoreToken(token) {
   const modifier = Math.log(token.value.length);
 
   if (!token.match) {
-    return -0.07 * modifier;
+    return TOKEN_MATCH_SCORES.NO_MATCH * modifier;
   }
 
   return (
     token.start
       ? (
         token.end
-          ? 131.9
-          : 7.87
+          ? TOKEN_MATCH_SCORES.FULL_MATCH
+          : token.wordEnd
+            ? TOKEN_MATCH_SCORES.START_FULL_WORD
+            : TOKEN_MATCH_SCORES.START_PARTIAL_WORD
       )
       : (
         token.wordStart
-          ? 2.19
-          : 1
+          ? TOKEN_MATCH_SCORES.WORD_START
+          : TOKEN_MATCH_SCORES.PARTIAL
       )
   ) * modifier;
 }

--- a/lib/features/search/search.js
+++ b/lib/features/search/search.js
@@ -36,6 +36,7 @@ import { isArray } from 'min-dash';
  * @param {string} pattern pattern to search for
  * @param { {
  *   keys: string[];
+ *   keyWeights?: Record<string, number>;
  * } } options
  *
  * @returns {SearchResult<T>[]}
@@ -43,7 +44,8 @@ import { isArray } from 'min-dash';
 export default function search(items, pattern, options) {
 
   const {
-    keys
+    keys,
+    keyWeights = {}
   } = options;
 
   pattern = pattern.trim().toLowerCase();
@@ -65,7 +67,7 @@ export default function search(items, pattern, options) {
       item,
       tokens
     };
-  }).sort(createResultSorter(keys));
+  }).sort(createResultSorter(keys, keyWeights));
 }
 
 /**
@@ -137,10 +139,11 @@ function matchItem(item, words, keys) {
  * Creates a compare function that can be used in Array.sort() based on a custom scoring function
  *
  * @param {string[]} keys
+ * @param {Record<string, number>} [keyWeights] per key weight, defaults to 0.5^i (i being the index of keys)
  *
  * @returns { (resultA: SearchResult, resultB: SearchResult) => number}
  */
-function createResultSorter(keys) {
+function createResultSorter(keys, keyWeights = {}) {
 
   /**
    * @param {SearchResult} resultA
@@ -149,10 +152,8 @@ function createResultSorter(keys) {
   return (resultA, resultB) => {
     let comparison = 0;
 
-    // used to assign some priority to earlier keys
-    let modifier = 1;
-
-    for (const key of keys) {
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
 
       const tokenComparison = compareTokens(
         resultA.tokens[key],
@@ -160,8 +161,7 @@ function createResultSorter(keys) {
       );
 
       if (tokenComparison !== 0) {
-        comparison += tokenComparison * modifier;
-        modifier *= 0.9;
+        comparison += tokenComparison * (keyWeights[key] ?? Math.pow(0.5, i));
         continue;
       }
 
@@ -171,8 +171,7 @@ function createResultSorter(keys) {
       );
 
       if (stringComparison !== 0) {
-        comparison += stringComparison * modifier;
-        modifier *= 0.9;
+        comparison += stringComparison * (keyWeights[key] ?? Math.pow(0.5, i));
         continue;
       }
     }

--- a/lib/features/search/search.js
+++ b/lib/features/search/search.js
@@ -224,10 +224,11 @@ function scoreToken(token) {
     return Math.max(...token.map(scoreToken));
   }
 
-  const modifier = Math.log(token.value.length);
+  const length = token.value.length;
+  const modifier = Math.log(length);
 
   if (!token.match) {
-    return TOKEN_MATCH_SCORES.NO_MATCH * modifier;
+    return TOKEN_MATCH_SCORES.NO_MATCH * length;
   }
 
   return (

--- a/lib/features/search/search.js
+++ b/lib/features/search/search.js
@@ -155,25 +155,16 @@ function createResultSorter(keys, keyWeights = {}) {
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
 
-      const tokenComparison = compareTokens(
-        resultA.tokens[key],
-        resultB.tokens[key]
-      );
-
-      if (tokenComparison !== 0) {
-        comparison += tokenComparison * (keyWeights[key] ?? Math.pow(0.5, i));
-        continue;
-      }
-
-      const stringComparison = compareStrings(
+      const resultComparison = compareTokens(
+        resultA.tokens[ key ],
+        resultB.tokens[ key ]
+      ) || compareStrings(
         resultA.item[ key ],
         resultB.item[ key ]
       );
 
-      if (stringComparison !== 0) {
-        comparison += stringComparison * (keyWeights[key] ?? Math.pow(0.5, i));
-        continue;
-      }
+      comparison += resultComparison * (keyWeights[key] ?? Math.pow(0.5, i));
+
     }
 
     return comparison;

--- a/test/spec/features/search/searchSpec.js
+++ b/test/spec/features/search/searchSpec.js
@@ -675,6 +675,34 @@ describe('features/search', function() {
     expect(fn).to.throw(/<pattern> must not be empty/);
   }));
 
+
+  it('should respect keyWeights to change ordering', inject(function(search) {
+
+    // given
+    const items = [
+      {
+        title: 'foo',
+        description: 'bar'
+      },
+      {
+        title: 'bar',
+        description: 'foo'
+      }
+    ];
+
+    const keys = [ 'title', 'description' ];
+
+    // when
+    const weightedResults = search(items, 'foo', {
+      keys,
+      keyWeights: { description: 10 }
+    });
+
+    // then
+    expect(weightedResults[0].item).to.eql(items[1]);
+    expect(weightedResults[1].item).to.eql(items[0]);
+  }));
+
 });
 
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5658

### Proposed Changes

Follow up to https://github.com/bpmn-io/diagram-js/pull/1014

- some scoring adjustments (refactoring, boosting whole words, penalizing longer mismatches more)
- adjusted keyweight values
  - eg previously keys were weighted with 0.9^i (label:1, search term: 0.9, description: 0.81)
  - description with such a high influence is surprising for the user as its mostly not visible
  - now its hardcoded at `label:1.0, search term: 0.9, description: 0.0` (fallback to 0.5^i)

<img width="337" height="409" alt="image" src="https://github.com/user-attachments/assets/6df08b5c-c7a7-4b4e-92f1-6705ac4e47f6" />

```
npx @bpmn-io/sr bpmn-io/bpmn-js-create-append-anything#5658_boost-plain-bpmn-elements -l bpmn-io/diagram-js#5658_optimize-scoring -c npm\ run\ start:camunda-templates
```

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
