### PR TITLE
feat: multi-step pop-up menu

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -617,10 +617,87 @@
   margin: 0;
 }
 
+.djs-popup-breadcrumbs {
+  display: flex;
+  line-height: 20px;
+  margin: 10px 12px;
+}
+
+.djs-popup-breadcrumbs-item {
+  display: inline-flex;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  border: 0;
+  outline: none;
+  appearance: none;
+  color: var(--popup-description-color);
+  font: inherit;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.djs-popup-breadcrumbs-item--separator::before {
+  display: inline-block;
+  content: '/';
+  color: var(--popup-description-color);
+  margin: 0 4px;
+}
+
+.djs-popup-breadcrumbs-item:hover {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.djs-popup-breadcrumbs-item:focus-visible {
+  outline: 1px solid var(--popup-search-focus-border-color);
+  outline-offset: 2px;
+}
+
+.djs-popup-breadcrumbs-item--back {
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 2px 3px;
+  margin-right: 6px;
+  border: 1px solid var(--popup-search-border-color);
+  border-radius: 4px;
+}
+
+.djs-popup-breadcrumbs-item--back:hover {
+  background: #f2f3f5;
+}
+
+.djs-popup-breadcrumbs-item--current {
+  font-weight: var(--popup-header-font-weight);
+  color: inherit;
+  cursor: default;
+}
+
+.djs-popup-breadcrumbs-item--current:hover {
+  text-decoration: none;
+}
+
+.djs-popup-entry-chevron {
+  display: flex;
+  align-items: center;
+  margin-left: 6px;
+  color: var(--popup-description-color);
+}
+
 .djs-popup-search-icon {
   position: absolute;
   left: 8px;
   top: 7px;
+}
+
+.djs-popup-search-count {
+  margin: 0 12px;
+  font-size: 11px;
+  color: var(--popup-description-color);
 }
 
 .djs-popup-results {

--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -112,9 +112,7 @@ PopupMenu.prototype._render = function() {
     options
   } = this._current;
 
-  const entriesArray = Object.entries(entries).map(
-    ([ key, value ]) => ({ id: key, ...value })
-  );
+  const entriesArray = flattenEntries(entries);
 
   const headerEntriesArray = Object.entries(headerEntries).map(
     ([ key, value ]) => ({ id: key, ...value })
@@ -629,3 +627,25 @@ PopupMenu.prototype._getEntry = function(entryId) {
 
   return entry;
 };
+
+
+/**
+ * Convert a `PopupMenuEntries` record into an array of entries with their id
+ * spliced in. Recurses into step entries so the whole tree uses the array
+ * shape downstream.
+ *
+ * @param {import('./PopupMenuProvider').PopupMenuEntries} entriesMap
+ *
+ * @return {import('./PopupMenuProvider').PopupMenuEntry[]}
+ */
+function flattenEntries(entriesMap) {
+  return Object.entries(entriesMap).map(([ id, value ]) => {
+    const entry = { id, ...value };
+
+    if (entry.entries) {
+      entry.entries = flattenEntries(entry.entries);
+    }
+
+    return entry;
+  });
+}

--- a/lib/features/popup-menu/PopupMenuBreadcrumbs.js
+++ b/lib/features/popup-menu/PopupMenuBreadcrumbs.js
@@ -1,0 +1,71 @@
+import {
+  html,
+  useMemo
+} from '../../ui';
+
+/**
+ * @typedef {import('./PopupMenuProvider').PopupMenuStepEntry} PopupMenuStepEntry
+ */
+
+/**
+ * Component that renders the popup menu navigation trail.
+ *
+ * @param {Object} props
+ * @param {PopupMenuStepEntry[]} props.navigationStack
+ * @param {(updater: (stack: PopupMenuStepEntry[]) => PopupMenuStepEntry[]) => void} props.setNavigationStack
+ */
+export default function PopupMenuBreadcrumbs(props) {
+  const {
+    navigationStack,
+    setNavigationStack
+  } = props;
+
+  const breadcrumbs = useMemo(() => {
+    if (navigationStack.length <= 1) {
+      return [];
+    }
+
+    return navigationStack.slice(0, -1).map((entry, index) => ({
+      label: entry.label,
+      onClick: () => setNavigationStack(stack => stack.slice(0, index + 1))
+    }));
+  }, [ navigationStack, setNavigationStack ]);
+
+  const handleBackClick = navigationStack.length > 0 ? () => setNavigationStack([]) : null;
+  const currentLabel = navigationStack.length > 0 ? navigationStack[navigationStack.length - 1].label : null;
+
+  return html`
+    <div class="djs-popup-breadcrumbs">
+      ${ handleBackClick && html`
+        <button
+          type="button"
+          class="djs-popup-breadcrumbs-item djs-popup-breadcrumbs-item--back"
+          title="Back"
+          aria-label="Back"
+          onClick=${ handleBackClick }
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M8.03033 1.46967C8.32322 1.76256 8.32322 2.23744 8.03033 2.53033L4.56066 6L8.03033 9.46967C8.32322 9.76256 8.32322 10.2374 8.03033 10.5303C7.73744 10.8232 7.26256 10.8232 6.96967 10.5303L2.96967 6.53033C2.67678 6.23744 2.67678 5.76256 2.96967 5.46967L6.96967 1.46967C7.26256 1.17678 7.73744 1.17678 8.03033 1.46967Z" fill="currentColor"/>
+          </svg>
+        </button>
+      ` }
+      ${ breadcrumbs.map((crumb, i) => html`
+        <button
+          key=${ i }
+          type="button"
+          class="djs-popup-breadcrumbs-item"
+          onClick=${ crumb.onClick }
+          title=${ crumb.label }
+        >
+          ${ crumb.label }
+        </button>
+        <span class="djs-popup-breadcrumbs-item--separator" aria-hidden="true"></span>
+      `) }
+      ${ currentLabel && html`
+        <span class="djs-popup-breadcrumbs-item djs-popup-breadcrumbs-item--current" title=${ currentLabel }>
+          ${ currentLabel }
+        </span>
+      ` }
+    </div>
+  `;
+}

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -13,6 +13,7 @@ import {
   matches as domMatches
 } from 'min-dom';
 
+import PopupMenuBreadcrumbs from './PopupMenuBreadcrumbs.js';
 import PopupMenuHeader from './PopupMenuHeader.js';
 import PopupMenuList from './PopupMenuList.js';
 import classNames from 'clsx';
@@ -20,6 +21,8 @@ import { isDefined, isFunction } from 'min-dash';
 
 /**
  * @typedef {import('./PopupMenuProvider.js').PopupMenuEntry} PopupMenuEntry
+ * @typedef {import('./PopupMenuProvider.js').PopupMenuActionEntry} PopupMenuActionEntry
+ * @typedef {import('./PopupMenuProvider.js').PopupMenuStepEntry} PopupMenuStepEntry
  * @typedef {import('./PopupMenuProvider.js').PopupMenuHeaderEntry} PopupMenuHeaderEntry
  * @typedef {import('./PopupMenuProvider.js').PopupMenuEmptyPlaceholderProvider | import('./PopupMenuProvider.js').PopupMenuEmptyPlaceholder} PopupMenuEmptyPlaceholder
  * @typedef {import('./PopupMenuProvider.js').PopupMenuGroup} PopupMenuGroup
@@ -59,57 +62,98 @@ export default function PopupMenuComponent(props) {
     search,
     emptyPlaceholder,
     searchFn,
-    entries: originalEntries,
+    entries,
     onOpened,
     onClosed
   } = props;
+
+  /**
+   * If a step entry (i.e. an entry with nested `entries`) is clicked,
+   * it is pushed onto the stack to keep track of the navigation path.
+   *
+   * When the user clicks "Back" or a breadcrumb, the stack is popped.
+   *
+   * @type {[ PopupMenuStepEntry[], (stack: PopupMenuStepEntry[] | ((stack: PopupMenuStepEntry[]) => PopupMenuStepEntry[])) => void ]}
+   */
+  const [ navigationStack, setNavigationStack ] = useState([]);
+
+  /**
+   * On `PopupMenu#refresh()` (i.e. when `entries` change)
+   * the stack is reset to root.
+   */
+  useEffect(() => {
+    setNavigationStack([]);
+  }, [ entries ]);
+
+  const [ searchValue, setSearchValue ] = useState('');
+  const isSearching = searchValue.trim().length > 0;
+
+  const actionableEntries = useMemo(() => getActionableEntries(entries), [ entries ]);
 
   const searchable = useMemo(() => {
     if (!isDefined(search)) {
       return false;
     }
 
-    return originalEntries.length > 5;
-  }, [ search, originalEntries ]);
+    return actionableEntries.length > 5;
+  }, [ search, actionableEntries ]);
 
-  const [ searchValue, setSearchValue ] = useState('');
+  const entriesToShow = useMemo(() => {
 
-  const filterEntries = useCallback((originalEntries, searchValue) => {
+    const availableEntries = navigationStack.length
+      ? navigationStack[navigationStack.length - 1].entries
+      : entries;
 
-    if (!searchable) {
-      return originalEntries;
+    if (!searchable) return availableEntries;
+
+    if (isSearching) {
+      return searchFn(
+        actionableEntries.filter(({ searchable }) => searchable !== false),
+        searchValue,
+        { keys: [ 'label', 'search', 'description' ] }
+      ).map(({ item }) => item);
     }
 
-    if (!searchValue.trim()) {
-      return originalEntries.filter(({ rank = 0 }) => rank >= 0);
-    }
-
-    const searchableEntries = originalEntries.filter(({ searchable }) => searchable !== false);
-
-    return searchFn(searchableEntries, searchValue, {
-      keys: [
-        'label',
-        'search',
-        'description'
-      ]
-    }).map(({ item }) => item);
-  }, [ searchable ]);
-
-  const entries = useMemo(() => filterEntries(originalEntries, searchValue), [ originalEntries, searchValue, filterEntries ]);
-  const [ selectedEntry, setSelectedEntry ] = useState(entries[0]);
+    return availableEntries.filter(({ rank = 0 }) => rank >= 0);
+  }, [ searchable, isSearching, actionableEntries, searchValue, searchFn, navigationStack, entries ]);
 
   const groupedEntries = useMemo(() => {
-    if (searchValue.trim()) {
-      return entries.length ? [ { id: 'default', entries } ] : [];
+    if (isSearching) {
+      return entriesToShow.length ? [ { id: 'default', entries: entriesToShow } ] : [];
     }
 
-    return groupEntries(entries);
-  }, [ entries, searchValue ]);
+    return groupEntries(entriesToShow);
+  }, [ entriesToShow, isSearching ]);
 
-  // always select first entry when filtered entries change
+  const [ selectedEntry, setSelectedEntry ] = useState(entriesToShow[0]);
+  const restoreSelection = useRef(null);
+
   useEffect(() => {
-    setSelectedEntry(entries[0]);
-  }, [ entries ]);
+    const restore = restoreSelection.current;
+
+    if (restore && entriesToShow.includes(restore)) {
+      setSelectedEntry(restore);
+    } else {
+      setSelectedEntry(entriesToShow[0]);
+    }
+
+    restoreSelection.current = null;
+  }, [ entriesToShow ]);
+
+  const handleEntryAction = useCallback((event, entry, action) => {
+    if (!entry || entry.disabled) {
+      return;
+    }
+
+    if (entry.entries) {
+      event.preventDefault();
+
+      setNavigationStack(stack => [ ...stack, entry ]);
+      return;
+    }
+
+    return onSelect(event, entry, action);
+  }, [ onSelect ]);
 
   // handle keyboard selection
   const keyboardSelect = useCallback(direction => {
@@ -127,7 +171,7 @@ export default function PopupMenuComponent(props) {
     }
 
     setSelectedEntry(entries[nextIdx]);
-  }, [ groupedEntries, selectedEntry, setSelectedEntry ]);
+  }, [ groupedEntries, selectedEntry ]);
 
   const handleKeyDown = useCallback(event => {
     if (event.key === 'Enter' && selectedEntry) {
@@ -135,7 +179,20 @@ export default function PopupMenuComponent(props) {
         return;
       }
 
-      return onSelect(event, selectedEntry);
+      return handleEntryAction(event, selectedEntry);
+    }
+
+    // BACKSPACE
+    if (event.key === 'Backspace' && navigationStack.length > 0) {
+      const target = event.target;
+      const isEditingSearch = domMatches(target, 'input') && target.value !== '';
+
+      if (!isEditingSearch) {
+        restoreSelection.current = navigationStack[navigationStack.length - 1];
+        setNavigationStack(stack => stack.slice(0, -1));
+
+        return event.preventDefault();
+      }
     }
 
     // ARROW_UP
@@ -151,7 +208,7 @@ export default function PopupMenuComponent(props) {
 
       return event.preventDefault();
     }
-  }, [ onSelect, selectedEntry, keyboardSelect ]);
+  }, [ selectedEntry, keyboardSelect, handleEntryAction, navigationStack ]);
 
   const handleKey = useCallback(event => {
     if (domMatches(event.target, 'input')) {
@@ -167,7 +224,8 @@ export default function PopupMenuComponent(props) {
     };
   }, []);
 
-  const displayHeader = useMemo(() => title || headerEntries.length > 0, [ title, headerEntries ]);
+  const displayBreadcrumbs = !isSearching && navigationStack.length > 0;
+  const displayHeader = (title || headerEntries.length > 0) && !displayBreadcrumbs;
 
   return html`
     <${PopupMenuWrapper}
@@ -188,7 +246,13 @@ export default function PopupMenuComponent(props) {
           title=${ title }
         />
       ` }
-      ${ originalEntries.length > 0 && html`
+      ${ displayBreadcrumbs && html`
+        <${PopupMenuBreadcrumbs}
+          navigationStack=${navigationStack}
+          setNavigationStack=${ setNavigationStack }
+        />
+      ` }
+      ${ entries.length > 0 && html`
         <div class="djs-popup-body">
 
           ${ searchable && html`
@@ -196,19 +260,25 @@ export default function PopupMenuComponent(props) {
             <svg class="djs-popup-search-icon" width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path fill-rule="evenodd" clip-rule="evenodd" d="M9.0325 8.5H9.625L13.3675 12.25L12.25 13.3675L8.5 9.625V9.0325L8.2975 8.8225C7.4425 9.5575 6.3325 10 5.125 10C2.4325 10 0.25 7.8175 0.25 5.125C0.25 2.4325 2.4325 0.25 5.125 0.25C7.8175 0.25 10 2.4325 10 5.125C10 6.3325 9.5575 7.4425 8.8225 8.2975L9.0325 8.5ZM1.75 5.125C1.75 6.9925 3.2575 8.5 5.125 8.5C6.9925 8.5 8.5 6.9925 8.5 5.125C8.5 3.2575 6.9925 1.75 5.125 1.75C3.2575 1.75 1.75 3.2575 1.75 5.125Z" fill="#22242A"/>
             </svg>
-            <input type="text" spellcheck=${ false } aria-label="${ title }" />
+            <input type="text" spellcheck=${ false } aria-label="${ title || 'Search' }" />
           </div>
+          ` }
+
+          ${ isSearching && html`
+            <div class="djs-popup-search-count" aria-live="polite">
+              ${ entriesToShow.length } ${ entriesToShow.length === 1 ? 'result' : 'results' } found
+            </div>
           ` }
 
           <${PopupMenuList}
             groupedEntries=${ groupedEntries }
             selectedEntry=${ selectedEntry }
             setSelectedEntry=${ setSelectedEntry }
-            onAction=${ onSelect }
+            onAction=${ handleEntryAction }
           />
         </div>
       ` }
-    ${ emptyPlaceholder && entries.length === 0 && html`
+    ${ emptyPlaceholder && entriesToShow.length === 0 && html`
       <div class="djs-popup-no-results">${ isFunction(emptyPlaceholder) ? emptyPlaceholder(searchValue) : emptyPlaceholder }</div>
     ` }
     </${PopupMenuWrapper}>
@@ -322,6 +392,34 @@ function getOrderedEntries(groupedEntries) {
   });
 
   return entries;
+}
+
+/**
+ * Get a flat list of entries that are actionable, i.e. that do not have nested `entries`.
+ *
+ * Walk the entry tree following `entries` and return a flat list of leaves.
+ *
+ * @param {PopupMenuEntry[]} entries
+ *
+ * @return {PopupMenuActionEntry[]}
+ */
+function getActionableEntries(entries) {
+  const leaves = [];
+
+  function walk(entries) {
+    entries.forEach(entry => {
+      if (entry.entries) {
+        walk(entry.entries);
+        return;
+      }
+
+      leaves.push(entry);
+    });
+  }
+
+  walk(entries);
+
+  return leaves;
 }
 
 /**

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -140,21 +140,6 @@ export default function PopupMenuComponent(props) {
     restoreSelection.current = null;
   }, [ entriesToShow ]);
 
-  const handleEntryAction = useCallback((event, entry, action) => {
-    if (!entry || entry.disabled) {
-      return;
-    }
-
-    if (entry.entries) {
-      event.preventDefault();
-
-      setNavigationStack(stack => [ ...stack, entry ]);
-      return;
-    }
-
-    return onSelect(event, entry, action);
-  }, [ onSelect ]);
-
   // handle keyboard selection
   const keyboardSelect = useCallback(direction => {
     const entries = getOrderedEntries(groupedEntries);
@@ -173,6 +158,30 @@ export default function PopupMenuComponent(props) {
     setSelectedEntry(entries[nextIdx]);
   }, [ groupedEntries, selectedEntry ]);
 
+  const keyboardDrilldown = useCallback((direction) => {
+    if (direction > 0 && selectedEntry && selectedEntry.entries) {
+      setNavigationStack(stack => [ ...stack, selectedEntry ]);
+    }
+
+    if (direction < 0 && navigationStack.length > 0) {
+      restoreSelection.current = navigationStack[navigationStack.length + direction];
+      setNavigationStack(stack => stack.slice(0, direction));
+    }
+  }, [ selectedEntry, navigationStack ]);
+
+  const handleEntryAction = useCallback((event, entry, action) => {
+    if (!entry || entry.disabled) {
+      return;
+    }
+
+    if (entry.entries) {
+      event.preventDefault();
+      return keyboardDrilldown(1);
+    }
+
+    return onSelect(event, entry, action);
+  }, [ onSelect, keyboardDrilldown ]);
+
   const handleKeyDown = useCallback(event => {
     if (event.key === 'Enter' && selectedEntry) {
       if (selectedEntry.disabled) {
@@ -183,14 +192,12 @@ export default function PopupMenuComponent(props) {
     }
 
     // BACKSPACE
-    if (event.key === 'Backspace' && navigationStack.length > 0) {
+    if (event.key === 'Backspace') {
       const target = event.target;
       const isEditingSearch = domMatches(target, 'input') && target.value !== '';
 
       if (!isEditingSearch) {
-        restoreSelection.current = navigationStack[navigationStack.length - 1];
-        setNavigationStack(stack => stack.slice(0, -1));
-
+        keyboardDrilldown(-1);
         return event.preventDefault();
       }
     }
@@ -208,7 +215,19 @@ export default function PopupMenuComponent(props) {
 
       return event.preventDefault();
     }
-  }, [ selectedEntry, keyboardSelect, handleEntryAction, navigationStack ]);
+
+    // ARROW_RIGHT
+    if (event.key === 'ArrowRight') {
+      keyboardDrilldown(1);
+      return event.preventDefault();
+    }
+
+    // ARROW_LEFT
+    if (event.key === 'ArrowLeft') {
+      keyboardDrilldown(-1);
+      return event.preventDefault();
+    }
+  }, [ selectedEntry, keyboardSelect, keyboardDrilldown, handleEntryAction ]);
 
   const handleKey = useCallback(event => {
     if (domMatches(event.target, 'input')) {

--- a/lib/features/popup-menu/PopupMenuItem.js
+++ b/lib/features/popup-menu/PopupMenuItem.js
@@ -36,6 +36,8 @@ export default function PopupMenuItem(props) {
     return onAction(event, entry, action);
   };
 
+  const draggable = !entry.entries;
+
   return html`
     <li
       class=${ classNames('entry', { selected, disabled: entry.disabled }) }
@@ -48,8 +50,8 @@ export default function PopupMenuItem(props) {
       onBlur=${ onMouseLeave }
       onMouseEnter=${ onMouseEnter }
       onMouseLeave=${ onMouseLeave }
-      onDragStart=${ (event) => handleClick(event, 'dragstart') }
-      draggable=${ true }
+      onDragStart=${ (event) => draggable && handleClick(event, 'dragstart') }
+      draggable=${ draggable }
     >
       <div class="djs-popup-entry-content">
         <span
@@ -86,6 +88,13 @@ export default function PopupMenuItem(props) {
               <path fill-rule="evenodd" clip-rule="evenodd" d="M10.6368 10.6375V5.91761H11.9995V10.6382C11.9995 10.9973 11.8623 11.3141 11.5878 11.5885C11.3134 11.863 10.9966 12.0002 10.6375 12.0002H1.36266C0.982345 12.0002 0.660159 11.8681 0.396102 11.6041C0.132044 11.34 1.52588e-05 11.0178 1.52588e-05 10.6375V1.36267C1.52588e-05 0.98236 0.132044 0.660173 0.396102 0.396116C0.660159 0.132058 0.982345 2.95639e-05 1.36266 2.95639e-05H5.91624V1.36267H1.36266V10.6375H10.6368ZM12 0H7.2794L7.27873 1.36197H9.68701L3.06507 7.98391L4.01541 8.93425L10.6373 2.31231V4.72059H12V0Z" fill="#818798"/>
             </svg>
           </a>
+        </div>
+      ` }
+      ${ entry.entries && html`
+        <div class="djs-popup-entry-chevron" aria-hidden="true">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M3.96967 1.46967C4.26256 1.17678 4.73744 1.17678 5.03033 1.46967L9.03033 5.46967C9.32322 5.76256 9.32322 6.23744 9.03033 6.53033L5.03033 10.5303C4.73744 10.8232 4.26256 10.8232 3.96967 10.5303C3.67678 10.2374 3.67678 9.76256 3.96967 9.46967L7.43934 6L3.96967 2.53033C3.67678 2.23744 3.67678 1.76256 3.96967 1.46967Z" fill="currentColor"/>
+          </svg>
         </div>
       ` }
     </li>

--- a/lib/features/popup-menu/PopupMenuProvider.ts
+++ b/lib/features/popup-menu/PopupMenuProvider.ts
@@ -4,19 +4,44 @@ import type { PopupMenuTarget } from './PopupMenu.js';
 
 export type PopupMenuEntryAction = (
   event: Event,
-  entry: PopupMenuEntry,
+  entry: PopupMenuActionEntry,
   action?: string
 ) => any;
 
-export type PopupMenuEntry = {
-  action: PopupMenuEntryAction;
-  className: string;
+type PopupMenuEntryBase = {
+  className?: string;
   group?: string;
   disabled?: boolean;
   imageUrl?: string;
   imageHtml?: string;
-  label: string;
+  label?: string;
+  title?: string;
+  description?: string;
+  documentationRef?: string;
+  rank?: number;
+  search?: string | string[];
+  searchable?: boolean;
 };
+
+/**
+ * Popup menu entry which performs an action when clicked.
+ */
+export type PopupMenuActionEntry = PopupMenuEntryBase & {
+  action: PopupMenuEntryAction;
+  entries?: never;
+};
+
+/**
+ * Popup menu entry which navigates to a sub-menu when clicked.
+ */
+export type PopupMenuStepEntry = PopupMenuEntryBase & {
+  entries: PopupMenuEntries;
+  action?: never;
+};
+
+export type PopupMenuEntry =
+  | PopupMenuActionEntry
+  | PopupMenuStepEntry;
 
 export type PopupMenuEntries = Record<string, PopupMenuEntry>;
 

--- a/test/spec/features/popup-menu/PopupMenuBreadcrumbsSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuBreadcrumbsSpec.js
@@ -1,0 +1,319 @@
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+import PopupMenuBreadcrumbs from 'lib/features/popup-menu/PopupMenuBreadcrumbs';
+
+import {
+  html,
+  render
+} from 'lib/ui';
+
+import {
+  fireEvent
+} from '@testing-library/preact';
+
+import {
+  query as domQuery,
+  queryAll as domQueryAll
+} from 'min-dom';
+
+
+describe('features/popup-menu - <PopupMenuBreadcrumbs>', function() {
+  let container;
+
+  beforeEach(function() {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(function() {
+    container.parentNode.removeChild(container);
+  });
+
+
+  it('should render container', function() {
+
+    // when
+    createPopupMenuBreadcrumbs({ container });
+
+    // then
+    expect(domQuery('.djs-popup-breadcrumbs', container)).to.exist;
+  });
+
+
+  describe('empty stack', function() {
+
+    it('should not render back button', function() {
+
+      // when
+      createPopupMenuBreadcrumbs({ container, navigationStack: [] });
+
+      // then
+      expect(domQuery('.djs-popup-breadcrumbs-item--back', container)).not.to.exist;
+    });
+
+
+    it('should not render current label', function() {
+
+      // when
+      createPopupMenuBreadcrumbs({ container, navigationStack: [] });
+
+      // then
+      expect(domQuery('.djs-popup-breadcrumbs-item--current', container)).not.to.exist;
+    });
+
+
+    it('should not render any items', function() {
+
+      // when
+      createPopupMenuBreadcrumbs({ container, navigationStack: [] });
+
+      // then
+      expect(domQueryAll('.djs-popup-breadcrumbs-item', container)).to.have.length(0);
+    });
+
+  });
+
+
+  describe('depth 1', function() {
+
+    const navigationStack = [
+      stepEntry('A')
+    ];
+
+
+    it('should render back button', function() {
+
+      // when
+      createPopupMenuBreadcrumbs({ container, navigationStack });
+
+      // then
+      expect(domQuery('.djs-popup-breadcrumbs-item--back', container)).to.exist;
+    });
+
+
+    it('should render current label', function() {
+
+      // when
+      createPopupMenuBreadcrumbs({ container, navigationStack });
+
+      // then
+      const current = domQuery('.djs-popup-breadcrumbs-item--current', container);
+      expect(current).to.exist;
+      expect(current.textContent.trim()).to.eql('A');
+    });
+
+
+    it('should not render parent crumbs', function() {
+
+      // when
+      createPopupMenuBreadcrumbs({ container, navigationStack });
+
+      // then
+      const crumbs = domQueryAll(
+        '.djs-popup-breadcrumbs-item:not(.djs-popup-breadcrumbs-item--back):not(.djs-popup-breadcrumbs-item--current)',
+        container
+      );
+      expect(crumbs).to.have.length(0);
+    });
+
+  });
+
+
+  describe('depth 2+', function() {
+
+    const navigationStack = [
+      stepEntry('A'),
+      stepEntry('B')
+    ];
+
+
+    it('should render parent crumb', function() {
+
+      // when
+      createPopupMenuBreadcrumbs({ container, navigationStack });
+
+      // then
+      const crumbs = domQueryAll(
+        '.djs-popup-breadcrumbs-item:not(.djs-popup-breadcrumbs-item--back):not(.djs-popup-breadcrumbs-item--current)',
+        container
+      );
+
+      expect([ ...crumbs ].map(c => c.textContent.trim())).to.eql([ 'A' ]);
+    });
+
+
+    it('should render current label as last item', function() {
+
+      // when
+      createPopupMenuBreadcrumbs({ container, navigationStack });
+
+      // then
+      const current = domQuery('.djs-popup-breadcrumbs-item--current', container);
+      expect(current.textContent.trim()).to.eql('B');
+    });
+
+
+    it('should render multiple parent crumbs in order', function() {
+
+      // when
+      createPopupMenuBreadcrumbs({
+        container,
+        navigationStack: [
+          stepEntry('A'),
+          stepEntry('B'),
+          stepEntry('C')
+        ]
+      });
+
+      // then
+      const crumbs = domQueryAll(
+        '.djs-popup-breadcrumbs-item:not(.djs-popup-breadcrumbs-item--back):not(.djs-popup-breadcrumbs-item--current)',
+        container
+      );
+
+      expect([ ...crumbs ].map(c => c.textContent.trim())).to.eql([ 'A', 'B' ]);
+
+      expect(domQuery('.djs-popup-breadcrumbs-item--current', container).textContent.trim())
+        .to.eql('C');
+    });
+
+
+    it('should render separators between items', function() {
+
+      // when
+      createPopupMenuBreadcrumbs({
+        container,
+        navigationStack: [
+          stepEntry('A'),
+          stepEntry('B'),
+          stepEntry('C')
+        ]
+      });
+
+      // then
+      const separators = domQueryAll('.djs-popup-breadcrumbs-item--separator', container);
+      expect(separators).to.have.length(2);
+    });
+
+  });
+
+
+  describe('interactions', function() {
+
+    it('should reset stack on back click', function() {
+
+      // given
+      const setNavigationStack = spy();
+
+      createPopupMenuBreadcrumbs({
+        container,
+        navigationStack: [
+          stepEntry('A'),
+          stepEntry('B')
+        ],
+        setNavigationStack
+      });
+
+      // when
+      fireEvent.click(domQuery('.djs-popup-breadcrumbs-item--back', container));
+
+      // then
+      expect(setNavigationStack).to.have.been.calledOnceWith([]);
+    });
+
+
+    it('should pop to clicked level on crumb click', function() {
+
+      // given
+      const setNavigationStack = spy();
+
+      const stack = [
+        stepEntry('A'),
+        stepEntry('B'),
+        stepEntry('C')
+      ];
+
+      createPopupMenuBreadcrumbs({
+        container,
+        navigationStack: stack,
+        setNavigationStack
+      });
+
+      const crumbs = domQueryAll(
+        '.djs-popup-breadcrumbs-item:not(.djs-popup-breadcrumbs-item--back):not(.djs-popup-breadcrumbs-item--current)',
+        container
+      );
+
+      // when
+      fireEvent.click(crumbs[0]);
+
+      // then
+      expect(setNavigationStack).to.have.been.calledOnce;
+
+      const updater = setNavigationStack.firstCall.args[0];
+      expect(updater(stack)).to.eql([ stack[0] ]);
+    });
+
+
+    it('should pop to deeper level on later crumb click', function() {
+
+      // given
+      const setNavigationStack = spy();
+
+      const stack = [
+        stepEntry('A'),
+        stepEntry('B'),
+        stepEntry('C')
+      ];
+
+      createPopupMenuBreadcrumbs({
+        container,
+        navigationStack: stack,
+        setNavigationStack
+      });
+
+      const crumbs = domQueryAll(
+        '.djs-popup-breadcrumbs-item:not(.djs-popup-breadcrumbs-item--back):not(.djs-popup-breadcrumbs-item--current)',
+        container
+      );
+
+      // when
+      fireEvent.click(crumbs[1]);
+
+      // then
+      const updater = setNavigationStack.firstCall.args[0];
+      expect(updater(stack)).to.eql([ stack[0], stack[1] ]);
+    });
+
+  });
+
+});
+
+
+// helpers
+function createPopupMenuBreadcrumbs(options) {
+  const {
+    container,
+    ...rest
+  } = options;
+
+  const props = {
+    navigationStack: [],
+    setNavigationStack: () => {},
+    ...rest
+  };
+
+  return render(
+    html`<${ PopupMenuBreadcrumbs } ...${ props } />`,
+    container
+  );
+}
+
+function stepEntry(label) {
+  return {
+    id: label,
+    label,
+    entries: []
+  };
+}

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -950,6 +950,517 @@ describe('features/popup-menu - <PopupMenu>', function() {
       expect(domQuery('.selected', container).textContent).to.include('Group C - Entry 2');
     });
 
+
+    it('should pop one level with <Backspace>', async function() {
+
+      // given
+      const nestedEntries = [
+        {
+          id: '1',
+          label: 'A',
+          entries: [
+            { id: '1-1', label: 'A-A', action: () => {} },
+            { id: '1-2', label: 'A-B', action: () => {} }
+          ]
+        },
+        {
+          id: '2',
+          label: 'B',
+          action: () => {}
+        }
+      ];
+
+      await createPopupMenu({ container, entries: nestedEntries });
+
+      fireEvent.click(domQuery('.entry[data-id="1"]', container));
+
+      const popupEl = domQuery('.djs-popup', container);
+
+      // when
+      fireEvent.keyDown(popupEl, { key: 'Backspace' });
+
+      // then
+      const entryLabels = domQueryAll('.djs-popup-label', container);
+      expect([ ...entryLabels ].map(e => e.textContent)).to.eql([ 'A', 'B' ]);
+    });
+
+
+    it('should restore selection to popped entry after <Backspace>', async function() {
+
+      // given
+      const nestedEntries = [
+        {
+          id: '1',
+          label: 'A',
+          action: () => {}
+        },
+        {
+          id: '2',
+          label: 'B',
+          entries: [
+            { id: '2-1', label: 'B-A', action: () => {} }
+          ]
+        }
+      ];
+
+      await createPopupMenu({ container, entries: nestedEntries });
+
+      fireEvent.click(domQuery('.entry[data-id="2"]', container));
+
+      const popupEl = domQuery('.djs-popup', container);
+
+      // when
+      fireEvent.keyDown(popupEl, { key: 'Backspace' });
+
+      // then
+      expect(domQuery('.selected .djs-popup-label', container).textContent).to.eql('B');
+    });
+
+  });
+
+
+  describe('navigation', function() {
+
+    const navigateEntries = [
+      {
+        id: 'issues',
+        label: 'Issues',
+        entries: [
+          { id: 'create-issue', label: 'Create Issue', action: () => {} },
+          { id: 'list-issues', label: 'List Issues', action: () => {} }
+        ]
+      },
+      {
+        id: 'leaf',
+        label: 'Leaf',
+        action: () => {}
+      }
+    ];
+
+
+    it('should push level on click of navigate entry', async function() {
+
+      // given
+      const onSelect = spy();
+
+      await createPopupMenu({ container, entries: navigateEntries, onSelect });
+
+      const navigateEntry = domQuery('.entry[data-id="issues"]', container);
+
+      // when
+      fireEvent.click(navigateEntry);
+
+      // then
+      expect(onSelect).not.to.be.called;
+
+      const entryLabels = domQueryAll('.djs-popup-label', container);
+      expect([ ...entryLabels ].map(e => e.textContent)).to.eql([
+        'Create Issue',
+        'List Issues'
+      ]);
+    });
+
+
+    it('should not close popup on click of navigate entry', async function() {
+
+      // given
+      const onClose = spy();
+
+      await createPopupMenu({ container, entries: navigateEntries, onClose });
+
+      // when
+      fireEvent.click(domQuery('.entry[data-id="issues"]', container));
+
+      // then
+      expect(onClose).not.to.have.been.called;
+      expect(domQuery('.entry[data-id="create-issue"]', container)).to.exist;
+    });
+
+
+    it('should push level on <Enter> over navigate entry', async function() {
+
+      // given
+      const onSelect = spy();
+
+      await createPopupMenu({ container, entries: navigateEntries, onSelect });
+
+      const popupEl = domQuery('.djs-popup', container);
+
+      // when
+      fireEvent.keyDown(popupEl, { key: 'Enter' });
+
+      // then
+      expect(onSelect).not.to.be.called;
+
+      const entryLabels = domQueryAll('.djs-popup-label', container);
+      expect([ ...entryLabels ].map(e => e.textContent)).to.eql([
+        'Create Issue',
+        'List Issues'
+      ]);
+    });
+
+
+    it('should trigger onSelect on click of leaf entry', async function() {
+
+      // given
+      const onSelect = spy();
+
+      await createPopupMenu({ container, entries: navigateEntries, onSelect });
+
+      const leafEntry = domQuery('.entry[data-id="leaf"]', container);
+
+      // when
+      fireEvent.click(leafEntry);
+
+      // then
+      expect(onSelect).to.have.been.calledOnce;
+    });
+
+
+    it('should render chevron on navigate entry', async function() {
+
+      // when
+      await createPopupMenu({ container, entries: navigateEntries });
+
+      // then
+      expect(domQuery('.entry[data-id="issues"] .djs-popup-entry-chevron', container)).to.exist;
+      expect(domQuery('.entry[data-id="leaf"] .djs-popup-entry-chevron', container)).not.to.exist;
+    });
+
+
+    it('should not allow to drag navigate entries', async function() {
+
+      // given
+      const onSelect = spy();
+
+      await createPopupMenu({ container, entries: navigateEntries, onSelect });
+
+      const navigateEntry = domQuery('.entry[data-id="issues"]', container);
+
+      // when
+      fireEvent.dragStart(navigateEntry);
+
+      // then
+      expect(onSelect).not.to.have.been.called;
+      expect(navigateEntry.getAttribute('draggable')).to.eql('false');
+    });
+
+
+    it('should select first entry of new level after push', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: navigateEntries });
+
+      const navigateEntry = domQuery('.entry[data-id="issues"]', container);
+
+      // when
+      fireEvent.click(navigateEntry);
+
+      // then
+      expect(domQuery('.selected .djs-popup-label', container).textContent).to.eql('Create Issue');
+    });
+
+
+    it('should pop level on back button click', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: navigateEntries });
+
+      fireEvent.click(domQuery('.entry[data-id="issues"]', container));
+
+      // when
+      fireEvent.click(domQuery('.djs-popup-breadcrumbs-item--back', container));
+
+      // then
+      const entryLabels = domQueryAll('.djs-popup-label', container);
+      expect([ ...entryLabels ].map(e => e.textContent)).to.eql([ 'Issues', 'Leaf' ]);
+    });
+
+
+    it('should pop all the way to root on back button click', async function() {
+
+      // given
+      const threeLevelEntries = [
+        {
+          id: 'connector',
+          label: 'GitHub Connector',
+          entries: [
+            {
+              id: 'issues',
+              label: 'Issues',
+              entries: [
+                { id: 'create-issue', label: 'Create Issue', action: () => {} }
+              ]
+            }
+          ]
+        }
+      ];
+
+      await createPopupMenu({ container, entries: threeLevelEntries });
+
+      fireEvent.click(domQuery('.entry[data-id="connector"]', container));
+      fireEvent.click(domQuery('.entry[data-id="issues"]', container));
+
+      // when
+      fireEvent.click(domQuery('.djs-popup-breadcrumbs-item--back', container));
+
+      // then
+      const entryLabels = domQueryAll('.djs-popup-label', container);
+      expect([ ...entryLabels ].map(e => e.textContent)).to.eql([ 'GitHub Connector' ]);
+    });
+
+
+    it('should display breadcrumbs when nested even without title or header entries', async function() {
+
+      // given
+      const noTitleEntries = [
+        {
+          id: 'group',
+          label: 'Group',
+          entries: [
+            { id: 'leaf', label: 'Leaf', action: () => {} }
+          ]
+        }
+      ];
+
+      await createPopupMenu({ container, entries: noTitleEntries });
+
+      // when
+      fireEvent.click(domQuery('.entry[data-id="group"]', container));
+
+      // then
+      expect(domQuery('.djs-popup-breadcrumbs', container)).to.exist;
+      expect(domQuery('.djs-popup-breadcrumbs-item--back', container)).to.exist;
+    });
+
+
+    it('should hide header when nested', async function() {
+
+      // given
+      const noTitleEntries = [
+        {
+          id: 'group',
+          label: 'Group',
+          entries: [
+            { id: 'leaf', label: 'Leaf', action: () => {} }
+          ]
+        }
+      ];
+
+      await createPopupMenu({ container, entries: noTitleEntries, title: 'Root' });
+
+      // when
+      fireEvent.click(domQuery('.entry[data-id="group"]', container));
+
+      // then
+      expect(domQuery('.djs-popup-header', container)).not.to.exist;
+    });
+
+
+    it('should reset to root when entries prop identity changes (refresh)', async function() {
+
+      // given
+      const nestedEntries = [
+        {
+          id: 'group',
+          label: 'Group',
+          entries: [
+            { id: 'leaf', label: 'Leaf', action: () => {} }
+          ]
+        }
+      ];
+
+      await createPopupMenu({ container, entries: nestedEntries });
+
+      fireEvent.click(domQuery('.entry[data-id="group"]', container));
+
+      // assume
+      expect(domQuery('.djs-popup-breadcrumbs', container)).to.exist;
+
+      // when
+      const refreshedEntries = [
+        {
+          id: 'group',
+          label: 'Group',
+          entries: [
+            { id: 'leaf', label: 'Leaf', action: () => {} }
+          ]
+        }
+      ];
+
+      await createPopupMenu({ container, entries: refreshedEntries });
+
+      // then
+      expect(domQuery('.djs-popup-breadcrumbs', container)).not.to.exist;
+      const entryLabels = domQueryAll('.djs-popup-label', container);
+      expect([ ...entryLabels ].map(e => e.textContent)).to.eql([ 'Group' ]);
+    });
+
+
+    describe('cross-level search', function() {
+
+      const searchableEntries = [
+        {
+          id: 'github',
+          label: 'GitHub Connector',
+          entries: [
+            { id: 'list-issues', label: 'List Issues', search: [ 'list issues' ], action: () => {} },
+            { id: 'list-branches', label: 'List Branches', search: [ 'list branches' ], action: () => {} },
+            { id: 'create-issue', label: 'Create Issue', action: () => {} }
+          ]
+        },
+        {
+          id: 'email',
+          label: 'Email Connector',
+          entries: [
+            { id: 'list-emails', label: 'List Emails', search: [ 'list emails' ], action: () => {} },
+            { id: 'send-email', label: 'Send Email', action: () => {} }
+          ]
+        },
+        {
+          id: 'rest',
+          label: 'REST',
+          action: () => {}
+        }
+      ];
+
+
+      it('should return leaves from any level when searching', async function() {
+
+        // given
+        await createPopupMenu({ container, entries: searchableEntries, search: true });
+
+        const input = domQuery('.djs-popup-search input', container);
+        input.value = 'list';
+
+        // when
+        fireEvent.keyUp(input, { key: 'l' });
+
+        // then
+        const labels = [ ...domQueryAll('.djs-popup-label', container) ].map(e => e.textContent);
+        expect(labels).to.include.members([ 'List Issues', 'List Branches', 'List Emails' ]);
+      });
+
+
+      it('should exclude navigate (group) entries from search results', async function() {
+
+        // given
+        await createPopupMenu({ container, entries: searchableEntries, search: true });
+
+        const input = domQuery('.djs-popup-search input', container);
+        input.value = 'connector';
+
+        // when
+        fireEvent.keyUp(input, { key: 'r' });
+
+        // then
+        const labels = [ ...domQueryAll('.djs-popup-label', container) ].map(e => e.textContent);
+        expect(labels).not.to.include('GitHub Connector');
+        expect(labels).not.to.include('Email Connector');
+      });
+
+
+      it('should hide back button while searching', async function() {
+
+        // given
+        await createPopupMenu({ container, entries: searchableEntries, search: true });
+
+        fireEvent.click(domQuery('.entry[data-id="github"]', container));
+
+        const input = domQuery('.djs-popup-search input', container);
+        input.value = 'list';
+
+        // when
+        fireEvent.keyUp(input, { key: 'l' });
+
+        // then
+        expect(domQuery('.djs-popup-breadcrumbs-item--back', container)).not.to.exist;
+      });
+
+
+      it('should render result count caption while searching', async function() {
+
+        // given
+        await createPopupMenu({ container, entries: searchableEntries, search: true });
+
+        const input = domQuery('.djs-popup-search input', container);
+        input.value = 'list';
+
+        // when
+        fireEvent.keyUp(input, { key: 'l' });
+
+        // then
+        const caption = domQuery('.djs-popup-search-count', container);
+        expect(caption).to.exist;
+        expect(caption.textContent.trim()).to.eql('3 results found');
+      });
+
+
+      it('should not render result count when search is empty', async function() {
+
+        // when
+        await createPopupMenu({ container, entries: searchableEntries, search: true });
+
+        // then
+        expect(domQuery('.djs-popup-search-count', container)).not.to.exist;
+      });
+
+
+      it('should use singular form for one result', async function() {
+
+        // given
+        await createPopupMenu({ container, entries: searchableEntries, search: true });
+
+        const input = domQuery('.djs-popup-search input', container);
+        input.value = 'send';
+
+        // when
+        fireEvent.keyUp(input, { key: 'd' });
+
+        // then
+        expect(domQuery('.djs-popup-search-count', container).textContent.trim()).to.eql('1 result found');
+      });
+
+
+      it('should render plain leaf labels while searching', async function() {
+
+        // given
+        await createPopupMenu({ container, entries: searchableEntries, search: true });
+
+        const input = domQuery('.djs-popup-search input', container);
+        input.value = 'list issues';
+
+        // when
+        fireEvent.keyUp(input, { key: 's' });
+
+        // then
+        const labels = [ ...domQueryAll('.djs-popup-label', container) ].map(e => e.textContent);
+        expect(labels).to.include('List Issues');
+      });
+
+      it('should restore level view after clearing search', async function() {
+
+        // given
+        await createPopupMenu({ container, entries: searchableEntries, search: true });
+
+        fireEvent.click(domQuery('.entry[data-id="github"]', container));
+
+        const input = domQuery('.djs-popup-search input', container);
+        input.value = 'list';
+        fireEvent.keyUp(input, { key: 'l' });
+
+        // when
+        input.value = '';
+        fireEvent.keyUp(input, { key: 'Backspace' });
+
+        // then
+        expect(domQuery('.djs-popup-breadcrumbs-item--back', container)).to.exist;
+        const labels = [ ...domQueryAll('.djs-popup-label', container) ].map(e => e.textContent);
+        expect(labels).to.have.members([ 'List Issues', 'List Branches', 'Create Issue' ]);
+      });
+
+    });
+
   });
 
 

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -1005,12 +1005,147 @@ describe('features/popup-menu - <PopupMenu>', function() {
 
       await createPopupMenu({ container, entries: nestedEntries });
 
-      fireEvent.click(domQuery('.entry[data-id="2"]', container));
+      const entryEl = domQuery('.entry[data-id="2"]', container);
+
+      fireEvent.mouseEnter(entryEl);
+      fireEvent.click(entryEl);
 
       const popupEl = domQuery('.djs-popup', container);
 
       // when
       fireEvent.keyDown(popupEl, { key: 'Backspace' });
+
+      // then
+      expect(domQuery('.selected .djs-popup-label', container).textContent).to.eql('B');
+    });
+
+
+    it('should push level with <ArrowRight> over navigate entry', async function() {
+
+      // given
+      const nestedEntries = [
+        {
+          id: '1',
+          label: 'A',
+          entries: [
+            { id: '1-1', label: 'A-A', action: () => {} },
+            { id: '1-2', label: 'A-B', action: () => {} }
+          ]
+        },
+        {
+          id: '2',
+          label: 'B',
+          action: () => {}
+        }
+      ];
+
+      await createPopupMenu({ container, entries: nestedEntries });
+
+      const popupEl = domQuery('.djs-popup', container);
+
+      // when
+      fireEvent.keyDown(popupEl, { key: 'ArrowRight' });
+
+      // then
+      const entryLabels = domQueryAll('.djs-popup-label', container);
+      expect([ ...entryLabels ].map(e => e.textContent)).to.eql([ 'A-A', 'A-B' ]);
+    });
+
+
+    it('should not push level with <ArrowRight> over leaf entry', async function() {
+
+      // given
+      const nestedEntries = [
+        {
+          id: '1',
+          label: 'A',
+          action: () => {}
+        },
+        {
+          id: '2',
+          label: 'B',
+          entries: [
+            { id: '2-1', label: 'B-A', action: () => {} }
+          ]
+        }
+      ];
+
+      await createPopupMenu({ container, entries: nestedEntries });
+
+      const popupEl = domQuery('.djs-popup', container);
+
+      // when
+      fireEvent.keyDown(popupEl, { key: 'ArrowRight' });
+
+      // then
+      const entryLabels = domQueryAll('.djs-popup-label', container);
+      expect([ ...entryLabels ].map(e => e.textContent)).to.eql([ 'A', 'B' ]);
+    });
+
+
+    it('should pop one level with <ArrowLeft>', async function() {
+
+      // given
+      const nestedEntries = [
+        {
+          id: '1',
+          label: 'A',
+          entries: [
+            { id: '1-1', label: 'A-A', action: () => {} },
+            { id: '1-2', label: 'A-B', action: () => {} }
+          ]
+        },
+        {
+          id: '2',
+          label: 'B',
+          action: () => {}
+        }
+      ];
+
+      await createPopupMenu({ container, entries: nestedEntries });
+
+      fireEvent.click(domQuery('.entry[data-id="1"]', container));
+
+      const popupEl = domQuery('.djs-popup', container);
+
+      // when
+      fireEvent.keyDown(popupEl, { key: 'ArrowLeft' });
+
+      // then
+      const entryLabels = domQueryAll('.djs-popup-label', container);
+      expect([ ...entryLabels ].map(e => e.textContent)).to.eql([ 'A', 'B' ]);
+    });
+
+
+    it('should restore selection to popped entry after <ArrowLeft>', async function() {
+
+      // given
+      const nestedEntries = [
+        {
+          id: '1',
+          label: 'A',
+          action: () => {}
+        },
+        {
+          id: '2',
+          label: 'B',
+          entries: [
+            { id: '2-1', label: 'B-A', action: () => {} }
+          ]
+        }
+      ];
+
+      await createPopupMenu({ container, entries: nestedEntries });
+
+      const entryEl = domQuery('.entry[data-id="2"]', container);
+
+      fireEvent.mouseEnter(entryEl);
+      fireEvent.click(entryEl);
+
+      const popupEl = domQuery('.djs-popup', container);
+
+      // when
+      fireEvent.keyDown(popupEl, { key: 'ArrowLeft' });
 
       // then
       expect(domQuery('.selected .djs-popup-label', container).textContent).to.eql('B');

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -341,6 +341,75 @@ describe('features/popup-menu', function() {
     }));
 
 
+    it('should render nested navigate entries from provider', inject(async function(popupMenu, eventBus) {
+
+      // given
+      const openedSpy = spy();
+      eventBus.on('popupMenu.opened', openedSpy);
+
+      popupMenu.registerProvider('navigate-menu', {
+        getPopupMenuEntries: function() {
+          return {
+            github: {
+              label: 'GitHub Connector',
+              entries: {
+                'create-issue': { label: 'Create Issue', action: function() {} },
+                'list-issues': { label: 'List Issues', action: function() {} }
+              }
+            }
+          };
+        }
+      });
+
+      // when
+      popupMenu.open({}, 'navigate-menu', { x: 100, y: 100 });
+
+      // then
+      await waitFor(() => expect(openedSpy).to.have.been.calledOnce);
+      expect(queryEntry('github')).to.exist;
+    }));
+
+
+    it('should navigate into nested entries on click', inject(async function(popupMenu, eventBus) {
+
+      // given
+      const openedSpy = spy();
+      eventBus.on('popupMenu.opened', openedSpy);
+
+      popupMenu.registerProvider('navigate-menu', {
+        getPopupMenuEntries: function() {
+          return {
+            github: {
+              label: 'GitHub Connector',
+              entries: {
+                'create-issue': { label: 'Create Issue', action: function() {} },
+                'list-issues': { label: 'List Issues', action: function() {} }
+              }
+            }
+          };
+        }
+      });
+
+      popupMenu.open({}, 'navigate-menu', { x: 100, y: 100 });
+
+      await waitFor(() => expect(openedSpy).to.have.been.calledOnce);
+
+      // when
+      await act(() => {
+        queryEntry('github').dispatchEvent(new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          clientX: 0,
+          clientY: 0
+        }));
+      });
+
+      // then
+      const labels = await queryEntryLabels();
+      expect(labels).to.eql([ 'Create Issue', 'List Issues' ]);
+    }));
+
+
     it('should add action-id to entry', inject(function(popupMenu) {
 
       // when


### PR DESCRIPTION
Related to https://github.com/bpmn-io/internal-docs/issues/1315

### Proposed Changes

Introduce multi-step navigation in the popup menu, allowing providers to expose nested entry groups that users can drill into and back out of, with a search that works across all levels.

#### Highlights:

* Nested entries — providers can declare entries with `entries` inside (instead of an `action`) to create a navigable sub-level.
* Breadcrumbs — new `PopupMenuBreadcrumbs` component shows the current navigation path with a back button and clickable parent crumbs.
* Keyboard navigation — `<Enter>` on a group enters it; `<Backspace>` pops one level and restores the previously selected entry.
* Cross-level search — typing in the search field surfaces leaf entries from any level; group entries are excluded from results.
* Recursive entry normalization — `PopupMenu#_render` now also flattens nested step entries into arrays, extending the existing top-level conversion to the full tree.
* Type housekeeping — aligned `PopupMenuEntry` with its actual usage: added previously-untyped properties (`description`, `documentationRef`, `rank`, `search`, `searchable`) and made `className` optional.

### Steps to try out

```sh
npx @bpmn-io/sr -l bpmn-io/diagram-js#native-ops bpmn-io/element-template-chooser#native-ops
```

#### Entries with steps

<img width="380" alt="image" src="https://github.com/user-attachments/assets/1f0cd4fa-fd69-4c61-920d-6a137b78a17a" />

#### Navigation

<img width="380" alt="popup-nav-new" src="https://github.com/user-attachments/assets/85e5eba4-6cd5-4fcd-bf95-0326ce7f867e" />

#### Search

<img width="380" alt="pr-search" src="https://github.com/user-attachments/assets/3583ea3b-b558-4d44-9e87-a829a4e912d8" />

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
