### PR TITLE
feat: apply selection color to selected connections

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -146,6 +146,11 @@
   display: none;
 }
 
+.djs-connection.selected .djs-visual path {
+    stroke: var(--element-selected-outline-stroke-color) !important;
+    fill: var(--element-selected-outline-stroke-color) !important;
+}
+
 .djs-multi-select .djs-element.selected .djs-outline,
 .djs-dragging-active-lasso .djs-element.selected .djs-outline {
   stroke: var(--element-selected-outline-secondary-stroke-color);


### PR DESCRIPTION
### Proposed Changes

Selected connections can be difficult to identify because connection outlines are hidden.

This is especially noticeable in the navigated viewer, where bendpoints are not available, resulting in little visual feedback for the currently selected connection.

This change applies the existing selection colour used for elements to selected connections, colouring both the connection path and arrowhead. This provides more consistent selection feedback across both the modeler and navigated viewer 

I'm opening this PR to gather feedback on this approach :)


https://github.com/user-attachments/assets/e0291996-3b64-4614-87b2-c507a47b935a



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

