### PR TITLE
Speed up move preview setup for large selections

### DIFF
--- a/lib/features/move/MovePreview.js
+++ b/lib/features/move/MovePreview.js
@@ -2,9 +2,7 @@ import {
   flatten,
   forEach,
   filter,
-  find,
   groupBy,
-  matchPattern,
   size
 } from 'min-dash';
 
@@ -237,6 +235,12 @@ MovePreview.$inject = [
  */
 function removeEdges(elements) {
 
+  var elementIds = new Set();
+
+  elements.forEach(function(element) {
+    elementIds.add(element.id);
+  });
+
   var filteredElements = filter(elements, function(element) {
 
     if (!isConnection(element)) {
@@ -244,8 +248,8 @@ function removeEdges(elements) {
     } else {
 
       return (
-        find(elements, matchPattern({ id: element.source.id })) &&
-        find(elements, matchPattern({ id: element.target.id }))
+        elementIds.has(element.source.id) &&
+        elementIds.has(element.target.id)
       );
     }
   });

--- a/lib/features/preview-support/PreviewSupport.js
+++ b/lib/features/preview-support/PreviewSupport.js
@@ -94,14 +94,10 @@ PreviewSupport.prototype.addDragger = function(element, group, gfx, className = 
   gfx = gfx || this.getGfx(element);
 
   var dragger = svgClone(gfx);
-  var bbox = gfx.getBoundingClientRect();
 
   this._cloneMarkers(getVisual(dragger), className);
 
-  svgAttr(dragger, this._styles.cls(className, [], {
-    x: bbox.top,
-    y: bbox.left
-  }));
+  svgAttr(dragger, this._styles.cls(className, []));
 
   svgAppend(group, dragger);
 

--- a/test/spec/features/move/MovePreviewSpec.js
+++ b/test/spec/features/move/MovePreviewSpec.js
@@ -481,6 +481,35 @@ describe('features/move - MovePreview', function() {
         })
       );
 
+
+      it('should not add connection with endpoint outside moved elements to dragGroup',
+        inject(function(move, dragging, elementRegistry, selection) {
+
+          var rootGfx = elementRegistry.getGraphics(rootShape),
+              dragGroup;
+
+          // given
+          // connectionA connects host -> shape, but only host is moved
+          selection.select([ host ]);
+
+          // when
+          move.start(canvasEvent({ x: 0, y: 0 }), host);
+
+          dragging.hover({
+            element: rootShape,
+            gfx: rootGfx
+          });
+
+          dragging.move(canvasEvent({ x: 150, y: 200 }));
+
+          dragGroup = dragging.context().data.context.dragGroup;
+
+          // then
+          expect(dragGroup).to.exist;
+          expect(domQuery('[data-element-id="connectionA"]', dragGroup)).not.to.exist;
+        })
+      );
+
     });
 
   });


### PR DESCRIPTION
### Proposed Changes

Speeds up the one-time move preview setup that runs on `shape.move.start`. Profiling a move of 500 chained shapes (~1000 visual elements) in headless Chrome showed the visible freeze is entirely this setup step — move rules (~0.8ms) and subsequent mousemoves (~4ms) are not the problem. The setup cost grew quadratically (100→40ms, 250→101ms, 500→246ms).

Two root causes, both behavior-preserving fixes:

**1. `PreviewSupport#addDragger` — layout thrashing (dominant, `lib/features/preview-support/PreviewSupport.js`)**

It called `gfx.getBoundingClientRect()` for every element interleaved with `svgAppend` (a DOM write). Read→write→read→write across ~1000 draggers forces a synchronous layout/reflow each iteration → O(n²). Critically, the bbox was only applied as `x`/`y` attributes on a cloned SVG `<g>` — SVG groups ignore `x`/`y`, so it had no rendering effect (dead code). Removed the `getBoundingClientRect()` call and the `x`/`y` attributes.

**2. `removeEdges` — O(n²) endpoint lookup (`lib/features/move/MovePreview.js`)**

It did `find(elements, matchPattern({ id }))` per connection endpoint — a linear scan per endpoint → O(connections × elements). Replaced with a `Set` of element ids for O(1) lookups. Dropped the now-unused `find`/`matchPattern` imports.

**Measured impact (500 elements, headless Chrome)**

| | before | after |
| --- | --- | --- |
| preview setup (total) | 246ms | 54ms (~4.5×) |
| `addDragger` | 205ms | 48ms |
| `removeEdges` / `getVisualDragShapes` | 26ms | 1.5ms |

Growth also becomes linear instead of quadratic. Profiling was done via a temporary benchmark of N chained tasks in headless Chrome (not added to the suite).

No public API or move-preview visual changes.

### Steps to try out

Load a large diagram (500+ connected shapes), select all, and start dragging — the initial freeze on drag start is gone.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes (none — no visual change)
  * [x] __Steps to try out__

<sub>🤖 Regression test added: a connection with an endpoint outside the moved set is excluded from the drag group preview (exercises `removeEdges`). `npm run lint`, `npm test` (2090 passing) and `npm run generate-types` all pass.</sub>