### PR TITLE
Do not show floating bendpoint at (0|0) position

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -885,6 +885,10 @@
   display: none;
 }
 
+.djs-bendpoint.floating:not(.positioned) {
+  display: none;
+}
+
 .djs-segment-dragger:hover .djs-visual,
 .djs-segment-dragger.djs-dragging .djs-visual,
 .djs-bendpoint:hover .djs-visual,

--- a/lib/features/bendpoints/Bendpoints.js
+++ b/lib/features/bendpoints/Bendpoints.js
@@ -264,6 +264,9 @@ export default function Bendpoints(
 
     translate(floating, point.x, point.y);
 
+    // mark as positioned so it may be shown; keeping it hidden until then
+    // avoids a ghost bendpoint appearing at (0, 0)
+    svgClasses(floating).add('positioned');
   }
 
   function updateSegmentDraggerPosition(parentGfx, intersection, waypoints) {
@@ -384,6 +387,28 @@ export default function Bendpoints(
 
     if (element.waypoints) {
       addHandles(element);
+    }
+  });
+
+  eventBus.on('element.out', function(event) {
+    var element = event.element;
+
+    if (!element.waypoints) {
+      return;
+    }
+
+    var bendpointsGfx = getBendpointsContainer(element);
+
+    if (!bendpointsGfx) {
+      return;
+    }
+
+    // reset floating bendpoint so it does not re-appear at a stale position
+    // before being re-positioned on the next element.mousemove
+    var floating = domQuery('.floating', bendpointsGfx);
+
+    if (floating) {
+      svgClasses(floating).remove('positioned');
     }
   });
 

--- a/test/spec/features/bendpoints/BendpointsSpec.js
+++ b/test/spec/features/bendpoints/BendpointsSpec.js
@@ -582,6 +582,95 @@ describe('features/bendpoints', function() {
     ));
 
 
+    it('should NOT show floating bendpoint before it got positioned', inject(
+      function(eventBus, canvas, elementRegistry) {
+
+        // given
+        var layer = canvas.getLayer('overlays');
+
+        // when
+        // hovering the connection without moving the mouse over it
+        eventBus.fire('element.hover', {
+          element: connection,
+          gfx: elementRegistry.getGraphics(connection)
+        });
+
+        var bendpointContainer = domQuery('.djs-bendpoints', layer),
+            floatingBendpointGfx = domQuery('.floating', bendpointContainer);
+
+        // then
+        // floating bendpoint is NOT shown as a ghost at (0, 0)
+        expect(isVisible(floatingBendpointGfx)).to.be.false;
+      }
+    ));
+
+
+    it('should NOT show floating bendpoint at (0, 0) after connection changed', inject(
+      function(eventBus, canvas, elementRegistry, bendpoints) {
+
+        // given
+        var layer = canvas.getLayer('overlays');
+
+        eventBus.fire('element.hover', {
+          element: connection,
+          gfx: elementRegistry.getGraphics(connection)
+        });
+
+        // position floating bendpoint
+        eventBus.fire('element.mousemove', {
+          element: connection,
+          originalEvent: canvasEvent({ x: 525, y: 250 })
+        });
+
+        // when
+        // handles get recreated, e.g. after dropping a bendpoint
+        bendpoints.updateHandles(connection);
+
+        var bendpointContainer = domQuery('.djs-bendpoints', layer),
+            floatingBendpointGfx = domQuery('.floating', bendpointContainer);
+
+        // then
+        // floating bendpoint is NOT shown as a ghost at (0, 0)
+        expect(isVisible(floatingBendpointGfx)).to.be.false;
+      }
+    ));
+
+
+    it('should hide floating bendpoint on out', inject(
+      function(eventBus, canvas, elementRegistry) {
+
+        // given
+        var layer = canvas.getLayer('overlays');
+
+        eventBus.fire('element.hover', {
+          element: connection,
+          gfx: elementRegistry.getGraphics(connection)
+        });
+
+        // position floating bendpoint
+        eventBus.fire('element.mousemove', {
+          element: connection,
+          originalEvent: canvasEvent({ x: 525, y: 250 })
+        });
+
+        var bendpointContainer = domQuery('.djs-bendpoints', layer),
+            floatingBendpointGfx = domQuery('.floating', bendpointContainer);
+
+        // assume
+        expect(isVisible(floatingBendpointGfx)).to.be.true;
+
+        // when
+        eventBus.fire('element.out', {
+          element: connection,
+          gfx: elementRegistry.getGraphics(connection)
+        });
+
+        // then
+        expect(isVisible(floatingBendpointGfx)).to.be.false;
+      }
+    ));
+
+
     it('should update floating bendpoint position on mousemove', inject(
       function(selection, canvas, eventBus, elementRegistry) {
 
@@ -682,3 +771,11 @@ describe('features/bendpoints', function() {
   });
 
 });
+
+
+// helpers //////////
+
+function isVisible(element) {
+  return window.getComputedStyle(element).display !== 'none';
+}
+


### PR DESCRIPTION
### Proposed Changes

Fixes an issue where sometimes a floating bendpoint is shown at position (0|0) - 
bendpoint created initially, but only positioned below the cursor on mousemove.

This PR ensures it is flagged as positioned on move and only shown then.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
