### PR TITLE
Correct popup menu closing on inside click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+## 15.15.1
+
+* `FIX`: correct popup menu closing on inside clicks ([#1045](https://github.com/bpmn-io/diagram-js/pull/1045))
+* `DEPS`: update to `@bpmn-io/diagram-js-ui@0.2.4` ([#1045](https://github.com/bpmn-io/diagram-js/pull/1045))
+
 ## 15.15.0
 
 * `FEAT`: introduce multi-step navigation to popup menu ([#1040](https://github.com/bpmn-io/diagram-js/pull/1040))

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -368,11 +368,14 @@ function PopupMenuWrapper(props) {
     };
 
     document.documentElement.addEventListener('keydown', handleKeyDown);
-    document.body.addEventListener('click', handleClick);
+
+    // use capture phase so containment is evaluated before an entry
+    // or the popup menu is potentially unmounted
+    document.body.addEventListener('click', handleClick, true);
 
     return () => {
       document.documentElement.removeEventListener('keydown', handleKeyDown);
-      document.body.removeEventListener('click', handleClick);
+      document.body.removeEventListener('click', handleClick, true);
     };
   }, []);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "15.15.0",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/diagram-js-ui": "^0.2.3",
+        "@bpmn-io/diagram-js-ui": "^0.2.4",
         "clsx": "^2.1.1",
         "didi": "^11.0.0",
         "inherits-browser": "^0.1.0",
@@ -351,12 +351,13 @@
       }
     },
     "node_modules/@bpmn-io/diagram-js-ui": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
-      "integrity": "sha512-OGyjZKvGK8tHSZ0l7RfeKhilGoOGtFDcoqSGYkX0uhFlo99OVZ9Jn1K7TJGzcE9BdKwvA5Y5kGqHEhdTxHvFfw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.4.tgz",
+      "integrity": "sha512-I678ZGtoH7z7FgzFhzzppM9ThsJ3Lh83kW3GjhjG3xyYciIPYHMaHK1MABP8F69H9pFZpViM6t4qUo8dwrVz0w==",
+      "license": "MIT",
       "dependencies": {
         "htm": "^3.1.1",
-        "preact": "^10.11.2"
+        "preact": "^10.29.2"
       }
     },
     "node_modules/@colors/colors": {
@@ -6712,9 +6713,10 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.11.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.2.tgz",
-      "integrity": "sha512-skAwGDFmgxhq1DCBHke/9e12ewkhc7WYwjuhHB8HHS8zkdtITXLRmUMTeol2ldxvLwYtwbFeifZ9uDDWuyL4Iw==",
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "webpack": "^5.104.1"
   },
   "dependencies": {
-    "@bpmn-io/diagram-js-ui": "^0.2.3",
+    "@bpmn-io/diagram-js-ui": "^0.2.4",
     "clsx": "^2.1.1",
     "didi": "^11.0.0",
     "inherits-browser": "^0.1.0",

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -278,14 +278,14 @@ describe('features/popup-menu', function() {
       eventBus.on('popupMenu.opened', openedSpy);
 
       // when
-      popupMenu.open({}, 'menu', { x: 100, y: 100 });
+      await act(() => {
+        popupMenu.open({}, 'menu', { x: 100, y: 100 });
+      });
 
       // then
       expect(popupMenu._current).to.exist;
+
       expect(openSpy).to.have.been.calledOnce;
-
-      await waitFor(() => expect(openedSpy).to.have.been.calledOnce);
-
       expect(openedSpy).to.have.been.calledOnce;
     }));
 
@@ -344,9 +344,6 @@ describe('features/popup-menu', function() {
     it('should render nested navigate entries from provider', inject(async function(popupMenu, eventBus) {
 
       // given
-      const openedSpy = spy();
-      eventBus.on('popupMenu.opened', openedSpy);
-
       popupMenu.registerProvider('navigate-menu', {
         getPopupMenuEntries: function() {
           return {
@@ -362,10 +359,11 @@ describe('features/popup-menu', function() {
       });
 
       // when
-      popupMenu.open({}, 'navigate-menu', { x: 100, y: 100 });
+      await act(() => {
+        popupMenu.open({}, 'navigate-menu', { x: 100, y: 100 });
+      });
 
       // then
-      await waitFor(() => expect(openedSpy).to.have.been.calledOnce);
       expect(queryEntry('github')).to.exist;
     }));
 
@@ -373,9 +371,6 @@ describe('features/popup-menu', function() {
     it('should navigate into nested entries on click', inject(async function(popupMenu, eventBus) {
 
       // given
-      const openedSpy = spy();
-      eventBus.on('popupMenu.opened', openedSpy);
-
       popupMenu.registerProvider('navigate-menu', {
         getPopupMenuEntries: function() {
           return {
@@ -390,9 +385,9 @@ describe('features/popup-menu', function() {
         }
       });
 
-      popupMenu.open({}, 'navigate-menu', { x: 100, y: 100 });
-
-      await waitFor(() => expect(openedSpy).to.have.been.calledOnce);
+      await act(() => {
+        popupMenu.open({}, 'navigate-menu', { x: 100, y: 100 });
+      });
 
       // when
       await act(() => {
@@ -734,15 +729,20 @@ describe('features/popup-menu', function() {
   describe('#close', function() {
 
     beforeEach(inject(async function(eventBus, popupMenu) {
+
+      // given
       var openedSpy = spy();
 
       eventBus.on('popupMenu.opened', openedSpy);
 
       popupMenu.registerProvider('menu', menuProvider);
 
-      popupMenu.open({}, 'menu', { x: 100, y: 100 });
+      await act(() => {
+        popupMenu.open({}, 'menu', { x: 100, y: 100 });
+      });
 
-      await waitFor(() => expect(openedSpy).to.have.been.calledOnce);
+      // assume
+      expect(openedSpy).to.have.been.calledOnce;
     }));
 
 
@@ -756,9 +756,11 @@ describe('features/popup-menu', function() {
       eventBus.on('popupMenu.closed', closedSpy);
 
       // when
-      popupMenu.close();
+      await act(() => {
+        popupMenu.close();
+      });
 
-      await waitFor(() => expect(closedSpy).to.have.been.calledOnce);
+      expect(closedSpy).to.have.been.calledOnce;
 
       // then
       var open = popupMenu.isOpen();
@@ -2582,9 +2584,12 @@ describe('features/popup-menu', function() {
         }
       });
 
-      popupMenu.open({}, 'test-menu', { x: 100, y: 100 });
+      await act(() => {
+        popupMenu.open({}, 'test-menu', { x: 100, y: 100 });
+      });
 
-      await waitFor(() => expect(openedSpy).to.have.been.calledOnce);
+      // assume
+      expect(openedSpy).to.have.been.calledOnce;
 
       // when
       // clicking outside the popup menu
@@ -2621,9 +2626,12 @@ describe('features/popup-menu', function() {
         }
       });
 
-      popupMenu.open({}, 'navigate-menu', { x: 100, y: 100 });
+      await act(() => {
+        popupMenu.open({}, 'navigate-menu', { x: 100, y: 100 });
+      });
 
-      await waitFor(() => expect(openedSpy).to.have.been.calledOnce);
+      // assume
+      expect(openedSpy).to.have.been.calledOnce;
 
       // navigate into nested entry
       withSyncRendering(() => {
@@ -2676,9 +2684,12 @@ describe('features/popup-menu', function() {
         }
       });
 
-      popupMenu.open({}, 'navigate-menu', { x: 100, y: 100 });
+      await act(() => {
+        popupMenu.open({}, 'navigate-menu', { x: 100, y: 100 });
+      });
 
-      await waitFor(() => expect(openedSpy).to.have.been.calledOnce);
+      // assume
+      expect(openedSpy).to.have.been.calledOnce;
 
       // when
       // navigating into entry

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -41,7 +41,7 @@ import { createEvent as globalEvent } from '../../../util/MockEvents.js';
 import popupMenuModule from 'lib/features/popup-menu';
 import modelingModule from 'lib/features/modeling';
 
-import { html } from 'lib/ui';
+import { html, options } from 'lib/ui';
 
 const entrySet = (entries) => {
 
@@ -2562,6 +2562,143 @@ describe('features/popup-menu', function() {
 
   });
 
+
+  describe('modal behavior', function() {
+
+    it('should close when clicking outside of popup menu', inject(async function(popupMenu, eventBus) {
+
+      // given
+      const openedSpy = spy();
+      const closeSpy = spy();
+
+      eventBus.on('popupMenu.opened', openedSpy);
+      eventBus.on('popupMenu.close', closeSpy);
+
+      popupMenu.registerProvider('test-menu', {
+        getPopupMenuEntries: function() {
+          return {
+            foo: { label: 'Foo', action: function() {} }
+          };
+        }
+      });
+
+      popupMenu.open({}, 'test-menu', { x: 100, y: 100 });
+
+      await waitFor(() => expect(openedSpy).to.have.been.calledOnce);
+
+      // when
+      // clicking outside the popup menu
+      document.body.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true
+      }));
+
+      // then
+      expect(closeSpy).to.have.been.calledOnce;
+      expect(popupMenu.isOpen()).to.be.false;
+    }));
+
+
+    it('should NOT CLOSE when navigating backwards', inject(async function(popupMenu, eventBus) {
+
+      // given
+      const openedSpy = spy();
+      const closeSpy = spy();
+
+      eventBus.on('popupMenu.opened', openedSpy);
+      eventBus.on('popupMenu.close', closeSpy);
+
+      popupMenu.registerProvider('navigate-menu', {
+        getPopupMenuEntries: function() {
+          return {
+            github: {
+              label: 'GitHub Connector',
+              entries: {
+                'create-issue': { label: 'Create Issue', action: function() {} }
+              }
+            }
+          };
+        }
+      });
+
+      popupMenu.open({}, 'navigate-menu', { x: 100, y: 100 });
+
+      await waitFor(() => expect(openedSpy).to.have.been.calledOnce);
+
+      // navigate into nested entry
+      withSyncRendering(() => {
+        queryEntry('github').dispatchEvent(new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true
+        }));
+      });
+
+      await expectEntries([ 'Create Issue' ]);
+
+      // when
+      // navigating back detaches the clicked (back) node before the click
+      // reaches the document body (see #withSyncRendering)
+      withSyncRendering(() => {
+        queryPopup('.djs-popup-breadcrumbs-item--back').dispatchEvent(new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true
+        }));
+      });
+
+      // then
+      // we navigated back to the root entries
+      await expectEntries([ 'GitHub Connector' ]);
+
+      // popup menu is still open
+      expect(closeSpy).not.to.have.been.called;
+    }));
+
+
+    it('should NOT CLOSE when navigating into nested entries', inject(async function(popupMenu, eventBus) {
+
+      // given
+      const openedSpy = spy();
+      const closeSpy = spy();
+
+      eventBus.on('popupMenu.opened', openedSpy);
+      eventBus.on('popupMenu.close', closeSpy);
+
+      popupMenu.registerProvider('navigate-menu', {
+        getPopupMenuEntries: function() {
+          return {
+            github: {
+              label: 'GitHub Connector',
+              entries: {
+                'create-issue': { label: 'Create Issue', action: function() {} }
+              }
+            }
+          };
+        }
+      });
+
+      popupMenu.open({}, 'navigate-menu', { x: 100, y: 100 });
+
+      await waitFor(() => expect(openedSpy).to.have.been.calledOnce);
+
+      // when
+      // navigating into entry
+      withSyncRendering(() => {
+        queryEntry('github').dispatchEvent(new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true
+        }));
+      });
+
+      // then
+      // nested entry is shown
+      await expectEntries([ 'Create Issue' ]);
+
+      // popup menu is still open
+      expect(closeSpy).not.to.have.been.called;
+    }));
+
+  });
+
 });
 
 
@@ -2662,6 +2799,27 @@ describe('features/popup-menu - integration', function() {
 
 
 // helpers /////////////
+
+/**
+ * Run `fn` while preact flushes re-renders synchronously.
+ *
+ * Emulates a real (user) click, where the micro-task scheduled re-render runs
+ * _between_ event listeners, i.e. before the event finishes propagating. A
+ * synthetic `dispatchEvent` cannot reproduce this on its own, as it keeps the
+ * call stack busy and thus defers the re-render past the whole event.
+ *
+ * @param {() => void} fn
+ */
+function withSyncRendering(fn) {
+  const previous = options.debounceRendering;
+  options.debounceRendering = cb => cb();
+
+  try {
+    fn();
+  } finally {
+    options.debounceRendering = previous;
+  }
+}
 
 function Provider(entries, headerEntries) {
   this.getPopupMenuEntries = isFunction(entries)


### PR DESCRIPTION
### Proposed Changes

This PR:

* Updates popup menu to track external clicks before potential unmounts / preact re-renders
* Updates `@bpmn-io/diagram-js-ui` to use latest `preact@10` version

Background - it turns out:

* our popup menu click outside detection was depending on a preact@10.11 quirk - would break with preact@10.22+
* our diagram-js-ui library operated on that ancient version, leaving it to chance whether the  click in nested entries and back button would work or not (https://github.com/bpmn-io/diagram-js/pull/1040)

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
