### PR TITLE
feat: keep selection visible on canvas resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+* `FEAT`: add feature to keep selection visible ([#1038](https://github.com/bpmn-io/diagram-js/pull/1038))
+
 ## 15.22.0
 
 * `FEAT`: restore canvas focus in next render cycle ([#1081](https://github.com/bpmn-io/diagram-js/pull/1081))

--- a/lib/features/keep-selection-visible/KeepSelectionVisible.js
+++ b/lib/features/keep-selection-visible/KeepSelectionVisible.js
@@ -1,0 +1,81 @@
+import { debounce } from 'min-dash';
+
+import { getBBox } from '../../util/Elements.js';
+import { asTRBL } from '../../layout/LayoutUtil.js';
+
+var UPDATE_DEBOUNCE_INTERVAL = 300;
+
+/**
+ * Keeps the current selection visible when the canvas container is resized,
+ * provided the selection was already visible before the resize. If the selection
+ * was out of view, this is a no-op.
+ *
+ * @param {import('../../core/EventBus').default} eventBus
+ * @param {import('../../core/Canvas').default} canvas
+ * @param {import('../selection/Selection').default} selection
+ */
+export default function KeepSelectionVisible(eventBus, canvas, selection) {
+
+  this._selectionWasVisible = false;
+
+  // canvas viewbox computation used to determine selection visibility
+  // is a potentially expensive activity. Hence we debounce it to prevent
+  // unnecessary computation. The side-effect is that this happens outside
+  // of the current update cycle - a good thing.
+  const updateSelectionVisible = debounce(() => {
+    this._selectionWasVisible = isSelectionVisible();
+  }, UPDATE_DEBOUNCE_INTERVAL);
+
+  eventBus.on('canvas.viewbox.changed', updateSelectionVisible);
+  eventBus.on('selection.changed', updateSelectionVisible);
+
+  eventBus.on('canvas.resized', () => {
+    var selected = selection.get();
+
+    if (!selected.length) {
+      return;
+    }
+
+    if (!this._selectionWasVisible) {
+      return;
+    }
+
+    if (isSelectionVisible()) {
+      return;
+    }
+
+    var currentRoot = canvas.getRootElement();
+
+    // we ensure that selection scrolling always happens on the current root
+    // (no root switch happens)
+    canvas.scrollToElement(selected.concat(currentRoot));
+  });
+
+  function isSelectionVisible() {
+    var selected = selection.get();
+
+    if (!selected.length) {
+      return false;
+    }
+
+    var selectionBBox = getBBox(selected);
+    var viewbox = canvas.viewbox();
+
+    var elementTrbl = asTRBL(selectionBBox);
+    var viewboxTrbl = asTRBL(viewbox);
+
+    return elementTrbl.left >= viewboxTrbl.left &&
+           elementTrbl.right <= viewboxTrbl.right &&
+           elementTrbl.top >= viewboxTrbl.top &&
+           elementTrbl.bottom <= viewboxTrbl.bottom;
+  }
+
+  // @ts-ignore - test helper - flush internal state
+  this._flush = updateSelectionVisible.flush;
+}
+
+KeepSelectionVisible.$inject = [
+  'eventBus',
+  'canvas',
+  'selection'
+];

--- a/lib/features/keep-selection-visible/index.js
+++ b/lib/features/keep-selection-visible/index.js
@@ -1,0 +1,14 @@
+import SelectionModule from '../selection/index.js';
+
+import KeepSelectionVisible from './KeepSelectionVisible.js';
+
+/**
+ * @type { import('didi').ModuleDeclaration }
+ */
+export default {
+  __init__: [ 'keepSelectionVisible' ],
+  __depends__: [
+    SelectionModule
+  ],
+  keepSelectionVisible: [ 'type', KeepSelectionVisible ]
+};

--- a/test/spec/features/keep-selection-visible/KeepSelectionVisibleSpec.js
+++ b/test/spec/features/keep-selection-visible/KeepSelectionVisibleSpec.js
@@ -1,0 +1,324 @@
+import { expect } from 'chai';
+
+import {
+  bootstrapDiagram,
+  getDiagramJS,
+  inject
+} from 'test/TestHelper';
+
+import coreModule from 'lib/core';
+import selectionModule from 'lib/features/selection';
+import keepSelectionVisibleModule from 'lib/features/keep-selection-visible';
+
+import { getBBox } from 'lib/util/Elements';
+import { asTRBL } from 'lib/layout/LayoutUtil';
+
+
+describe('features/keep-selection-visible', function() {
+
+  beforeEach(bootstrapDiagram({
+    modules: [
+      coreModule,
+      selectionModule,
+      keepSelectionVisibleModule
+    ],
+    canvas: {
+      width: 800,
+      height: 600
+    }
+  }));
+
+  var shape1, shape2, shape3;
+
+  beforeEach(inject(function(canvas) {
+
+    shape1 = canvas.addShape({
+      id: 'shape1', x: 700, y: 200, width: 100, height: 100
+    });
+
+    shape2 = canvas.addShape({
+      id: 'shape2', x: 200, y: 500, width: 100, height: 100
+    });
+
+    shape3 = canvas.addShape({
+      id: 'shape3', x: 10, y: 10, width: 100, height: 100
+    });
+  }));
+
+
+  describe('scroll adjustment on resize', function() {
+
+    it('should scroll right when canvas shrinks from right', inject(
+      function(canvas, selection) {
+
+        // given
+        act(() => {
+          selection.select(shape1);
+        });
+
+        var viewboxBeforeResize = canvas.viewbox();
+
+        // when
+        canvas.getContainer().style.width = '600px';
+        canvas.resized();
+
+        // then
+        expectSelectionInView(canvas, selection);
+        expectAxisUnchanged(canvas, viewboxBeforeResize, 'y');
+      }
+    ));
+
+
+    it('should scroll down when canvas shrinks from bottom', inject(
+      function(canvas, selection) {
+
+        // given
+        act(() => {
+          selection.select(shape2);
+        });
+
+        var viewboxBeforeResize = canvas.viewbox();
+
+        // when
+        canvas.getContainer().style.height = '400px';
+        canvas.resized();
+
+        // then
+        expectSelectionInView(canvas, selection);
+        expectAxisUnchanged(canvas, viewboxBeforeResize, 'x');
+      }
+    ));
+
+
+    it('should scroll to keep multi-selection bounding box visible', inject(
+      function(canvas, selection) {
+
+        // given
+        var nearRight1 = canvas.addShape({
+          id: 'nearRight1', x: 500, y: 200, width: 100, height: 100
+        });
+        var nearRight2 = canvas.addShape({
+          id: 'nearRight2', x: 700, y: 200, width: 100, height: 100
+        });
+
+        act(() => {
+          selection.select([ nearRight1, nearRight2 ]);
+        });
+
+        var viewboxBeforeResize = canvas.viewbox();
+
+        // when
+        canvas.getContainer().style.width = '600px';
+        canvas.resized();
+
+        // then
+        expectSelectionInView(canvas, selection);
+        expectAxisUnchanged(canvas, viewboxBeforeResize, 'y');
+      }
+    ));
+
+  });
+
+
+  describe('visibility guard', function() {
+
+    it('should NOT scroll when selection was not visible before resize', inject(
+      function(canvas, selection) {
+
+        // given
+        act(() => {
+          selection.select(shape1);
+          canvas.scroll({ dx: -2000, dy: 0 });
+        });
+
+        var viewboxBeforeResize = canvas.viewbox();
+
+        // when
+        canvas.getContainer().style.width = '600px';
+        canvas.resized();
+
+        // then
+        expectViewboxUnchanged(canvas, viewboxBeforeResize);
+      }
+    ));
+
+
+    it('should NOT scroll when selection still fits after resize', inject(
+      function(canvas, selection) {
+
+        // given
+        act(() => {
+          selection.select(shape3);
+        });
+
+        var viewboxBeforeResize = canvas.viewbox();
+
+        // when
+        canvas.getContainer().style.width = '600px';
+        canvas.resized();
+
+        // then
+        expectViewboxUnchanged(canvas, viewboxBeforeResize);
+      }
+    ));
+
+
+    it('should NOT scroll when selection bbox is larger than viewport', inject(
+      function(canvas, selection) {
+
+        // given
+        var wideShape = canvas.addShape({
+          id: 'wideShape', x: 0, y: 0, width: 2000, height: 100
+        });
+
+        act(() => {
+          selection.select(wideShape);
+        });
+
+        var viewboxBeforeResize = canvas.viewbox();
+
+        // when
+        canvas.getContainer().style.width = '600px';
+        canvas.resized();
+
+        // then
+        expectViewboxUnchanged(canvas, viewboxBeforeResize);
+      }
+    ));
+
+
+    it('should NOT scroll when nothing is selected', inject(
+      function(canvas) {
+
+        // given
+        var viewboxBeforeResize = canvas.viewbox();
+
+        // when
+        canvas.getContainer().style.width = '600px';
+        canvas.resized();
+
+        // then
+        expectViewboxUnchanged(canvas, viewboxBeforeResize);
+      }
+    ));
+
+
+    it('should NOT scroll when selection is in a different root element', inject(
+      function(canvas, selection) {
+
+        // given
+        var otherRoot = canvas.addRootElement({ id: 'otherRoot' });
+        var shapeInOtherRoot = canvas.addShape(
+          { id: 'otherShape', x: 700, y: 10, width: 100, height: 100 },
+          otherRoot
+        );
+
+        act(() => {
+          selection.select(shapeInOtherRoot);
+        });
+
+        var viewboxBeforeResize = canvas.viewbox();
+
+        // when
+        canvas.getContainer().style.width = '600px';
+        canvas.resized();
+
+        // then
+        expectViewboxUnchanged(canvas, viewboxBeforeResize);
+      }
+    ));
+
+  });
+
+
+  describe('visibility flag tracking', function() {
+
+    it('should not bring selection back after user scrolls it away', inject(
+      function(canvas, selection) {
+
+        // given
+        act(() => {
+          selection.select(shape1);
+          canvas.scroll({ dx: -2000, dy: 0 });
+        });
+
+        var viewboxBeforeResize = canvas.viewbox();
+
+        // when
+        canvas.getContainer().style.width = '600px';
+        canvas.resized();
+
+        // then
+        expectViewboxUnchanged(canvas, viewboxBeforeResize);
+      }
+    ));
+
+
+    it('should track the current selection, not the previous one', inject(
+      function(canvas, selection) {
+
+        // given
+        act(() => {
+          selection.select(shape1);
+          selection.select(shape3);
+        });
+
+        var viewboxBeforeResize = canvas.viewbox();
+
+        // when
+        canvas.getContainer().style.width = '600px';
+        canvas.resized();
+
+        // then
+        expectViewboxUnchanged(canvas, viewboxBeforeResize);
+      }
+    ));
+
+  });
+
+});
+
+
+// helpers ///////////////
+
+function expectSelectionInView(canvas, selection) {
+  var scrollPadding = 100;
+
+  var viewbox = canvas.viewbox();
+  var viewboxTrbl = asTRBL(viewbox);
+  var selectionBBox = getBBox(selection.get());
+  var selectionTrbl = asTRBL(selectionBBox);
+
+  expect(selectionTrbl.left).to.be.at.least(viewboxTrbl.left + scrollPadding);
+  expect(selectionTrbl.right).to.be.at.most(viewboxTrbl.right - scrollPadding);
+  expect(selectionTrbl.top).to.be.at.least(viewboxTrbl.top + scrollPadding);
+  expect(selectionTrbl.bottom).to.be.at.most(viewboxTrbl.bottom - scrollPadding);
+}
+
+function expectAxisUnchanged(canvas, viewboxBefore, axis) {
+  var viewbox = canvas.viewbox();
+  expect(viewbox[axis]).to.equal(viewboxBefore[axis]);
+}
+
+function expectViewboxUnchanged(canvas, viewboxBefore) {
+  var viewbox = canvas.viewbox();
+  expect(viewbox.x).to.equal(viewboxBefore.x);
+  expect(viewbox.y).to.equal(viewboxBefore.y);
+}
+
+/**
+ * Performs change - flushes internal state to pick change up.
+ *
+ * @param {Function} fn
+ */
+function act(fn) {
+
+  getDiagramJS().invoke(function(keepSelectionVisible) {
+
+    try {
+      fn();
+    } finally {
+      keepSelectionVisible._flush();
+    }
+  });
+}


### PR DESCRIPTION
Related to camunda/camunda-modeler#5957

### Proposed Changes

This pull request aims to introduce an opt-in feature to keep the selection in view on resizing the canvas.

Without this `feature`, resizing the canvas may have left the `selection` out of the view even if there was enough space in the canvas. Along with this, when the selection is in the view, resizing the canvas will try to keep the selection in the view with minimum movement. If the selection was already out of the view before resizing, this feature is no-op as the focus was not on the selection already.

The screencast below consists of two parts. The first part demonstrates the feature to keep the selection in view on resizing. The second part demonstrates the no-op part of the feature as the selection was off of the view already.

https://github.com/user-attachments/assets/3f8cf14a-5c5e-4ad6-adbf-fe5a4deaf863



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
