### PR TITLE
Fix redundant child reorder

### DIFF
--- a/lib/core/GraphicsFactory.js
+++ b/lib/core/GraphicsFactory.js
@@ -189,10 +189,21 @@ GraphicsFactory.prototype.updateContainments = function(elements) {
 
     var childrenGfx = self._getChildrenContainer(parent);
 
-    forEach(children.slice().reverse(), function(child) {
-      var childGfx = elementRegistry.getGraphics(child);
+    // only (re-)insert children that are not already in their expected
+    // position; needlessly detaching and re-attaching siblings that did
+    // not move breaks in-progress pointer interactions (the browser drops
+    // the native `click` when the moused-down node is momentarily removed)
+    // and causes unnecessary DOM churn
+    var expected = childrenGfx.firstChild;
 
-      prependTo(childGfx.parentNode, childrenGfx);
+    forEach(children, function(child) {
+      var childGfx = elementRegistry.getGraphics(child).parentNode;
+
+      if (childGfx === expected) {
+        expected = expected.nextSibling;
+      } else {
+        childrenGfx.insertBefore(childGfx, expected);
+      }
     });
   });
 };

--- a/test/spec/core/ElementRegistrySpec.js
+++ b/test/spec/core/ElementRegistrySpec.js
@@ -6,7 +6,7 @@ import {
 } from 'test/TestHelper';
 
 
-describe('ElementRegistry', function() {
+describe('core/ElementRegistry', function() {
 
   beforeEach(bootstrapDiagram());
 

--- a/test/spec/core/GraphicsFactorySpec.js
+++ b/test/spec/core/GraphicsFactorySpec.js
@@ -14,6 +14,15 @@ import {
   classes as svgClasses
 } from 'tiny-svg';
 
+import changeSupportModule from 'lib/features/change-support';
+import interactionEventsModule from 'lib/features/interaction-events';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import { recordChildChanges } from 'test/util/DomMutations';
+
 
 describe('core/GraphicsFactory', function() {
 
@@ -116,6 +125,154 @@ describe('core/GraphicsFactory', function() {
       expect(renderSpy).to.have.been.calledWith(match({
         attrs: { foo: 'bar' }
       }));
+    }
+  ));
+
+
+  describe('on containment update', function() {
+
+    it('should not detach unchanged siblings on update', inject(
+      function(canvas, graphicsFactory, elementRegistry) {
+
+        // given
+        var shape1 = canvas.addShape({
+          id: 's1', x: 10, y: 10, width: 50, height: 50
+        });
+
+        var shape2 = canvas.addShape({
+          id: 's2', x: 100, y: 10, width: 50, height: 50
+        });
+
+        var shape2Group = elementRegistry.getGraphics(shape2).parentNode;
+        var childrenGfx = shape2Group.parentNode;
+
+        // when
+        // simulate shape1 having changed (e.g. its label was updated)
+        var changes = recordChildChanges(childrenGfx, function() {
+          graphicsFactory.updateContainments([ shape1 ]);
+        });
+
+        // then
+        expect(changes.touched(shape2Group), 'unchanged sibling must not be detached').to.be.false;
+        expect(shape2Group.parentNode).to.equal(childrenGfx);
+      }
+    ));
+
+
+    it('should reorder children to match model order', inject(
+      function(canvas, graphicsFactory, elementRegistry) {
+
+        // given
+        var root = canvas.getRootElement();
+
+        var shape1 = canvas.addShape({
+          id: 's1', x: 10, y: 10, width: 50, height: 50
+        });
+
+        var shape2 = canvas.addShape({
+          id: 's2', x: 100, y: 10, width: 50, height: 50
+        });
+
+        var shape3 = canvas.addShape({
+          id: 's3', x: 200, y: 10, width: 50, height: 50
+        });
+
+        var rootGfx = elementRegistry.getGraphics(root);
+
+        // when
+        // model order changes to [ s3, s1, s2 ]
+        root.children = [ shape3, shape1, shape2 ];
+
+        graphicsFactory.updateContainments([ shape1, shape2, shape3 ]);
+
+        // then
+        expect(domOrder(rootGfx)).to.eql([ 's3', 's1', 's2' ]);
+      }
+    ));
+
+  });
+
+
+  describe('on element change', function() {
+
+    // exercise the full ChangeSupport -> GraphicsFactory + InteractionEvents
+    // path that runs when an element is updated (e.g. label editing completes)
+    beforeEach(bootstrapDiagram({
+      modules: [
+        changeSupportModule,
+        interactionEventsModule
+      ]
     }));
 
+
+    it('should keep hit box of changed element (not re-create it)', inject(
+      function(canvas, eventBus, elementRegistry) {
+
+        // given
+        var shape = canvas.addShape({
+          id: 's1', x: 10, y: 10, width: 50, height: 50
+        });
+
+        var hit = domQuery('.djs-hit', elementRegistry.getGraphics(shape));
+
+        // assume
+        expect(hit, 'hit box exists').to.exist;
+
+        // when
+        eventBus.fire('elements.changed', { elements: [ shape ] });
+
+        // then
+        // the same hit box node is reused (only its attributes are updated),
+        // so an in-progress click on the changed element is not lost
+        expect(domQuery('.djs-hit', elementRegistry.getGraphics(shape))).to.equal(hit);
+      }
+    ));
+
+
+    it('should not detach changed element or its siblings on change', inject(
+      function(canvas, eventBus, elementRegistry) {
+
+        // given
+        var shape1 = canvas.addShape({
+          id: 's1', x: 10, y: 10, width: 50, height: 50
+        });
+
+        var shape2 = canvas.addShape({
+          id: 's2', x: 100, y: 10, width: 50, height: 50
+        });
+
+        var shape1Group = elementRegistry.getGraphics(shape1).parentNode,
+            shape2Group = elementRegistry.getGraphics(shape2).parentNode,
+            childrenGfx = shape1Group.parentNode;
+
+        // when
+        var changes = recordChildChanges(childrenGfx, function() {
+          eventBus.fire('elements.changed', { elements: [ shape1 ] });
+        });
+
+        // then
+        expect(changes.touched(shape1Group), 'changed element must not be detached').to.be.false;
+        expect(changes.touched(shape2Group), 'sibling must not be detached').to.be.false;
+      }
+    ));
+
+  });
+
 });
+
+
+// helpers ////////////////
+
+/**
+ * @param {Element} elementGfx
+ *
+ * @return { string[] }
+ */
+function domOrder(elementGfx) {
+
+  return Array.from(elementGfx.childNodes).filter(
+    node => node.classList && node.classList.contains('djs-group')
+  ).map(
+    group => group.querySelector('.djs-element').getAttribute('data-element-id')
+  );
+}

--- a/test/spec/core/GraphicsFactorySpec.js
+++ b/test/spec/core/GraphicsFactorySpec.js
@@ -15,7 +15,7 @@ import {
 } from 'tiny-svg';
 
 
-describe('GraphicsFactory', function() {
+describe('core/GraphicsFactory', function() {
 
   beforeEach(bootstrapDiagram());
 

--- a/test/util/DomMutations.js
+++ b/test/util/DomMutations.js
@@ -1,0 +1,59 @@
+import {
+  assign
+} from 'min-dash';
+
+/**
+ * Observe child DOM mutations on the given node while executing `fn` and
+ * return an API to inspect which child nodes were touched (added and/or
+ * removed) during the execution.
+ *
+ * Uses `MutationObserver#takeRecords` to collect changes synchronously, so it
+ * can be used in tests without waiting for the observer callback to fire.
+ *
+ * @example
+ *
+ * ```javascript
+ * var changes = recordChildChanges(container, function() {
+ *   doSomething();
+ * });
+ *
+ * expect(changes.touched(someChildNode)).to.be.false;
+ * ```
+ *
+ * @param {Node} node the node to observe
+ * @param {Function} fn the operation to execute while observing
+ * @param {MutationObserverInit} [options] additional observer options; merged
+ * with `{ childList: true }`
+ *
+ * @return {{ records: MutationRecord[], touched(node: Node): boolean }}
+ */
+export function recordChildChanges(node, fn, options) {
+  var observer = new MutationObserver(function() {});
+
+  observer.observe(node, assign({ childList: true }, options || {}));
+
+  try {
+    fn();
+  } finally {
+    var records = observer.takeRecords();
+
+    observer.disconnect();
+  }
+
+  return {
+    records: records,
+    touched: function(target) {
+      return records.some(function(record) {
+        return includesNode(record.removedNodes, target)
+          || includesNode(record.addedNodes, target);
+      });
+    }
+  };
+}
+
+
+// helpers //////////
+
+function includesNode(nodeList, node) {
+  return Array.prototype.indexOf.call(nodeList, node) !== -1;
+}


### PR DESCRIPTION
### Proposed Changes

Only update an elements containment (parent) when its order changed. This ensures that DOM mutations are kept minimal:

* Prevents useless move operations when the actual order of elements is correct.
* Ensures that elements are as stable as possible - they remain addressable by the browser, i.e. to receive <click> events.

The later point is demonstrated below - now fixed, `<click>` events are processed by elements - and actual selection happens, i.e. from direct editing:

<img width="916" height="560" alt="capture 7YoSQH_optimized" src="https://github.com/user-attachments/assets/c7c92efb-9f13-4733-aa70-04b0c8afda2c" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
