### PR TITLE
feat(resize): pass direction to `canResize` when rendering handles

### DIFF
--- a/lib/features/resize/ResizeHandles.js
+++ b/lib/features/resize/ResizeHandles.js
@@ -162,12 +162,14 @@ ResizeHandles.prototype.createResizer = function(element, direction) {
 ResizeHandles.prototype.addResizer = function(element) {
   var self = this;
 
-  if (isConnection(element) || !this._resize.canResize({ shape: element })) {
+  if (isConnection(element)) {
     return;
   }
 
   forEach(directions, function(direction) {
-    self.createResizer(element, direction);
+    if (self._resize.canResize({ shape: element, direction: direction })) {
+      self.createResizer(element, direction);
+    }
   });
 };
 

--- a/test/spec/features/resize/ResizeSpec.js
+++ b/test/spec/features/resize/ResizeSpec.js
@@ -137,6 +137,27 @@ describe('features/resize - Resize', function() {
       expect(resizeAnchors).to.have.length(0);
     }));
 
+
+    it('should add only for allowed directions', inject(function(canvas, selection, resizeHandles) {
+
+      // given
+      var restrictedShape = canvas.addShape({
+        id: 'restricted',
+        resizable: true,
+        resizableDirections: [ 'n', 'se' ],
+        x: 300, y: 100, width: 100, height: 100
+      });
+
+      // when
+      selection.select(restrictedShape);
+
+      // then
+      var parent = resizeHandles._getResizersParent();
+      expect(domQueryAll('.djs-resizer', parent)).to.have.length(2);
+      expect(domQuery('.djs-resizer-n', parent)).to.exist;
+      expect(domQuery('.djs-resizer-se', parent)).to.exist;
+    }));
+
   });
 
 

--- a/test/spec/features/resize/rules/ResizeRules.js
+++ b/test/spec/features/resize/rules/ResizeRules.js
@@ -23,6 +23,13 @@ ResizeRules.prototype.init = function() {
       if (!shape.resizable) {
         return false;
       }
+
+      // check direction-specific resizability
+      if (context.direction && shape.resizableDirections) {
+        if (shape.resizableDirections.indexOf(context.direction) === -1) {
+          return false;
+        }
+      }
     } else {
       if (shape.resizable === 'always') {
         return true;


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js/pull/2414

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

Pass direction to `canResize`, to allow the consumer to add resize handles only for specified directions.

Example in bpmn-js:

<img width="204" height="243" alt="image" src="https://github.com/user-attachments/assets/3d245ca8-509f-4f41-a37a-c6c0936aca46" />

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
