### PR TITLE
Popup menu bug fixes

### DIFF
--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -268,6 +268,7 @@ export default function PopupMenuComponent(props) {
       position=${ position }
       width=${ width }
       scale=${ scale }
+      navigationStack=${ navigationStack }
     >
       ${ displayHeader && html`
         <${PopupMenuHeader}
@@ -330,6 +331,7 @@ function PopupMenuWrapper(props) {
     onKeyup,
     className,
     children,
+    navigationStack,
     position: positionGetter
   } = props;
 
@@ -348,7 +350,6 @@ function PopupMenuWrapper(props) {
     popupEl.style.top = `${position.y}px`;
   }, [ popupRef.current, positionGetter ]);
 
-  // initial focus
   useLayoutEffect(() => {
     const popupEl = popupRef.current;
 
@@ -359,7 +360,7 @@ function PopupMenuWrapper(props) {
     const inputEl = popupEl.querySelector('input');
 
     (inputEl || popupEl).focus();
-  }, []);
+  }, [ navigationStack ]);
 
   // global <Escape> / blur handlers
   useEffect(() => {

--- a/lib/features/popup-menu/PopupMenuList.js
+++ b/lib/features/popup-menu/PopupMenuList.js
@@ -37,8 +37,6 @@ export default function PopupMenuList(props) {
       return;
     }
 
-    keyboardSelection.current = false;
-
     const containerEl = resultsRef.current;
 
     if (!containerEl)
@@ -51,8 +49,31 @@ export default function PopupMenuList(props) {
     }
   }, [ selectedEntry ]);
 
+  const handleMouseMove = () => {
+    keyboardSelection.current = false;
+  };
+
+  const handleEntryMouseEnter = (entry) => {
+
+    // Prevents keyboard selection from being overridden
+    // by mouse hover when `scrollIntoView` is called.
+    if (keyboardSelection.current) {
+      return;
+    }
+
+    setSelectedEntry(entry);
+  };
+
+  const handleEntryMouseLeave = () => {
+    if (keyboardSelection.current) {
+      return;
+    }
+
+    setSelectedEntry(null);
+  };
+
   return html`
-    <div class="djs-popup-results" ref=${ resultsRef }>
+    <div class="djs-popup-results" ref=${ resultsRef } onMouseMove=${ handleMouseMove }>
       ${ groupedEntries.map(group => html`
         ${ group.name && html`
           <div key=${ group.id } class="entry-header" title=${ group.name }>
@@ -65,8 +86,8 @@ export default function PopupMenuList(props) {
               key=${ entry.id }
               entry=${ entry }
               selected=${ entry === selectedEntry }
-              onMouseEnter=${ () => setSelectedEntry(entry) }
-              onMouseLeave=${ () => setSelectedEntry(null) }
+              onMouseEnter=${ () => handleEntryMouseEnter(entry) }
+              onMouseLeave=${ handleEntryMouseLeave }
               ...${ restProps }
             />
           `) }

--- a/test/spec/features/popup-menu/PopupMenuListSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuListSpec.js
@@ -48,6 +48,7 @@ function createPopupMenuList(options) {
     groupedEntries: [ ],
     selectedEntry: null,
     setSelectedEntry: () => {},
+    keyboardSelection: { current: false },
     onSelect: () => {},
     ...restProps
   };

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -1586,6 +1586,7 @@ describe('features/popup-menu', function() {
 
       // when
       await act(function() {
+        queryPopup('.djs-popup-results').dispatchEvent(mouseMove());
         queryEntry('3').dispatchEvent(new MouseEvent('mouseenter'));
       });
 
@@ -1593,6 +1594,122 @@ describe('features/popup-menu', function() {
       await expectSelected('Entry 3');
 
       expect(scrollSpy).not.to.have.been.called;
+    }));
+
+  });
+
+
+  describe('mouse navigation', function() {
+
+    afterEach(restore);
+
+
+    var entries = [
+      { id: '1', label: 'Entry 1' },
+      { id: '2', label: 'Entry 2' },
+      { id: '3', label: 'Entry 3' }
+    ];
+
+    var testMenuProvider = {
+      getEntries: function() {
+        return entries;
+      }
+    };
+
+
+    it('should select on mouse hover', inject(async function(popupMenu) {
+
+      // given
+      popupMenu.registerProvider('test-menu', testMenuProvider);
+
+      await act(function() {
+        popupMenu.open({}, 'test-menu', { x: 100, y: 100 });
+      });
+
+      // when
+      await act(function() {
+        queryPopup('.djs-popup-results').dispatchEvent(mouseMove());
+        queryEntry('3').dispatchEvent(new MouseEvent('mouseenter'));
+      });
+
+      // then
+      await expectSelected('Entry 3');
+    }));
+
+
+    it('should NOT steal selection on mouse enter while navigating with keyboard', inject(async function(popupMenu) {
+
+      // given
+      popupMenu.registerProvider('test-menu', testMenuProvider);
+
+      await act(function() {
+        popupMenu.open({}, 'test-menu', { x: 100, y: 100 });
+      });
+
+      await act(function() {
+        queryPopup('.djs-popup').dispatchEvent(keyDown('ArrowDown'));
+      });
+
+      await expectSelected('Entry 2');
+
+      // when
+      await act(function() {
+        queryEntry('3').dispatchEvent(new MouseEvent('mouseenter'));
+      });
+
+      // then
+      await expectSelected('Entry 2');
+    }));
+
+
+    it('should deselect on mouse leave', inject(async function(popupMenu) {
+
+      // given
+      popupMenu.registerProvider('test-menu', testMenuProvider);
+
+      await act(function() {
+        popupMenu.open({}, 'test-menu', { x: 100, y: 100 });
+      });
+
+      await act(function() {
+        queryPopup('.djs-popup-results').dispatchEvent(mouseMove());
+        queryEntry('3').dispatchEvent(new MouseEvent('mouseenter'));
+      });
+
+      await expectSelected('Entry 3');
+
+      // when
+      await act(function() {
+        queryEntry('3').dispatchEvent(new MouseEvent('mouseleave'));
+      });
+
+      // then
+      expect(queryPopup('.entry.selected')).not.to.exist;
+    }));
+
+
+    it('should NOT deselect on mouse leave while navigating with keyboard', inject(async function(popupMenu) {
+
+      // given
+      popupMenu.registerProvider('test-menu', testMenuProvider);
+
+      await act(function() {
+        popupMenu.open({}, 'test-menu', { x: 100, y: 100 });
+      });
+
+      await act(function() {
+        queryPopup('.djs-popup').dispatchEvent(keyDown('ArrowDown'));
+      });
+
+      await expectSelected('Entry 2');
+
+      // when
+      await act(function() {
+        queryEntry('2').dispatchEvent(new MouseEvent('mouseleave'));
+      });
+
+      // then
+      await expectSelected('Entry 2');
     }));
 
   });
@@ -3208,6 +3325,13 @@ function keyUp(key) {
  */
 function keyDown(key) {
   return new KeyboardEvent('keydown', { key, bubbles: true });
+}
+
+/**
+ * @return {MouseEvent}
+ */
+function mouseMove() {
+  return new MouseEvent('mousemove', { bubbles: true });
 }
 
 /**


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/6027

### Proposed Changes

### Ignore mouse when navigating with keyboard

Prevents a bug happening when you navigate down on the last entry, and you land on the entry which is hovered by mouse, instead of the first one in the list.

Before

<img width="300" alt="djs-popup-to-first-bug" src="https://github.com/user-attachments/assets/2a97299d-4c50-4c2b-bc16-2ccb01e67856" />

After

<img width="300" alt="djs-popup-to-first-fix" src="https://github.com/user-attachments/assets/425cba1f-df61-4350-b52e-7e509a866192" />

### Restore focus after drilling down into an entry

Allows for keyboard navigation after clicking into an entry with steps. Was not possible before.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
