### PR TITLE
Improve popup accessibility

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -709,6 +709,16 @@
   padding-right: 9px;
 }
 
+/**
+ * The results list is focusable (as a listbox holding
+ * `aria-activedescendant`) when there is no search field.
+ * The active entry is indicated via `.entry.selected`, so we hide
+ * the outline on the list container itself.
+ */
+.djs-popup-results:focus {
+  outline: none;
+}
+
 .djs-popup-group {
   margin: 0;
   padding: 0;
@@ -816,19 +826,51 @@
   color: var(--popup-no-results-color);
 }
 
+.djs-popup-footer {
+  display: flex;
+  padding: 5px 12px 7px 12px;
+  border-top: solid 1px var(--popup-border-color);
+}
+
+/**
+ * The footer holds the keyboard/assistive-technology reachable documentation
+ * link. Mouse users get the per-entry `.djs-popup-entry-docs` affordance on
+ * hover instead, so the (redundant) footer link is hidden while the results
+ * list is hovered and shown during keyboard navigation.
+ */
+.djs-popup-results:hover ~ .djs-popup-footer {
+  display: none;
+}
+
 .djs-popup-entry-docs {
   display: none;
   margin-left: 3px;
   color: var(--popup-description-color);
 }
 
-.djs-popup-body .entry:focus-within .djs-popup-entry-docs,
-.djs-popup-body .entry:focus .djs-popup-entry-docs,
 .djs-popup-body .entry:hover .djs-popup-entry-docs {
   display: inline;
 }
 
 .djs-popup-entry-docs svg {
+  vertical-align: middle;
+  margin: 2px;
+}
+
+.djs-popup-footer-docs {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: var(--popup-secondary-font-size);
+  color: var(--popup-description-color);
+  text-decoration: none;
+}
+
+.djs-popup-footer-docs:hover {
+  text-decoration: underline;
+}
+
+.djs-popup-footer-docs svg {
   vertical-align: middle;
   margin: 2px;
 }

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -57,6 +57,7 @@
 
   --popup-font-family: "IBM Plex Sans", sans-serif;
   --popup-font-size: 14px;
+  --popup-secondary-font-size: .9em;
   --popup-header-entry-selected-color: var(--color-blue-205-100-50);
   --popup-header-font-weight: bolder;
   --popup-header-group-divider-color: var(--color-grey-225-10-75);
@@ -696,7 +697,7 @@
 
 .djs-popup-search-count {
   margin: 0 12px;
-  font-size: 11px;
+  font-size: var(--popup-secondary-font-size);
   color: var(--popup-description-color);
 }
 
@@ -773,7 +774,7 @@
 }
 
 .djs-popup-entry-description {
-  font-size: .9em;
+  font-size: var(--popup-secondary-font-size);
   margin-top: .25em;
 
   color: var(--popup-description-color);

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -16,8 +16,12 @@ import {
 import PopupMenuBreadcrumbs from './PopupMenuBreadcrumbs.js';
 import PopupMenuHeader from './PopupMenuHeader.js';
 import PopupMenuList from './PopupMenuList.js';
+import { getPopupMenuItemId } from './PopupMenuItem.js';
+import Ids from '../../util/IdGenerator.js';
 import classNames from 'clsx';
 import { isDefined, isFunction } from 'min-dash';
+
+const ids = new Ids('djs-popup');
 
 /**
  * @typedef {import('./PopupMenuProvider.js').PopupMenuEntry} PopupMenuEntry
@@ -134,6 +138,12 @@ export default function PopupMenuComponent(props) {
    * @type {import('@bpmn-io/diagram-js-ui').Ref<boolean>}
    */
   const keyboardSelection = useRef(false);
+
+  // per instance basis to generate field IDs
+  const idPrefix = useMemo(() => ids.next(), []);
+
+  const resultsId = `${ idPrefix }-results`;
+  const activeDescendantId = selectedEntry && getPopupMenuItemId(idPrefix, selectedEntry);
 
   useEffect(() => {
     const restore = restoreSelection.current;
@@ -293,7 +303,16 @@ export default function PopupMenuComponent(props) {
             <svg class="djs-popup-search-icon" width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path fill-rule="evenodd" clip-rule="evenodd" d="M9.0325 8.5H9.625L13.3675 12.25L12.25 13.3675L8.5 9.625V9.0325L8.2975 8.8225C7.4425 9.5575 6.3325 10 5.125 10C2.4325 10 0.25 7.8175 0.25 5.125C0.25 2.4325 2.4325 0.25 5.125 0.25C7.8175 0.25 10 2.4325 10 5.125C10 6.3325 9.5575 7.4425 8.8225 8.2975L9.0325 8.5ZM1.75 5.125C1.75 6.9925 3.2575 8.5 5.125 8.5C6.9925 8.5 8.5 6.9925 8.5 5.125C8.5 3.2575 6.9925 1.75 5.125 1.75C3.2575 1.75 1.75 3.2575 1.75 5.125Z" fill="#22242A"/>
             </svg>
-            <input type="text" spellcheck=${ false } aria-label="${ title || 'Search' }" />
+            <input
+              type="text"
+              spellcheck=${ false }
+              role="combobox"
+              aria-label="${ title || 'Search' }"
+              aria-expanded="true"
+              aria-controls=${ resultsId }
+              aria-activedescendant=${ activeDescendantId || undefined }
+              aria-autocomplete="list"
+            />
           </div>
           ` }
 
@@ -309,7 +328,31 @@ export default function PopupMenuComponent(props) {
             setSelectedEntry=${ setSelectedEntry }
             keyboardSelection=${ keyboardSelection }
             onAction=${ handleEntryAction }
+            idPrefix=${ idPrefix }
+            id=${ resultsId }
+            ariaLabel=${ title || 'Results' }
+            tabIndex=${ searchable ? -1 : 0 }
+            ariaActivedescendant=${ searchable ? undefined : (activeDescendantId || undefined) }
           />
+
+          ${ selectedEntry && selectedEntry.documentationRef && html`
+            <div class="djs-popup-footer">
+              <a
+                class="djs-popup-footer-docs"
+                href=${ selectedEntry.documentationRef }
+                onClick=${ (event) => event.stopPropagation() }
+                aria-label=${ selectedEntry.label ? `Open entry documentation for ${ selectedEntry.label }` : 'Open entry documentation' }
+                target="_blank"
+                rel="noopener"
+              >
+                Open entry documentation
+
+                <svg aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path fill-rule="evenodd" clip-rule="evenodd" d="M10.6368 10.6375V5.91761H11.9995V10.6382C11.9995 10.9973 11.8623 11.3141 11.5878 11.5885C11.3134 11.863 10.9966 12.0002 10.6375 12.0002H1.36266C0.982345 12.0002 0.660159 11.8681 0.396102 11.6041C0.132044 11.34 1.52588e-05 11.0178 1.52588e-05 10.6375V1.36267C1.52588e-05 0.98236 0.132044 0.660173 0.396102 0.396116C0.660159 0.132058 0.982345 2.95639e-05 1.36266 2.95639e-05H5.91624V1.36267H1.36266V10.6375H10.6368ZM12 0H7.2794L7.27873 1.36197H9.68701L3.06507 7.98391L4.01541 8.93425L10.6373 2.31231V4.72059H12V0Z" fill="#818798"/>
+                </svg>
+              </a>
+            </div>
+          ` }
         </div>
       ` }
     ${ emptyPlaceholder && entriesToShow.length === 0 && html`
@@ -357,9 +400,14 @@ function PopupMenuWrapper(props) {
       return;
     }
 
-    const inputEl = popupEl.querySelector('input');
+    // focus the combobox (search) if present, otherwise the listbox
+    // itself which then holds focus + `aria-activedescendant`;
+    // fall back to the popup element (e.g. empty placeholder)
+    const focusEl = popupEl.querySelector('input')
+      || popupEl.querySelector('[role="listbox"]')
+      || popupEl;
 
-    (inputEl || popupEl).focus();
+    focusEl.focus();
   }, [ navigationStack ]);
 
   // global <Escape> / blur handlers

--- a/lib/features/popup-menu/PopupMenuItem.js
+++ b/lib/features/popup-menu/PopupMenuItem.js
@@ -43,7 +43,6 @@ export default function PopupMenuItem(props) {
       class=${ classNames('entry', { selected, disabled: entry.disabled }) }
       data-id=${ entry.id }
       title=${ entry.title }
-      aria-label=${ entry.title || entry.label }
       aria-disabled=${ entry.disabled || undefined }
       tabIndex="0"
       onClick=${ handleClick }

--- a/lib/features/popup-menu/PopupMenuItem.js
+++ b/lib/features/popup-menu/PopupMenuItem.js
@@ -9,10 +9,26 @@ import {
  */
 
 /**
+ * Compute the DOM `id` of a rendered popup menu entry.
+ *
+ * Used to wire the entry (`role="option"`) to the search field
+ * via `aria-activedescendant`.
+ *
+ * @param {string} idPrefix
+ * @param {PopupMenuEntry} entry
+ *
+ * @return {string}
+ */
+export function getPopupMenuItemId(idPrefix, entry) {
+  return `${ idPrefix }-entry-${ entry.id }`;
+}
+
+/**
  * Component that renders a popup menu entry.
  *
  * @param {Object} props
  * @param {string} props.key
+ * @param {string} props.idPrefix
  * @param {PopupMenuEntry} props.entry
  * @param {boolean} props.selected
  * @param {(event: MouseEvent) => void} props.onMouseEnter
@@ -21,6 +37,7 @@ import {
  */
 export default function PopupMenuItem(props) {
   const {
+    idPrefix,
     entry,
     selected,
     onMouseEnter,
@@ -42,12 +59,13 @@ export default function PopupMenuItem(props) {
     <li
       class=${ classNames('entry', { selected, disabled: entry.disabled }) }
       data-id=${ entry.id }
+      id=${ getPopupMenuItemId(idPrefix, entry) }
+      role="option"
+      aria-selected=${ selected || undefined }
+      aria-haspopup=${ entry.entries ? 'true' : undefined }
       title=${ entry.title }
       aria-disabled=${ entry.disabled || undefined }
-      tabIndex="0"
       onClick=${ handleClick }
-      onFocus=${ onMouseEnter }
-      onBlur=${ onMouseLeave }
       onMouseEnter=${ onMouseEnter }
       onMouseLeave=${ onMouseLeave }
       onDragStart=${ (event) => draggable && handleClick(event, 'dragstart') }
@@ -67,15 +85,17 @@ export default function PopupMenuItem(props) {
           ` : null }
 
           ${ entry.documentationRef && html`
-            <a class="djs-popup-entry-docs"
+            <a
+              class="djs-popup-entry-docs"
               href=${ entry.documentationRef }
               onClick=${ (event) => event.stopPropagation() }
-              title="Open element documentation"
-              aria-label="Open element documentation"
+              title="Open entry documentation"
+              tabIndex="-1"
+              aria-hidden="true"
               target="_blank"
               rel="noopener"
             >
-              <svg aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M10.6368 10.6375V5.91761H11.9995V10.6382C11.9995 10.9973 11.8623 11.3141 11.5878 11.5885C11.3134 11.863 10.9966 12.0002 10.6375 12.0002H1.36266C0.982345 12.0002 0.660159 11.8681 0.396102 11.6041C0.132044 11.34 1.52588e-05 11.0178 1.52588e-05 10.6375V1.36267C1.52588e-05 0.98236 0.132044 0.660173 0.396102 0.396116C0.660159 0.132058 0.982345 2.95639e-05 1.36266 2.95639e-05H5.91624V1.36267H1.36266V10.6375H10.6368ZM12 0H7.2794L7.27873 1.36197H9.68701L3.06507 7.98391L4.01541 8.93425L10.6373 2.31231V4.72059H12V0Z" fill="#818798"/>
               </svg>
             </a>

--- a/lib/features/popup-menu/PopupMenuList.js
+++ b/lib/features/popup-menu/PopupMenuList.js
@@ -19,6 +19,11 @@ import PopupMenuItem from './PopupMenuItem.js';
  * @param {PopupMenuEntry} props.selectedEntry
  * @param {(entry: PopupMenuEntry | null) => void} props.setSelectedEntry
  * @param {import('@bpmn-io/diagram-js-ui').Ref<boolean>} props.keyboardSelection
+ * @param {string} props.idPrefix
+ * @param {string} props.id
+ * @param {string} [props.ariaLabel]
+ * @param {number} [props.tabIndex]
+ * @param {string} [props.ariaActivedescendant]
  */
 export default function PopupMenuList(props) {
   const {
@@ -26,6 +31,11 @@ export default function PopupMenuList(props) {
     setSelectedEntry,
     groupedEntries,
     keyboardSelection,
+    idPrefix,
+    id,
+    ariaLabel,
+    tabIndex,
+    ariaActivedescendant,
     ...restProps
   } = props;
 
@@ -73,17 +83,32 @@ export default function PopupMenuList(props) {
   };
 
   return html`
-    <div class="djs-popup-results" ref=${ resultsRef } onMouseMove=${ handleMouseMove }>
+    <div
+      class="djs-popup-results"
+      ref=${ resultsRef }
+      id=${ id }
+      role="listbox"
+      aria-label=${ ariaLabel }
+      tabIndex=${ tabIndex }
+      aria-activedescendant=${ ariaActivedescendant }
+      onMouseMove=${ handleMouseMove }
+    >
       ${ groupedEntries.map(group => html`
         ${ group.name && html`
-          <div key=${ group.id } class="entry-header" title=${ group.name }>
+          <div key=${ group.id } id=${ getGroupHeaderId(idPrefix, group) } class="entry-header" title=${ group.name }>
             ${ group.name }
           </div>
         ` }
-        <ul class="djs-popup-group" data-group=${ group.id }>
+        <ul
+          class="djs-popup-group"
+          data-group=${ group.id }
+          role="group"
+          aria-labelledby=${ group.name ? getGroupHeaderId(idPrefix, group) : undefined }
+        >
           ${ group.entries.map(entry => html`
             <${PopupMenuItem}
               key=${ entry.id }
+              idPrefix=${ idPrefix }
               entry=${ entry }
               selected=${ entry === selectedEntry }
               onMouseEnter=${ () => handleEntryMouseEnter(entry) }
@@ -99,6 +124,10 @@ export default function PopupMenuList(props) {
 
 
 // helpers ////////////////
+
+function getGroupHeaderId(idPrefix, group) {
+  return `${ idPrefix }-group-${ group.id }`;
+}
 
 function scrollIntoView(el) {
   if (typeof el.scrollIntoViewIfNeeded === 'function') {

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -180,7 +180,28 @@ describe('features/popup-menu - <PopupMenu>', function() {
 
       // when
       await createPopupMenu({
-        container
+        container,
+        entries: [
+          { id: '1', label: 'Entry 1' },
+          { id: '2', label: 'Entry 2' }
+        ]
+      });
+
+      const listboxEl = domQuery(
+        '.djs-popup-results', container
+      );
+
+      // then
+      expect(document.activeElement).to.equal(listboxEl);
+    });
+
+
+    it('without search or entries', async function() {
+
+      // when
+      await createPopupMenu({
+        container,
+        emptyPlaceholder: 'No entries'
       });
 
       const popupEl = domQuery(
@@ -1666,6 +1687,282 @@ describe('features/popup-menu - <PopupMenu>', function() {
 
       // then
       await expectToBeAccessible(container);
+    });
+
+
+    it('should render entries as options', async function() {
+
+      // given
+      await createPopupMenu({ container, entries });
+
+      // when
+      const options = domQueryAll('.entry', container);
+
+      // then
+      expect(options).to.have.length(entries.length);
+
+      options.forEach(option => {
+        expect(option.getAttribute('role')).to.eql('option');
+      });
+    });
+
+
+    it('should derive accessible name from content (no title needed)', async function() {
+
+      // given
+      await createPopupMenu({ container, entries });
+
+      // when
+      const [ firstEntry ] = domQueryAll('.entry', container);
+
+      // then
+      // `role="option"` supports name from contents, so the visible
+      // label is the accessible name without an extra title/aria-label
+      expect(firstEntry.getAttribute('role')).to.eql('option');
+      expect(firstEntry.title).to.be.empty;
+      expect(firstEntry.getAttribute('aria-label')).not.to.exist;
+      expect(firstEntry.textContent).to.contain('Entry 1');
+    });
+
+
+    it('should mark selected entry with aria-selected', async function() {
+
+      // given
+      await createPopupMenu({ container, entries });
+
+      // when
+      const selected = domQuery('.entry.selected', container);
+      const notSelected = domQuery('.entry:not(.selected)', container);
+
+      // then
+      expect(selected.getAttribute('aria-selected')).to.eql('true');
+      expect(notSelected.getAttribute('aria-selected')).not.to.exist;
+    });
+
+
+    it('should mark entries with sub menu via aria-haspopup', async function() {
+
+      // given
+      const entries = [
+        {
+          id: 'nav',
+          label: 'Navigate',
+          entries: [ { id: 'child', label: 'Child' } ]
+        }
+      ];
+
+      await createPopupMenu({ container, entries });
+
+      // when
+      const entry = domQuery('.entry', container);
+
+      // then
+      expect(entry.getAttribute('aria-haspopup')).to.eql('true');
+    });
+
+
+    it('should wire search field (combobox) to results (listbox)', async function() {
+
+      // given
+      await createPopupMenu({ container, entries, title: 'Search', search: true });
+
+      // when
+      const input = domQuery('.djs-popup-search input', container);
+      const results = domQuery('.djs-popup-results', container);
+      const selected = domQuery('.entry.selected', container);
+
+      // then
+      expect(input.getAttribute('role')).to.eql('combobox');
+      expect(input.getAttribute('aria-expanded')).to.eql('true');
+      expect(input.getAttribute('aria-autocomplete')).to.eql('list');
+
+      expect(results.getAttribute('role')).to.eql('listbox');
+      expect(results.id).to.exist.and.to.eql(input.getAttribute('aria-controls'));
+
+      expect(input.getAttribute('aria-activedescendant')).to.eql(selected.id);
+    });
+
+
+    it('should keep listbox out of tab order when searchable (combobox owns focus)', async function() {
+
+      // given
+      await createPopupMenu({ container, entries, title: 'Search', search: true });
+
+      // when
+      const results = domQuery('.djs-popup-results', container);
+
+      // then
+      expect(results.getAttribute('tabindex')).to.eql('-1');
+      expect(results.getAttribute('aria-activedescendant')).not.to.exist;
+    });
+
+
+    it('should make listbox the focus holder when not searchable', async function() {
+
+      // given
+      const entries = [
+        { id: '1', label: 'Entry 1' },
+        { id: '2', label: 'Entry 2' }
+      ];
+
+      await createPopupMenu({ container, entries });
+
+      // when
+      const results = domQuery('.djs-popup-results', container);
+      const selected = domQuery('.entry.selected', container);
+
+      // then
+      expect(results.getAttribute('tabindex')).to.eql('0');
+      expect(results.getAttribute('aria-activedescendant')).to.eql(selected.id);
+    });
+
+
+    it('should not show an outline on the focused listbox', async function() {
+
+      // given
+      const entries = [
+        { id: '1', label: 'Entry 1' },
+        { id: '2', label: 'Entry 2' }
+      ];
+
+      await createPopupMenu({ container, entries });
+
+      // when
+      const results = domQuery('.djs-popup-results', container);
+
+      results.focus();
+
+      // then
+      expect(document.activeElement).to.equal(results);
+      expect(getComputedStyle(results).outlineStyle).to.eql('none');
+    });
+
+
+    describe('entry documentation', function() {
+
+      const docEntries = [
+        { id: '1', label: 'Entry 1', documentationRef: 'https://example.com/1' },
+        { id: '2', label: 'Entry 2' }
+      ];
+
+
+      it('should render a per-row documentation icon hidden from assistive technology', async function() {
+
+        // given
+        await createPopupMenu({ container, entries: docEntries });
+
+        // when
+        // the per-row icon lives inside the option, as a mouse affordance
+        const rowLink = domQuery('.entry .djs-popup-entry-docs', container);
+
+        // then
+        expect(rowLink).to.exist;
+        expect(rowLink.getAttribute('aria-hidden')).to.eql('true');
+        expect(rowLink.getAttribute('tabindex')).to.eql('-1');
+        expect(rowLink.getAttribute('href')).to.eql('https://example.com/1');
+      });
+
+
+      it('should render the actionable documentation link in the footer', async function() {
+
+        // given
+        await createPopupMenu({ container, entries: docEntries });
+
+        // when
+        const link = domQuery('.djs-popup-footer-docs', container);
+
+        // then
+        // the actionable, AT-reachable link is hoisted out of the listbox
+        expect(link).to.exist;
+        expect(link.closest('.entry')).not.to.exist;
+        expect(link.closest('[role="listbox"]')).not.to.exist;
+        expect(link.closest('.djs-popup-footer')).to.exist;
+      });
+
+
+      it('should reflect the active entry in the footer documentation link', async function() {
+
+        // given
+        await createPopupMenu({ container, entries: docEntries });
+
+        // when
+        // the first entry (with docs) is active by default
+        const link = domQuery('.djs-popup-footer-docs', container);
+
+        // then
+        expect(link.getAttribute('href')).to.eql('https://example.com/1');
+        expect(link.getAttribute('aria-label')).to.eql('Open entry documentation for Entry 1');
+      });
+
+
+      it('should hide the footer documentation link for entries without docs', async function() {
+
+        // given
+        await createPopupMenu({ container, entries: [
+          { id: '1', label: 'Entry 1' },
+          { id: '2', label: 'Entry 2', documentationRef: 'https://example.com/2' }
+        ] });
+
+        // when
+        // first (docs-less) entry is active by default
+        const link = domQuery('.djs-popup-footer-docs', container);
+
+        // then
+        expect(link).not.to.exist;
+      });
+
+
+      it('should keep the footer documentation link keyboard reachable', async function() {
+
+        // given
+        await createPopupMenu({ container, entries: docEntries });
+
+        // when
+        const link = domQuery('.djs-popup-footer-docs', container);
+
+        link.focus();
+
+        // then
+        // a plain link outside the listbox is naturally focusable
+        expect(document.activeElement).to.equal(link);
+      });
+
+    });
+
+
+    it('should generate unique ids per popup instance', async function() {
+
+      // given
+      await createPopupMenu({ container, entries });
+      const firstId = domQuery('.djs-popup-results', container).id;
+
+      const otherContainer = domify('<div class="djs-parent"></div>');
+      document.body.appendChild(otherContainer);
+
+      // when
+      await act(() => render(
+        html`<${PopupMenuComponent} ...${ {
+          entries,
+          headerEntries: [],
+          searchFn,
+          position() { return { x: 0, y: 0 }; },
+          onClose() {},
+          onOpened() {},
+          onClosed() {}
+        } } />`,
+        otherContainer
+      ));
+
+      const secondId = domQuery('.djs-popup-results', otherContainer).id;
+
+      // then
+      expect(firstId).to.exist;
+      expect(secondId).to.exist;
+      expect(secondId).not.to.eql(firstId);
+
+      // cleanup
+      render(null, otherContainer);
+      document.body.removeChild(otherContainer);
     });
   });
 

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -362,16 +362,13 @@ describe('features/popup-menu - <PopupMenu>', function() {
 
       // then
       expect(firstEntry.title).to.be.empty;
-      expect(firstEntry.getAttribute('aria-label')).to.eql('1');
       expect(firstEntry.textContent).to.eql('1');
 
       expect(secondEntry.title).to.eql('Toggle foo');
-      expect(secondEntry.getAttribute('aria-label')).to.eql('Toggle foo');
       expect(secondEntry.textContent).to.eql('');
       expect(secondEntry.innerHTML).to.include(`<img class="djs-popup-entry-icon" src="${ imageUrl }" alt="">`);
 
       expect(describedEntry.title).to.be.empty;
-      expect(describedEntry.getAttribute('aria-label')).to.eql('FOO');
       expect(describedEntry.textContent).to.eql('FOOI DESCRIBE IT');
     });
 

--- a/test/spec/features/popup-menu/PopupMenuItemSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuItemSpec.js
@@ -34,36 +34,6 @@ describe('features/popup-menu - <PopupMenuItem>', function() {
     expect(domQuery('.entry', container)).to.exist;
   });
 
-
-  it('should be labelled by <label>', function() {
-
-    // when
-    createPopupMenu({
-      container,
-      entry: { id: 'foo', label: 'User task' }
-    });
-
-    // then
-    const entry = domQuery('.entry', container);
-
-    expect(entry.getAttribute('aria-label')).to.eql('User task');
-  });
-
-
-  it('should be labelled by <title>', function() {
-
-    // when
-    createPopupMenu({
-      container,
-      entry: { id: 'foo', label: 'User task', title: 'User task (long)' }
-    });
-
-    // then
-    const entry = domQuery('.entry', container);
-
-    expect(entry.getAttribute('aria-label')).to.eql('User task (long)');
-  });
-
 });
 
 

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -3189,6 +3189,58 @@ describe('features/popup-menu - integration', function() {
 
   }));
 
+
+  // accessibility playground
+  //
+  // add `.only` to this test and run `npm run dev` to open a rich popup menu
+  // for manual inspection (DevTools > Accessibility pane and/or a screen
+  // reader). Covers the #1056 rework:
+  //
+  //   - entries are role="option", named from their visible label
+  //   - hovering an entry reveals the mouse-only (aria-hidden) docs icon
+  //   - the actionable "Open entry documentation" link sits in the footer and
+  //     reflects the active entry (keyboard/AT reachable via Tab)
+  //   - > 5 entries render a search field (role="combobox") driving the list
+  //     (role="listbox") via aria-activedescendant
+  it('should render accessibility playground', inject(function(popupMenu) {
+
+    // given
+    const tasksGroup = { id: 'tasks', name: 'Tasks' };
+    const gatewaysGroup = { id: 'gateways', name: 'Gateways' };
+
+    const entries = entrySet([
+      { id: 'task', label: 'Task', group: tasksGroup, className: 'bpmn-icon-task',
+        documentationRef: 'https://docs.camunda.io/docs/components/modeler/bpmn/tasks/' },
+      { id: 'service-task', label: 'Service Task', group: tasksGroup, className: 'bpmn-icon-service',
+        description: 'Invokes a service, e.g. a REST endpoint',
+        documentationRef: 'https://docs.camunda.io/docs/components/modeler/bpmn/service-tasks/' },
+      { id: 'user-task', label: 'User Task', group: tasksGroup, className: 'bpmn-icon-user',
+        documentationRef: 'https://docs.camunda.io/docs/components/modeler/bpmn/user-tasks/' },
+      { id: 'script-task', label: 'Script Task', group: tasksGroup, className: 'bpmn-icon-script' },
+      { id: 'send-task', label: 'Send Task', group: tasksGroup, className: 'bpmn-icon-send' },
+      { id: 'exclusive-gateway', label: 'Exclusive Gateway', group: gatewaysGroup, className: 'bpmn-icon-gateway-xor',
+        documentationRef: 'https://docs.camunda.io/docs/components/modeler/bpmn/exclusive-gateways/' },
+      { id: 'parallel-gateway', label: 'Parallel Gateway', group: gatewaysGroup, className: 'bpmn-icon-gateway-parallel' }
+    ]);
+
+    const provider = new Provider(entries);
+
+    // when
+    popupMenu.registerProvider('a11y-playground', provider);
+
+    // then
+    // searchable variant (combobox + listbox); to inspect the non-searchable
+    // listbox variant, drop `search: true` (or pass < 6 entries)
+    popupMenu.open({}, 'a11y-playground', {
+      x: 100, y: 100
+    }, {
+      width: 250,
+      search: true,
+      title: 'Append element'
+    });
+
+  }));
+
 });
 
 


### PR DESCRIPTION
### Proposed Changes

This PR explores improving the accessibility of our popup menu:

* Turns it into a real combobox (with search) / listbox (no search)
* Removes past focus hack
* Works in two dedicated modes (still)
  * Keyboard navigation - shows documentation link not inline, but on the bottom of the box (we'll otherwise not comply with `aria` specification - list items cannot contain focusable elements)
  * Mouse navigation - documentation link is "in focus", on the individual item
* Keyboard navigation is _fixed_. No longer endless tabbing through the elements - a combo-box has _one_ keyboard focus, and I can tab out of it easily

<img width="1024" height="738" alt="capture U59Jjd_optimized" src="https://github.com/user-attachments/assets/df6467ce-2178-4955-82b2-58c235590139" />

Relates to https://github.com/bpmn-io/diagram-js/issues/1056 - just a proper fix that _truely_ improves the components accessibility.

Closes https://github.com/bpmn-io/diagram-js/issues/735


### Try out via

```
npx @bpmn-io/sr bpmn-io/bpmn-js-create-append-anything -l bpmn-io/diagram-js#improve-popup-accessibility
```

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
