### PR TITLE
feat: add to selection if shift pressed on lasso start

### DIFF
--- a/lib/features/lasso-tool/LassoTool.js
+++ b/lib/features/lasso-tool/LassoTool.js
@@ -121,9 +121,7 @@ export default function LassoTool(
       return element;
     });
 
-    var add = hasSecondaryModifier(event);
-
-    self.select(elements, bbox, add ? context.selection : []);
+    self.select(elements, bbox, context.add ? context.selection : []);
   });
 
   eventBus.on('lasso.start', function(event) {
@@ -134,6 +132,7 @@ export default function LassoTool(
     visuals.create(context);
 
     context.selection = selection.get();
+    context.add = hasSecondaryModifier(event);
   });
 
   eventBus.on('lasso.move', function(event) {

--- a/test/spec/features/lasso-tool/LassoToolSpec.js
+++ b/test/spec/features/lasso-tool/LassoToolSpec.js
@@ -162,6 +162,46 @@ describe('features/lasso-tool', function() {
       expect(selection.get()).to.eql([ elementRegistry.get('child') ]);
     }));
 
+
+    it('should add to selection if shift is held at drag start', inject(
+      function(lassoTool, dragging, selection, elementRegistry) {
+
+        // given - childShape is already selected
+        selection.select([ elementRegistry.get('child') ]);
+
+        // when - start lasso with shift held, selecting childShape2 and childShape3
+        lassoTool.activateLasso(canvasEvent({ x: 175, y: 100 }));
+        dragging.move(canvasEvent({ x: 295, y: 220 }, { shiftKey: true }));
+        dragging.end(canvasEvent({ x: 295, y: 220 }));
+
+        // then - previously selected element is included
+        var selected = selection.get();
+        expect(selected).to.include(elementRegistry.get('child'));
+        expect(selected).to.include(elementRegistry.get('child2'));
+        expect(selected).to.include(elementRegistry.get('child3'));
+      }
+    ));
+
+
+    it('should NOT add to selection if shift is held only at drag end', inject(
+      function(lassoTool, dragging, selection, elementRegistry) {
+
+        // given - childShape is already selected
+        selection.select([ elementRegistry.get('child') ]);
+
+        // when - start lasso WITHOUT shift, selecting childShape2 and childShape3
+        lassoTool.activateLasso(canvasEvent({ x: 175, y: 100 }));
+        dragging.move(canvasEvent({ x: 295, y: 220 }));
+        dragging.end(canvasEvent({ x: 295, y: 220 }, { shiftKey: true }));
+
+        // then - previously selected element is NOT included (shift at end is ignored)
+        var selected = selection.get();
+        expect(selected).not.to.include(elementRegistry.get('child'));
+        expect(selected).to.include(elementRegistry.get('child2'));
+        expect(selected).to.include(elementRegistry.get('child3'));
+      }
+    ));
+
   });
 
 


### PR DESCRIPTION
### Proposed Changes

closes #1028 

Add originally selected elements to the lasso selection if Shift was pressed at the start of the lasso drag.

Try it out:
```
npx @bpmn-io/sr bpmn-io/bpmn-js -l bpmn-io/diagram-js#1028-check-shift-lasso-start
```

https://github.com/user-attachments/assets/a56636a1-4e45-4052-85e8-bd8709ac8390




### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
