### PR TITLE
feat: show outline around lasso-selected elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 _**Note:** Yet to be released changes appear here._
 
 * `FEAT`: add to selection if `SHIFT` is pressed at start of lasso ([#1028](https://github.com/bpmn-io/diagram-js/issues/1028), [#1029](https://github.com/bpmn-io/diagram-js/pull/1029))
+* `FEAT`: show outline around lasso-selected elements ([bpmn-js#1021](https://github.com/bpmn-io/bpmn-js/issues/173), [#1021](https://github.com/bpmn-io/diagram-js/pull/1021))
 
 ## 15.12.0
 

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -146,7 +146,8 @@
   display: none;
 }
 
-.djs-multi-select .djs-element.selected .djs-outline {
+.djs-multi-select .djs-element.selected .djs-outline,
+.djs-dragging-active-lasso .djs-element.selected .djs-outline {
   stroke: var(--element-selected-outline-secondary-stroke-color);
   display: block;
 }

--- a/lib/features/lasso-tool/LassoTool.js
+++ b/lib/features/lasso-tool/LassoTool.js
@@ -27,6 +27,15 @@ import {
  *
  * @typedef {import('../../util/Types').Rect} Rect
  * @typedef {import('../../model/Types').Element} Element
+ *
+ * @typedef { {
+ *   add?: boolean,
+ *   bbox?: Rect,
+ *   marked?: Set<Element>,
+ *   lastMarked?: Set<Element>,
+ *   initialMarked?: Set<Element>,
+ *   frame?: SVGElement
+ * } } LassoContext
  */
 
 var LASSO_TOOL_CURSOR = 'crosshair';
@@ -61,6 +70,9 @@ export default function LassoTool(
   */
   var visuals = {
 
+    /**
+     * @param {LassoContext} context
+     */
     create: function(context) {
       var container = canvas.getActiveLayer();
       var frame = context.frame = svgCreate('rect');
@@ -80,6 +92,9 @@ export default function LassoTool(
       this.update(context);
     },
 
+    /**
+     * @param {LassoContext} context
+     */
     update: function(context) {
       var frame = context.frame,
           bbox = context.bbox;
@@ -111,6 +126,9 @@ export default function LassoTool(
       }
     },
 
+    /**
+     * @param {LassoContext} context
+     */
     remove: function(context) {
 
       this.update(context);
@@ -164,6 +182,9 @@ export default function LassoTool(
 
   eventBus.on('lasso.end', 0, function(event) {
 
+    /**
+     * @type {LassoContext}
+     */
     var context = event.context;
 
     self._select(Array.from(context.marked));
@@ -171,6 +192,9 @@ export default function LassoTool(
 
   eventBus.on('lasso.start', function(event) {
 
+    /**
+     * @type {LassoContext}
+     */
     var context = event.context;
 
     context.bbox = toBBox(event);
@@ -190,6 +214,9 @@ export default function LassoTool(
 
   eventBus.on('lasso.move', function(event) {
 
+    /**
+     * @type {LassoContext}
+     */
     var context = event.context;
 
     var bbox = context.bbox = toBBox(event);
@@ -206,6 +233,9 @@ export default function LassoTool(
 
   eventBus.on('lasso.cleanup', function(event) {
 
+    /**
+     * @type {LassoContext}
+     */
     var context = event.context;
 
     context.lastMarked = context.marked;
@@ -327,6 +357,11 @@ LassoTool.prototype.isActive = function() {
 };
 
 
+/**
+ * @param {Event} event
+ *
+ * @return {Rect}
+ */
 function toBBox(event) {
 
   var start = {

--- a/lib/features/lasso-tool/LassoTool.js
+++ b/lib/features/lasso-tool/LassoTool.js
@@ -1,6 +1,8 @@
 import { values } from 'min-dash';
 
-import { getEnclosedElements } from '../../util/Elements';
+import {
+  getEnclosedElements
+} from '../../util/Elements';
 
 import {
   hasSecondaryModifier
@@ -9,6 +11,7 @@ import {
 import {
   append as svgAppend,
   attr as svgAttr,
+  classes as svgClasses,
   create as svgCreate,
   remove as svgRemove
 } from 'tiny-svg';
@@ -23,9 +26,13 @@ import {
  * @typedef {import('../tool-manager/ToolManager').default} ToolManager
  *
  * @typedef {import('../../util/Types').Rect} Rect
+ * @typedef {import('../../model/Types').Element} Element
  */
 
 var LASSO_TOOL_CURSOR = 'crosshair';
+
+var MARKER_SELECTED = 'selected';
+var LASSO_ACTIVE_CLS = 'djs-dragging-active-lasso';
 
 /**
  * @param {EventBus} eventBus
@@ -68,27 +75,72 @@ export default function LassoTool(
       });
 
       svgAppend(container, frame);
+
+      toggleLassoMarkerClass(true);
+
+      this.update(context);
     },
 
     update: function(context) {
       var frame = context.frame,
           bbox = context.bbox;
 
-      svgAttr(frame, {
-        x: bbox.x,
-        y: bbox.y,
-        width: bbox.width,
-        height: bbox.height
-      });
+      if (frame && bbox) {
+        svgAttr(frame, {
+          x: bbox.x,
+          y: bbox.y,
+          width: bbox.width,
+          height: bbox.height
+        });
+      }
+
+      var currentlyMarked = context.marked,
+          lastMarked = context.lastMarked;
+
+      if (currentlyMarked && lastMarked) {
+        for (const e of lastMarked) {
+          if (!currentlyMarked.has(e)) {
+            canvas.removeMarker(e, MARKER_SELECTED);
+          }
+        }
+
+        for (const e of currentlyMarked) {
+          if (!lastMarked.has(e)) {
+            canvas.addMarker(e, MARKER_SELECTED);
+          }
+        }
+      }
     },
 
     remove: function(context) {
 
+      this.update(context);
+
       if (context.frame) {
         svgRemove(context.frame);
       }
+
+      toggleLassoMarkerClass(false);
     }
   };
+
+  function toggleLassoMarkerClass(enabled) {
+    svgClasses(canvas.getContainer()).toggle(LASSO_ACTIVE_CLS, enabled);
+  }
+
+  /**
+   * @param {Rect} bbox
+   *
+   * @return {Set<Element>}
+   */
+  function getAllEnclosedElements(bbox) {
+
+    var allElements = elementRegistry.getAll();
+
+    return new Set(
+      values(getEnclosedElements(allElements, bbox))
+    );
+  }
 
   toolManager.registerTool('lasso', {
     tool: 'lasso.selection',
@@ -115,13 +167,7 @@ export default function LassoTool(
 
     var context = event.context;
 
-    var bbox = toBBox(event);
-
-    var elements = elementRegistry.filter(function(element) {
-      return element;
-    });
-
-    self.select(elements, bbox, context.add ? context.selection : []);
+    self._select(Array.from(context.marked));
   });
 
   eventBus.on('lasso.start', function(event) {
@@ -129,17 +175,33 @@ export default function LassoTool(
     var context = event.context;
 
     context.bbox = toBBox(event);
-    visuals.create(context);
-
-    context.selection = selection.get();
     context.add = hasSecondaryModifier(event);
+    context.lastMarked = new Set(selection.get());
+
+    if (context.add) {
+      context.marked = context.lastMarked;
+    } else {
+      context.marked = new Set();
+    }
+
+    context.initialMarked = context.marked;
+
+    visuals.create(context);
   });
 
   eventBus.on('lasso.move', function(event) {
 
     var context = event.context;
 
-    context.bbox = toBBox(event);
+    var bbox = context.bbox = toBBox(event);
+
+    var enclosedElements = getAllEnclosedElements(bbox);
+
+    var marked = context.initialMarked.union(enclosedElements);
+
+    context.lastMarked = context.marked;
+    context.marked = marked;
+
     visuals.update(context);
   });
 
@@ -147,7 +209,10 @@ export default function LassoTool(
 
     var context = event.context;
 
-    visuals.remove(context);
+    context.lastMarked = context.marked;
+    context.marked = new Set(selection.get());
+
+    visuals.remove(event.context);
   });
 
 
@@ -189,7 +254,8 @@ LassoTool.prototype.activateLasso = function(event, autoActivate) {
     cursor: LASSO_TOOL_CURSOR,
     data: {
       context: {}
-    }
+    },
+    keepSelection: true
   });
 };
 
@@ -213,6 +279,15 @@ LassoTool.prototype.activateSelection = function(event, autoActivate) {
 };
 
 /**
+ * Select elements.
+ *
+ * @param {Element[]} elements
+ */
+LassoTool.prototype._select = function(elements) {
+  this._selection.select(elements);
+};
+
+/**
  * Select elements within the given bounds.
  *
  * @param {Element[]} elements
@@ -220,11 +295,11 @@ LassoTool.prototype.activateSelection = function(event, autoActivate) {
  * @param {Element[]} [previousSelection]
  */
 LassoTool.prototype.select = function(elements, bbox, previousSelection = []) {
-  var selectedElements = getEnclosedElements(elements, bbox);
+  var selectedElements = values(getEnclosedElements(elements, bbox));
 
-  this._selection.select([
+  this._select([
     ...previousSelection,
-    ...values(selectedElements)
+    ...selectedElements
   ]);
 };
 

--- a/lib/features/lasso-tool/LassoTool.js
+++ b/lib/features/lasso-tool/LassoTool.js
@@ -62,10 +62,9 @@ export default function LassoTool(
   var visuals = {
 
     create: function(context) {
-      var container = canvas.getActiveLayer(),
-          frame;
+      var container = canvas.getActiveLayer();
+      var frame = context.frame = svgCreate('rect');
 
-      frame = context.frame = svgCreate('rect');
       svgAttr(frame, {
         class: 'djs-lasso-overlay',
         width:  1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "mocha": "^11.0.0",
         "mocha-test-container-support": "^0.2.0",
         "npm-run-all2": "^8.0.4",
-        "puppeteer": "^24.35.0",
+        "puppeteer": "^24.42.0",
         "sinon": "^21.0.0",
         "sinon-chai": "^4.0.0",
         "typescript": "^5.9.3",
@@ -843,9 +843,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.1.tgz",
-      "integrity": "sha512-YmhAxs7XPuxN0j7LJloHpfD1ylhDuFmmwMvfy/+6nBSrETT2ycL53LrhgPtR+f+GcPSybQVuQ5inWWu5MrWCpA==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+      "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -853,7 +853,7 @@
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "tar-fs": "^3.1.1",
         "yargs": "^17.7.2"
       },
@@ -1645,9 +1645,9 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -1751,12 +1751,11 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
-      "integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
@@ -1777,12 +1776,11 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
-      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
+      "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "bare": ">=1.14.0"
       }
@@ -1793,26 +1791,29 @@
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
-      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
-        "streamx": "^2.21.0"
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
       },
       "peerDependencies": {
+        "bare-abort-controller": "*",
         "bare-buffer": "*",
         "bare-events": "*"
       },
       "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
         "bare-buffer": {
           "optional": true
         },
@@ -1822,12 +1823,11 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
+      "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-path": "^3.0.0"
       }
@@ -1853,9 +1853,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
-      "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2118,9 +2118,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-12.0.1.tgz",
-      "integrity": "sha512-fGg+6jr0xjQhzpy5N4ErZxQ4wF7KLEvhGZXD6EgvZKDhu7iOhZXnZhcDxPJDcwTcrD48NPzOCo84RP2lv3Z+Cg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2578,9 +2578,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1534754",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
-      "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
+      "version": "0.0.1595872",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
+      "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -5649,9 +5649,9 @@
       "license": "MIT"
     },
     "node_modules/netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6288,9 +6288,9 @@
       "license": "MIT"
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6307,19 +6307,19 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.35.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.35.0.tgz",
-      "integrity": "sha512-sbjB5JnJ+3nwgSdRM/bqkFXqLxRz/vsz0GRIeTlCk+j+fGpqaF2dId9Qp25rXz9zfhqnN9s0krek1M/C2GDKtA==",
+      "version": "24.42.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.42.0.tgz",
+      "integrity": "sha512-94MoPfFp2eY3eYIMdINkez4IOP5TMHntlZbVx06fHlQTtiQiYgaY0L2Zzfod8PVUkPqP7m3Qlre2v8YS8cudPA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.11.1",
-        "chromium-bidi": "12.0.1",
+        "@puppeteer/browsers": "2.13.0",
+        "chromium-bidi": "14.0.0",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1534754",
-        "puppeteer-core": "24.35.0",
-        "typed-query-selector": "^2.12.0"
+        "devtools-protocol": "0.0.1595872",
+        "puppeteer-core": "24.42.0",
+        "typed-query-selector": "^2.12.1"
       },
       "bin": {
         "puppeteer": "lib/cjs/puppeteer/node/cli.js"
@@ -6329,18 +6329,18 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.35.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.35.0.tgz",
-      "integrity": "sha512-vt1zc2ME0kHBn7ZDOqLvgvrYD5bqNv5y2ZNXzYnCv8DEtZGw/zKhljlrGuImxptZ4rq+QI9dFGrUIYqG4/IQzA==",
+      "version": "24.42.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.42.0.tgz",
+      "integrity": "sha512-T4zXokk/izH01fYPhyyev1A4piWiOKrYq7CUFpdoYQxmOnXoV6YjUabmfIjCYkNspSoAXIxRid3Tw+Vg0fthYg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.11.1",
-        "chromium-bidi": "12.0.1",
+        "@puppeteer/browsers": "2.13.0",
+        "chromium-bidi": "14.0.0",
         "debug": "^4.4.3",
-        "devtools-protocol": "0.0.1534754",
-        "typed-query-selector": "^2.12.0",
-        "webdriver-bidi-protocol": "0.3.10",
+        "devtools-protocol": "0.0.1595872",
+        "typed-query-selector": "^2.12.1",
+        "webdriver-bidi-protocol": "0.4.1",
         "ws": "^8.19.0"
       },
       "engines": {
@@ -6366,9 +6366,9 @@
       }
     },
     "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6789,9 +6789,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7126,9 +7126,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7331,9 +7331,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
-      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7346,15 +7346,26 @@
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
       }
     },
     "node_modules/terser": {
@@ -7521,9 +7532,9 @@
       }
     },
     "node_modules/text-decoder": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7706,9 +7717,9 @@
       }
     },
     "node_modules/typed-query-selector": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
-      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
+      "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -7881,9 +7892,9 @@
       }
     },
     "node_modules/webdriver-bidi-protocol": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.10.tgz",
-      "integrity": "sha512-5LAE43jAVLOhB/QqX4bwSiv0Hg1HBfMmOuwBSXHdvg4GMGu9Y0lIq7p4R/yySu6w74WmaR4GM4H9t2IwLW7hgw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
       "dev": true,
       "license": "Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "mocha": "^11.0.0",
     "mocha-test-container-support": "^0.2.0",
     "npm-run-all2": "^8.0.4",
-    "puppeteer": "^24.35.0",
+    "puppeteer": "^24.42.0",
     "sinon": "^21.0.0",
     "sinon-chai": "^4.0.0",
     "typescript": "^5.9.3",

--- a/test/spec/features/lasso-tool/LassoToolPreviewSpec.js
+++ b/test/spec/features/lasso-tool/LassoToolPreviewSpec.js
@@ -1,0 +1,416 @@
+import { expect } from 'chai';
+
+import {
+  bootstrapDiagram,
+  inject
+} from 'test/TestHelper';
+
+import {
+  createCanvasEvent as canvasEvent
+} from '../../../util/MockEvents';
+
+import {
+  classes as domClasses
+} from 'min-dom';
+
+import modelingModule from 'lib/features/modeling';
+import lassoToolModule from 'lib/features/lasso-tool';
+import draggingModule from 'lib/features/dragging';
+
+
+describe('features/lasso-tool - preview styling', function() {
+
+  beforeEach(bootstrapDiagram({
+    modules: [
+      modelingModule,
+      lassoToolModule,
+      draggingModule
+    ]
+  }));
+
+
+  var rootShape, child1, child2, child3, child4;
+
+  beforeEach(inject(function(elementFactory, canvas) {
+
+    rootShape = elementFactory.createRoot({
+      id: 'root'
+    });
+
+    canvas.setRootElement(rootShape);
+
+    child1 = elementFactory.createShape({
+      id: 'child1',
+      x: 100, y: 100, width: 80, height: 80
+    });
+
+    canvas.addShape(child1, rootShape);
+
+    child2 = elementFactory.createShape({
+      id: 'child2',
+      x: 220, y: 100, width: 80, height: 80
+    });
+
+    canvas.addShape(child2, rootShape);
+
+    child3 = elementFactory.createShape({
+      id: 'child3',
+      x: 340, y: 100, width: 80, height: 80
+    });
+
+    canvas.addShape(child3, rootShape);
+
+    child4 = elementFactory.createShape({
+      id: 'child4',
+      x: 460, y: 100, width: 80, height: 80
+    });
+
+    canvas.addShape(child4, rootShape);
+  }));
+
+
+  describe('preview markers during drag', function() {
+
+    beforeEach(inject(function(dragging) {
+      dragging.setOptions({ manual: true });
+    }));
+
+
+    it('should add selected marker to elements as they are enclosed', inject(function(lassoTool, dragging, canvas) {
+
+      // given
+      lassoTool.activateLasso(canvasEvent({ x: 90, y: 90 }));
+
+      // when: drag to enclose child1 only (bbox right=200 > child1.right=180, excludes child2.x=220)
+      dragging.move(canvasEvent({ x: 200, y: 200 }));
+
+      // then
+      expect(canvas.hasMarker(child1, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child2, 'selected')).to.be.false;
+      expect(canvas.hasMarker(child3, 'selected')).to.be.false;
+
+      // when: drag further to also enclose child2 and child3 (bbox right=430 > child3.right=420)
+      dragging.move(canvasEvent({ x: 430, y: 200 }));
+
+      // then
+      expect(canvas.hasMarker(child1, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child2, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child3, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child4, 'selected')).to.be.false;
+    }));
+
+
+    it('should remove selected marker when element leaves lasso bounds', inject(function(lassoTool, dragging, canvas) {
+
+      // given
+      lassoTool.activateLasso(canvasEvent({ x: 90, y: 90 }));
+
+      // when: drag to enclose child1, child2, child3
+      dragging.move(canvasEvent({ x: 430, y: 200 }));
+
+      // then
+      expect(canvas.hasMarker(child1, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child2, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child3, 'selected')).to.be.true;
+
+      // when: drag back so bbox right=310, excluding child3 (right=420)
+      dragging.move(canvasEvent({ x: 310, y: 200 }));
+
+      // then
+      expect(canvas.hasMarker(child1, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child2, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child3, 'selected')).to.be.false;
+    }));
+
+
+    it('should clear preview markers on cancel', inject(function(lassoTool, dragging, canvas) {
+
+      // given
+      lassoTool.activateLasso(canvasEvent({ x: 90, y: 90 }));
+      dragging.move(canvasEvent({ x: 430, y: 200 }));
+
+      // assume
+      expect(canvas.hasMarker(child1, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child2, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child3, 'selected')).to.be.true;
+
+      // when
+      dragging.cancel();
+
+      // then
+      expect(canvas.hasMarker(child1, 'selected')).to.be.false;
+      expect(canvas.hasMarker(child2, 'selected')).to.be.false;
+      expect(canvas.hasMarker(child3, 'selected')).to.be.false;
+    }));
+
+
+    it('should clear all preview markers when no elements are enclosed', inject(function(lassoTool, dragging, canvas) {
+
+      // given: drag to enclose child1, child2, child3
+      lassoTool.activateLasso(canvasEvent({ x: 90, y: 90 }));
+      dragging.move(canvasEvent({ x: 430, y: 200 }));
+
+      // assume
+      expect(canvas.hasMarker(child1, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child2, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child3, 'selected')).to.be.true;
+
+      // when: drag back so bbox encloses nothing
+      dragging.move(canvasEvent({ x: 91, y: 91 }));
+
+      // then: all markers removed
+      expect(canvas.hasMarker(child1, 'selected')).to.be.false;
+      expect(canvas.hasMarker(child2, 'selected')).to.be.false;
+      expect(canvas.hasMarker(child3, 'selected')).to.be.false;
+    }));
+
+
+    it('should apply final selection after lasso end', inject(function(lassoTool, dragging, canvas, selection) {
+
+      // given
+      lassoTool.activateLasso(canvasEvent({ x: 90, y: 90 }));
+      dragging.move(canvasEvent({ x: 430, y: 200 }));
+
+      // when
+      dragging.end();
+
+      // then
+      var selected = selection.get();
+      expect(selected).to.include(child1);
+      expect(selected).to.include(child2);
+      expect(selected).to.include(child3);
+      expect(selected).to.not.include(child4);
+
+      expect(canvas.hasMarker(child1, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child2, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child3, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child4, 'selected')).to.be.false;
+    }));
+
+  });
+
+
+  describe('djs-dragging-active-lasso class', function() {
+
+    beforeEach(inject(function(dragging) {
+      dragging.setOptions({ manual: true });
+    }));
+
+
+    it('should add djs-dragging-active-lasso on drag start', inject(function(lassoTool, dragging, canvas) {
+
+      // given
+      lassoTool.activateLasso(canvasEvent({ x: 90, y: 90 }));
+
+      // when: first move triggers lasso.start
+      dragging.move(canvasEvent({ x: 430, y: 200 }));
+
+      // then
+      expect(domClasses(canvas.getContainer()).has('djs-dragging-active-lasso')).to.be.true;
+    }));
+
+
+    it('should add djs-dragging-active-lasso even when no elements are enclosed', inject(function(lassoTool, dragging, canvas) {
+
+      // given
+      lassoTool.activateLasso(canvasEvent({ x: 90, y: 90 }));
+
+      // when: tiny move, no elements enclosed (elements start at x:100, y:100)
+      dragging.move(canvasEvent({ x: 95, y: 95 }));
+
+      // then: class is added regardless of enclosed elements
+      expect(domClasses(canvas.getContainer()).has('djs-dragging-active-lasso')).to.be.true;
+    }));
+
+
+    it('should remove djs-dragging-active-lasso on cancel', inject(function(lassoTool, dragging, canvas) {
+
+      // given
+      lassoTool.activateLasso(canvasEvent({ x: 90, y: 90 }));
+      dragging.move(canvasEvent({ x: 200, y: 200 }));
+
+      // assume
+      expect(domClasses(canvas.getContainer()).has('djs-dragging-active-lasso')).to.be.true;
+
+      // when
+      dragging.cancel();
+
+      // then
+      expect(domClasses(canvas.getContainer()).has('djs-dragging-active-lasso')).to.be.false;
+    }));
+
+
+    it('should remove djs-dragging-active-lasso on end', inject(function(lassoTool, dragging, canvas) {
+
+      // given
+      lassoTool.activateLasso(canvasEvent({ x: 90, y: 90 }));
+      dragging.move(canvasEvent({ x: 200, y: 200 }));
+
+      // assume
+      expect(domClasses(canvas.getContainer()).has('djs-dragging-active-lasso')).to.be.true;
+
+      // when
+      dragging.end();
+
+      // then
+      expect(domClasses(canvas.getContainer()).has('djs-dragging-active-lasso')).to.be.false;
+    }));
+
+  });
+
+
+  describe('original selection', function() {
+
+    beforeEach(inject(function(dragging) {
+      dragging.setOptions({ manual: true });
+    }));
+
+
+    it('should show original selection markers when shift is held during drag', inject(function(lassoTool, dragging, canvas, selection) {
+
+      // given
+      selection.select([ child1 ]);
+
+      // start lasso after child1's right edge (x=180) to avoid re-enclosing it
+      lassoTool.activateLasso(canvasEvent({ x: 190, y: 90 }));
+
+      // when
+      // drag with shift held
+      dragging.move(canvasEvent({ x: 430, y: 200 }, { shiftKey: true }));
+
+      // then
+      // child1 (original) and child2/3 (enclosed) all have marker
+      expect(canvas.hasMarker(child1, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child2, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child3, 'selected')).to.be.true;
+    }));
+
+
+    it('should hide original selection markers when shift is NOT held at drag start', inject(function(lassoTool, dragging, canvas, selection) {
+
+      // given
+      // child1 is pre-selected
+      selection.select([ child1 ]);
+
+      // start lasso after child1's right edge so it is not re-enclosed
+      lassoTool.activateLasso(canvasEvent({ x: 190, y: 90 }));
+
+      // when
+      // drag without shift
+      dragging.move(canvasEvent({ x: 430, y: 200 }));
+
+      // then
+      // child1 marker is hidden (no shift = won't be in final selection)
+      expect(canvas.hasMarker(child1, 'selected')).to.be.false;
+
+      // only newly enclosed elements have preview markers
+      expect(canvas.hasMarker(child2, 'selected')).to.be.true;
+      expect(canvas.hasMarker(child3, 'selected')).to.be.true;
+    }));
+
+
+    it('should NOT toggle original selection markers when shift is pressed and released mid-drag', inject(function(lassoTool, dragging, canvas, selection) {
+
+      // given
+      selection.select([ child1 ]);
+
+      lassoTool.activateLasso(canvasEvent({ x: 190, y: 90 }));
+
+      dragging.move(canvasEvent({ x: 430, y: 200 }));
+      expect(canvas.hasMarker(child1, 'selected')).to.be.false;
+
+      // when
+      // press shift mid-drag → original markers not restored
+      dragging.move(canvasEvent({ x: 430, y: 200 }, { shiftKey: true }));
+      expect(canvas.hasMarker(child1, 'selected')).to.be.false;
+      expect(canvas.hasMarker(child2, 'selected')).to.be.true;
+
+      // when
+      // release shift mid-drag → original markers still hidden
+      dragging.move(canvasEvent({ x: 430, y: 200 }));
+      expect(canvas.hasMarker(child1, 'selected')).to.be.false;
+      expect(canvas.hasMarker(child2, 'selected')).to.be.true;
+    }));
+
+
+    describe('should restore original selection markers on cancel', function() {
+
+      it('in <add> mode', inject(function(lassoTool, dragging, canvas, selection) {
+
+        // given
+        selection.select([ child1 ]);
+
+        lassoTool.activateLasso(canvasEvent({ x: 190, y: 90 }));
+
+        // when
+        // drag with shift to enclose child2
+        dragging.move(canvasEvent({ x: 310, y: 200 }, { shiftKey: true }));
+
+        // assume
+        // both have markers
+        expect(canvas.hasMarker(child1, 'selected')).to.be.true;
+        expect(canvas.hasMarker(child2, 'selected')).to.be.true;
+
+        // when
+        dragging.cancel();
+
+        // then
+        // original selection marker preserved, preview-only marker removed
+        expect(canvas.hasMarker(child1, 'selected')).to.be.true;
+        expect(canvas.hasMarker(child2, 'selected')).to.be.false;
+      }));
+
+
+      it('in <new selection> mode', inject(function(lassoTool, dragging, canvas, selection) {
+
+        // given
+        selection.select([ child1 ]);
+
+        lassoTool.activateLasso(canvasEvent({ x: 190, y: 90 }));
+
+        // when
+        // drag without SHIFT to only select child2
+        dragging.move(canvasEvent({ x: 310, y: 200 }));
+
+        // assume
+        // child2 has marker
+        expect(canvas.hasMarker(child1, 'selected')).to.be.false;
+        expect(canvas.hasMarker(child2, 'selected')).to.be.true;
+
+        // when
+        dragging.cancel();
+
+        // then
+        // original selection marker preserved, preview-only marker removed
+        expect(canvas.hasMarker(child1, 'selected')).to.be.true;
+        expect(canvas.hasMarker(child2, 'selected')).to.be.false;
+      }));
+
+    });
+
+
+    it('should include original selection and enclosed elements in final selection in add mode', inject(function(lassoTool, dragging, canvas, selection) {
+
+      // given
+      selection.select([ child1 ]);
+
+      // start lasso after child1's right edge so it is not re-enclosed
+      lassoTool.activateLasso(canvasEvent({ x: 190, y: 90 }));
+
+      // when
+      // drag with shift to enclose child2 and child3
+      dragging.move(canvasEvent({ x: 430, y: 200 }, { shiftKey: true }));
+      dragging.end();
+
+      // then
+      // final selection contains original + newly enclosed
+      var selected = selection.get();
+      expect(selected).to.include(child1);
+      expect(selected).to.include(child2);
+      expect(selected).to.include(child3);
+      expect(selected).to.not.include(child4);
+    }));
+
+  });
+
+});

--- a/test/spec/features/lasso-tool/LassoToolSpec.js
+++ b/test/spec/features/lasso-tool/LassoToolSpec.js
@@ -166,15 +166,18 @@ describe('features/lasso-tool', function() {
     it('should add to selection if shift is held at drag start', inject(
       function(lassoTool, dragging, selection, elementRegistry) {
 
-        // given - childShape is already selected
+        // given
+        // childShape is already selected
         selection.select([ elementRegistry.get('child') ]);
 
-        // when - start lasso with shift held, selecting childShape2 and childShape3
+        // when
+        // start lasso with shift held, selecting childShape2 and childShape3
         lassoTool.activateLasso(canvasEvent({ x: 175, y: 100 }));
         dragging.move(canvasEvent({ x: 295, y: 220 }, { shiftKey: true }));
         dragging.end(canvasEvent({ x: 295, y: 220 }));
 
-        // then - previously selected element is included
+        // then
+        // previously selected element is included
         var selected = selection.get();
         expect(selected).to.include(elementRegistry.get('child'));
         expect(selected).to.include(elementRegistry.get('child2'));
@@ -186,15 +189,18 @@ describe('features/lasso-tool', function() {
     it('should NOT add to selection if shift is held only at drag end', inject(
       function(lassoTool, dragging, selection, elementRegistry) {
 
-        // given - childShape is already selected
+        // given
+        // childShape is already selected
         selection.select([ elementRegistry.get('child') ]);
 
-        // when - start lasso WITHOUT shift, selecting childShape2 and childShape3
+        // when
+        // start lasso WITHOUT shift, selecting childShape2 and childShape3
         lassoTool.activateLasso(canvasEvent({ x: 175, y: 100 }));
         dragging.move(canvasEvent({ x: 295, y: 220 }));
         dragging.end(canvasEvent({ x: 295, y: 220 }, { shiftKey: true }));
 
-        // then - previously selected element is NOT included (shift at end is ignored)
+        // then
+        // previously selected element is NOT included (shift at end is ignored)
         var selected = selection.get();
         expect(selected).not.to.include(elementRegistry.get('child'));
         expect(selected).to.include(elementRegistry.get('child2'));


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

related to https://github.com/bpmn-io/bpmn-js/issues/173

Add a selection outline to elements enclosed by the lasso.

Try out using:

`npx @bpmn-io/sr bpmn-io/bpmn-js -l bpmn-io/diagram-js#bpmn-js-173-show-select-in-lasso`

Demo in `bpmn-js`:

https://github.com/user-attachments/assets/2f61096c-2826-4bc1-888a-ea7fe600256b

Demo in `dmn-js`:

https://github.com/user-attachments/assets/3c40ec1e-3921-49da-b5ae-14a757af4dbf



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
