### PR TITLE
feat(PopupMenu): use parents' entries keywords for search

### DIFF
--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -12,6 +12,7 @@ import {
 
 import {
   forEach,
+  isArray,
   isFunction,
   omit,
   isDefined
@@ -642,18 +643,39 @@ PopupMenu.prototype._getEntry = function(entryId) {
  * spliced in. Recurses into step entries so the whole tree uses the array
  * shape downstream.
  *
+ * Leaf entries inherit the `search` terms of their ancestors, so a leaf can be
+ * found by keywords declared on any of its parents.
+ *
  * @param {import('./PopupMenuProvider').PopupMenuEntries} entriesMap
+ * @param {string[]} [search]
  *
  * @return {import('./PopupMenuProvider').PopupMenuEntry[]}
  */
-function flattenEntries(entriesMap) {
+function flattenEntries(entriesMap, search = []) {
   return Object.entries(entriesMap).map(([ id, value ]) => {
     const entry = { id, ...value };
 
     if (entry.entries) {
-      entry.entries = flattenEntries(entry.entries);
+      entry.entries = flattenEntries(
+        entry.entries,
+        [ ...search, ...asArray(entry.search) ]
+      );
+    } else if (search.length) {
+      entry.search = [ ...search, ...asArray(entry.search) ];
     }
 
     return entry;
   });
+}
+
+/**
+ * @param {string | string[]} [value]
+ * @return {string[]}
+ */
+function asArray(value) {
+  if (!value) {
+    return [];
+  }
+
+  return isArray(value) ? value : [ value ];
 }

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -1787,6 +1787,144 @@ describe('features/popup-menu', function() {
     });
 
 
+    describe('keyword inheritance (nested entries)', function() {
+
+      function nestedProvider(github) {
+        return {
+          getPopupMenuEntries: function() {
+            return {
+              github,
+              'filler-1': { label: 'Filler 1', action: function() {} },
+              'filler-2': { label: 'Filler 2', action: function() {} },
+              'filler-3': { label: 'Filler 3', action: function() {} },
+              'filler-4': { label: 'Filler 4', action: function() {} },
+              'filler-5': { label: 'Filler 5', action: function() {} }
+            };
+          }
+        };
+      }
+
+
+      it('should find leaf by ancestor search keyword', inject(async function(popupMenu) {
+
+        // given
+        popupMenu.registerProvider('test-menu', nestedProvider({
+          label: 'GitHub Connector',
+          search: 'github',
+          entries: {
+            'create-issue': { label: 'Create Issue', action: function() {} }
+          }
+        }));
+
+        popupMenu.open({}, 'test-menu', { x: 100, y: 100 }, { search: true });
+
+        // when
+        await triggerSearch('github');
+
+        // then
+        await expectEntries([ 'Create Issue' ]);
+      }));
+
+
+      it('should match ancestor and leaf keywords combined', inject(async function(popupMenu) {
+
+        // given
+        popupMenu.registerProvider('test-menu', {
+          getPopupMenuEntries: function() {
+            return {
+              github: {
+                label: 'GitHub Connector',
+                search: 'github',
+                entries: {
+                  'create-issue': { label: 'Create Issue', search: 'ticket', action: function() {} },
+                  'list-issues': { label: 'List Issues', action: function() {} }
+                }
+              },
+              'filler-1': { label: 'Filler 1', action: function() {} },
+              'filler-2': { label: 'Filler 2', action: function() {} },
+              'filler-3': { label: 'Filler 3', action: function() {} },
+              'filler-4': { label: 'Filler 4', action: function() {} }
+            };
+          }
+        });
+
+        popupMenu.open({}, 'test-menu', { x: 100, y: 100 }, { search: true });
+
+        // when
+        await triggerSearch('github ticket');
+
+        // then
+        await expectEntries([ 'Create Issue' ]);
+      }));
+
+
+      it('should inherit keywords across multiple levels', inject(async function(popupMenu) {
+
+        // given
+        popupMenu.registerProvider('test-menu', nestedProvider({
+          label: 'GitHub Connector',
+          search: 'github',
+          entries: {
+            issues: {
+              label: 'Issues',
+              search: 'issue',
+              entries: {
+                'open-ticket': { label: 'Open ticket', action: function() {} }
+              }
+            }
+          }
+        }));
+
+        popupMenu.open({}, 'test-menu', { x: 100, y: 100 }, { search: true });
+
+        // when
+        await triggerSearch('github issue');
+
+        // then
+        await expectEntries([ 'Open ticket' ]);
+      }));
+
+
+      it('should not leak keywords to sibling subtrees', inject(async function(popupMenu) {
+
+        // given
+        popupMenu.registerProvider('test-menu', {
+          getPopupMenuEntries: function() {
+            return {
+              github: {
+                label: 'GitHub Connector',
+                search: 'github',
+                entries: {
+                  'create-issue': { label: 'Create Issue', action: function() {} }
+                }
+              },
+              gitlab: {
+                label: 'GitLab Connector',
+                search: 'gitlab',
+                entries: {
+                  'create-mr': { label: 'Create Merge Request', action: function() {} }
+                }
+              },
+              'filler-1': { label: 'Filler 1', action: function() {} },
+              'filler-2': { label: 'Filler 2', action: function() {} },
+              'filler-3': { label: 'Filler 3', action: function() {} },
+              'filler-4': { label: 'Filler 4', action: function() {} }
+            };
+          }
+        });
+
+        popupMenu.open({}, 'test-menu', { x: 100, y: 100 }, { search: true });
+
+        // when
+        await triggerSearch('github');
+
+        // then
+        await expectEntries([ 'Create Issue' ]);
+      }));
+
+    });
+
+
     it('should render entry if no search results', inject(async function(popupMenu) {
 
       // given


### PR DESCRIPTION
Related to https://github.com/bpmn-io/internal-docs/issues/1315

### Proposed Changes

Popup menu entries now inherit search keywords from their parent entries.

### Try it

```sh
npx @bpmn-io/sr -l bpmn-io/diagram-js#popup-search bpmn-io/bpmn-js-create-append-anything#native-ops
```

See that if you type "github", all GitHub operations are found, even though individual `steps` in the template don't have the github keyword.

<img width="347" height="428" alt="image" src="https://github.com/user-attachments/assets/12aeffa5-25cb-4acb-a5cb-72b76b6ddfba" />

```json
"steps": [
      {
        "name": "Issues",
        "description": "Manage GitHub issues",
        "keywords": [
          "issues"
        ],
        "steps": [
          {
            "name": "Create an issue",
            "description": "Create a new GitHub issue",
            "keywords": [
              "create issue",
              "open ticket"
            ],
            "presetId": "createIssue"
          },
...
```


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
