### PR TITLE
chore: improve popup menu styling

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -789,19 +789,6 @@
   margin: 1px;
 }
 
-.djs-popup-title,
-.djs-popup-label,
-.djs-popup-entry-description,
-.djs-popup .entry-header {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.djs-popup-entry-name {
-  display: flex;
-}
-
 .djs-popup-body {
   flex-direction: column;
   width: auto;
@@ -830,7 +817,6 @@
 
 .djs-popup-entry-docs {
   display: none;
-  align-items: center;
   margin-left: 3px;
   color: var(--popup-description-color);
 }
@@ -838,11 +824,12 @@
 .djs-popup-body .entry:focus-within .djs-popup-entry-docs,
 .djs-popup-body .entry:focus .djs-popup-entry-docs,
 .djs-popup-body .entry:hover .djs-popup-entry-docs {
-  display: flex;
+  display: inline;
 }
 
 .djs-popup-entry-docs svg {
-  margin: auto 2px auto 2px;
+  vertical-align: middle;
+  margin: 2px;
 }
 
 /**

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -829,11 +829,10 @@
 }
 
 .djs-popup-entry-docs {
-  flex: 0;
-  flex-direction: row;
-  align-items: center;
-  padding-left: 5px;
   display: none;
+  align-items: center;
+  margin-left: 3px;
+  color: var(--popup-description-color);
 }
 
 .djs-popup-body .entry:hover .djs-popup-entry-docs {
@@ -841,8 +840,7 @@
 }
 
 .djs-popup-entry-docs svg {
-  vertical-align: middle;
-  margin: auto 2px auto 5px;
+  margin: auto 2px auto 2px;
 }
 
 /**

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -64,7 +64,7 @@
   --popup-border-color: transparent;
   --popup-shadow-color: var(--color-black-opacity-30);
   --popup-disabled-color: var(--color-grey-225-10-35);
-  --popup-description-color: var(--color-grey-225-10-55);
+  --popup-description-color: var(--color-grey-225-10-35);
   --popup-no-results-color: var(--color-grey-225-10-55);
   --popup-entry-title-color: var(--color-grey-225-10-55);
   --popup-entry-hover-color:  var(--color-grey-225-10-95);
@@ -770,10 +770,12 @@
   display: flex;
   flex-direction: column;
   flex: 1;
-  overflow: hidden;
 }
 
 .djs-popup-entry-description {
+  font-size: .9em;
+  margin-top: .25em;
+
   color: var(--popup-description-color);
 }
 

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -835,6 +835,8 @@
   color: var(--popup-description-color);
 }
 
+.djs-popup-body .entry:focus-within .djs-popup-entry-docs,
+.djs-popup-body .entry:focus .djs-popup-entry-docs,
 .djs-popup-body .entry:hover .djs-popup-entry-docs {
   display: flex;
 }

--- a/lib/features/popup-menu/PopupMenuItem.js
+++ b/lib/features/popup-menu/PopupMenuItem.js
@@ -68,7 +68,7 @@ export default function PopupMenuItem(props) {
 
           ${ entry.documentationRef && html`
             <a class="djs-popup-entry-docs"
-              href="${ entry.documentationRef }"
+              href=${ entry.documentationRef }
               onClick=${ (event) => event.stopPropagation() }
               title="Open element documentation"
               aria-label="Open element documentation"

--- a/lib/features/popup-menu/PopupMenuItem.js
+++ b/lib/features/popup-menu/PopupMenuItem.js
@@ -42,7 +42,7 @@ export default function PopupMenuItem(props) {
     <li
       class=${ classNames('entry', { selected, disabled: entry.disabled }) }
       data-id=${ entry.id }
-      title=${ entry.title || entry.label }
+      title=${ entry.title }
       aria-disabled=${ entry.disabled || undefined }
       tabIndex="0"
       onClick=${ handleClick }
@@ -84,7 +84,6 @@ export default function PopupMenuItem(props) {
         ${ entry.description && html`
           <span
             class="djs-popup-entry-description"
-            title=${ entry.description }
           >
             ${ entry.description }
           </span>

--- a/lib/features/popup-menu/PopupMenuItem.js
+++ b/lib/features/popup-menu/PopupMenuItem.js
@@ -65,6 +65,20 @@ export default function PopupMenuItem(props) {
               ${ entry.label }
             </span>
           ` : null }
+
+          ${ entry.documentationRef && html`
+            <a class="djs-popup-entry-docs"
+              href="${ entry.documentationRef }"
+              onClick=${ (event) => event.stopPropagation() }
+              title="Open element documentation"
+              target="_blank"
+              rel="noopener"
+            >
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path fill-rule="evenodd" clip-rule="evenodd" d="M10.6368 10.6375V5.91761H11.9995V10.6382C11.9995 10.9973 11.8623 11.3141 11.5878 11.5885C11.3134 11.863 10.9966 12.0002 10.6375 12.0002H1.36266C0.982345 12.0002 0.660159 11.8681 0.396102 11.6041C0.132044 11.34 1.52588e-05 11.0178 1.52588e-05 10.6375V1.36267C1.52588e-05 0.98236 0.132044 0.660173 0.396102 0.396116C0.660159 0.132058 0.982345 2.95639e-05 1.36266 2.95639e-05H5.91624V1.36267H1.36266V10.6375H10.6368ZM12 0H7.2794L7.27873 1.36197H9.68701L3.06507 7.98391L4.01541 8.93425L10.6373 2.31231V4.72059H12V0Z" fill="#818798"/>
+              </svg>
+            </a>
+          ` }
         </span>
         ${ entry.description && html`
           <span
@@ -75,21 +89,6 @@ export default function PopupMenuItem(props) {
           </span>
         ` }
       </div>
-      ${ entry.documentationRef && html`
-        <div class="djs-popup-entry-docs">
-          <a
-            href="${ entry.documentationRef }"
-            onClick=${ (event) => event.stopPropagation() }
-            title="Open element documentation"
-            target="_blank"
-            rel="noopener"
-          >
-            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path fill-rule="evenodd" clip-rule="evenodd" d="M10.6368 10.6375V5.91761H11.9995V10.6382C11.9995 10.9973 11.8623 11.3141 11.5878 11.5885C11.3134 11.863 10.9966 12.0002 10.6375 12.0002H1.36266C0.982345 12.0002 0.660159 11.8681 0.396102 11.6041C0.132044 11.34 1.52588e-05 11.0178 1.52588e-05 10.6375V1.36267C1.52588e-05 0.98236 0.132044 0.660173 0.396102 0.396116C0.660159 0.132058 0.982345 2.95639e-05 1.36266 2.95639e-05H5.91624V1.36267H1.36266V10.6375H10.6368ZM12 0H7.2794L7.27873 1.36197H9.68701L3.06507 7.98391L4.01541 8.93425L10.6373 2.31231V4.72059H12V0Z" fill="#818798"/>
-            </svg>
-          </a>
-        </div>
-      ` }
       ${ entry.entries && html`
         <div class="djs-popup-entry-chevron" aria-hidden="true">
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/lib/features/popup-menu/PopupMenuItem.js
+++ b/lib/features/popup-menu/PopupMenuItem.js
@@ -71,10 +71,11 @@ export default function PopupMenuItem(props) {
               href="${ entry.documentationRef }"
               onClick=${ (event) => event.stopPropagation() }
               title="Open element documentation"
+              aria-label="Open element documentation"
               target="_blank"
               rel="noopener"
             >
-              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <svg aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M10.6368 10.6375V5.91761H11.9995V10.6382C11.9995 10.9973 11.8623 11.3141 11.5878 11.5885C11.3134 11.863 10.9966 12.0002 10.6375 12.0002H1.36266C0.982345 12.0002 0.660159 11.8681 0.396102 11.6041C0.132044 11.34 1.52588e-05 11.0178 1.52588e-05 10.6375V1.36267C1.52588e-05 0.98236 0.132044 0.660173 0.396102 0.396116C0.660159 0.132058 0.982345 2.95639e-05 1.36266 2.95639e-05H5.91624V1.36267H1.36266V10.6375H10.6368ZM12 0H7.2794L7.27873 1.36197H9.68701L3.06507 7.98391L4.01541 8.93425L10.6373 2.31231V4.72059H12V0Z" fill="#818798"/>
               </svg>
             </a>

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -361,14 +361,14 @@ describe('features/popup-menu - <PopupMenu>', function() {
       ] = domQueryAll('.entry', container);
 
       // then
-      expect(firstEntry.title).to.eql('1');
+      expect(firstEntry.title).to.be.empty;
       expect(firstEntry.textContent).to.eql('1');
 
       expect(secondEntry.title).to.eql('Toggle foo');
       expect(secondEntry.textContent).to.eql('');
       expect(secondEntry.innerHTML).to.include(`<img class="djs-popup-entry-icon" src="${ imageUrl }" alt="">`);
 
-      expect(describedEntry.title).to.eql('FOO');
+      expect(describedEntry.title).to.be.empty;
       expect(describedEntry.textContent).to.eql('FOOI DESCRIBE IT');
     });
 

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -1453,7 +1453,7 @@ describe('features/popup-menu', function() {
       popupMenu.open({}, 'test-menu', { x: 100, y: 100 });
 
       // then
-      var link = queryPopup('.djs-popup-entry-docs a');
+      var link = queryPopup('a.djs-popup-entry-docs');
 
       expect(link).to.exist;
 


### PR DESCRIPTION
### Proposed Changes

On top of #1040 this adds a couple of small UI adjustments - with the intend to make the UI more readable and less cluttered - documentation appears on hover only, and is a `?` instead of a random "external" link.

#### Before

<img width="737" height="693" alt="screenshot HFaVQ2" src="https://github.com/user-attachments/assets/e071d88b-3d10-4cc6-bc08-f54fac997ca1" />

#### After

<img width="775" height="718" alt="capture NgHcYV_optimized" src="https://github.com/user-attachments/assets/1df27d44-6fca-465c-abe9-946a644d2eb2" />

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
