### PR TITLE
feat(outline): defer rendering until needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 _**Note:** Yet to be released changes appear here._
 
 * `FEAT`: defer outline rendering until needed ([#1064](https://github.com/bpmn-io/diagram-js/pull/1064))
+* `FIX`: collect `Elements#selfAndChildren` unique results in linear time ([#1065](https://github.com/bpmn-io/diagram-js/pull/1065))
 * `FIX`: build element copy tree in linear time ([#1066](https://github.com/bpmn-io/diagram-js/pull/1066))
 * `FIX`: improve `Elements#getParents` utility to resolve in linear time ([#1065](https://github.com/bpmn-io/diagram-js/pull/1065))
 * `FIX`: avoid layout thrashing when creating element previews ([#1063](https://github.com/bpmn-io/diagram-js/pull/1063))
 * `FIX`: resolve affected edges in move preview in linear time ([#1063](https://github.com/bpmn-io/diagram-js/pull/1063))
 * `FIX`: only re-order children when actual order changed ([#1062](https://github.com/bpmn-io/diagram-js/pull/1062))
 * `FIX`: do not show floating bendpoint at `(0|0)` position ([#1061](https://github.com/bpmn-io/diagram-js/pull/1061))
+* `CHORE`: always return unique `Elements#selfAndChildren` results; `unique` / `allowDuplicates` flags are deprecated and ignored ([#1065](https://github.com/bpmn-io/diagram-js/pull/1065))
 
 ## 15.18.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+* `FEAT`: defer outline rendering until needed ([#1064](https://github.com/bpmn-io/diagram-js/pull/1064))
 * `FIX`: build element copy tree in linear time ([#1066](https://github.com/bpmn-io/diagram-js/pull/1066))
 * `FIX`: improve `Elements#getParents` utility to resolve in linear time ([#1065](https://github.com/bpmn-io/diagram-js/pull/1065))
 * `FIX`: avoid layout thrashing when creating element previews ([#1063](https://github.com/bpmn-io/diagram-js/pull/1063))

--- a/lib/features/move/MovePreview.js
+++ b/lib/features/move/MovePreview.js
@@ -59,7 +59,7 @@ export default function MovePreview(
   }
 
   function getAllDraggedElements(shapes) {
-    var allShapes = selfAndAllChildren(shapes, true);
+    var allShapes = selfAndAllChildren(shapes);
 
     var allConnections = allShapes.flatMap(shape =>
       (shape.incoming || []).concat(shape.outgoing || [])

--- a/lib/features/outline/Outline.js
+++ b/lib/features/outline/Outline.js
@@ -48,7 +48,7 @@ export default function Outline(eventBus, styles, elementRegistry) {
   this._eventBus = eventBus;
   this._elementRegistry = elementRegistry;
 
-  this.offset = 5;
+  this._outlineOffset = 5;
 
   this._outlineStyle = styles.cls('djs-outline', [ 'no-fill' ]);
 
@@ -176,10 +176,10 @@ Outline.prototype.updateShapeOutline = function(outline, element) {
 
   if (!updated) {
     svgAttr(outline, {
-      x: -this.offset,
-      y: -this.offset,
-      width: element.width + this.offset * 2,
-      height: element.height + this.offset * 2
+      x: -this._outlineOffset,
+      y: -this._outlineOffset,
+      width: element.width + this._outlineOffset * 2,
+      height: element.height + this._outlineOffset * 2
     });
   }
 };
@@ -196,10 +196,10 @@ Outline.prototype.updateConnectionOutline = function(outline, connection) {
   var bbox = getBBox(connection);
 
   svgAttr(outline, {
-    x: bbox.x - this.offset,
-    y: bbox.y - this.offset,
-    width: bbox.width + this.offset * 2,
-    height: bbox.height + this.offset * 2
+    x: bbox.x - this._outlineOffset,
+    y: bbox.y - this._outlineOffset,
+    width: bbox.width + this._outlineOffset * 2,
+    height: bbox.height + this._outlineOffset * 2
   });
 };
 

--- a/lib/features/outline/Outline.js
+++ b/lib/features/outline/Outline.js
@@ -50,50 +50,9 @@ export default function Outline(eventBus, styles, elementRegistry) {
 
   this.offset = 5;
 
-  var OUTLINE_STYLE = styles.cls('djs-outline', [ 'no-fill' ]);
+  this._outlineStyle = styles.cls('djs-outline', [ 'no-fill' ]);
 
   var self = this;
-
-  /**
-   * @param {SVGElement} gfx
-   *
-   * @return {SVGElement} outline
-   */
-  function createOutline(gfx) {
-    var outline = svgCreate('rect');
-
-    svgAttr(outline, assign({
-      x: 0,
-      y: 0,
-      rx: 4,
-      width: 100,
-      height: 100
-    }, OUTLINE_STYLE));
-
-    return outline;
-  }
-
-  /**
-   * Return the outline of the given element's graphics, creating and
-   * appending it on first access.
-   *
-   * @param {Element} element
-   * @param {SVGElement} gfx
-   *
-   * @return {SVGElement} outline
-   */
-  function ensureOutline(element, gfx) {
-    var outline = domQuery('.djs-outline', gfx);
-
-    if (!outline) {
-      outline = self.getOutline(element) || createOutline(gfx);
-      svgAppend(gfx, outline);
-
-      self.updateOutline(element, outline);
-    }
-
-    return outline;
-  }
 
   /**
    * Lazily create the outline once an element is hovered or selected.
@@ -101,11 +60,7 @@ export default function Outline(eventBus, styles, elementRegistry) {
    * @param {Element} element
    */
   function createElementOutline(element) {
-    var gfx = self._elementRegistry.getGraphics(element);
-
-    if (gfx) {
-      ensureOutline(element, gfx);
-    }
+    self.createOutline(element);
   }
 
   eventBus.on('element.hover', function(event) {
@@ -133,6 +88,57 @@ export default function Outline(eventBus, styles, elementRegistry) {
     }
   });
 }
+
+/**
+ * Ensure the outline for the given element is present, creating, appending
+ * and updating it on first access.
+ *
+ * Outlines are created lazily, i.e. only once an element is hovered or
+ * selected. Use this to force outline creation, e.g. for features or tests
+ * that rely on the outline being present.
+ *
+ * @param {Element} element
+ *
+ * @return {SVGElement|null} the element's outline, or `null` if the element
+ * has no rendered graphics
+ */
+Outline.prototype.createOutline = function(element) {
+  var gfx = this._elementRegistry.getGraphics(element);
+
+  if (!gfx) {
+    return null;
+  }
+
+  var outline = domQuery('.djs-outline', gfx);
+
+  if (!outline) {
+    outline = this.getOutline(element) || this._createOutlineGfx();
+    svgAppend(gfx, outline);
+
+    this.updateOutline(element, outline);
+  }
+
+  return outline;
+};
+
+/**
+ * Create the default outline graphics.
+ *
+ * @return {SVGElement} outline
+ */
+Outline.prototype._createOutlineGfx = function() {
+  var outline = svgCreate('rect');
+
+  svgAttr(outline, assign({
+    x: 0,
+    y: 0,
+    rx: 4,
+    width: 100,
+    height: 100
+  }, this._outlineStyle));
+
+  return outline;
+};
 
 /**
  * Updates the outline of the given element, dispatching to the shape or

--- a/lib/features/outline/Outline.js
+++ b/lib/features/outline/Outline.js
@@ -99,14 +99,13 @@ export default function Outline(eventBus, styles, elementRegistry) {
  *
  * @param {Element} element
  *
- * @return {SVGElement|null} the element's outline, or `null` if the element
- * has no rendered graphics
+ * @return {SVGElement} the element's outline
  */
 Outline.prototype.createOutline = function(element) {
   var gfx = this._elementRegistry.getGraphics(element);
 
   if (!gfx) {
-    return null;
+    throw new Error('cannot create outline for non-rendered element');
   }
 
   var outline = domQuery('.djs-outline', gfx);

--- a/lib/features/outline/Outline.js
+++ b/lib/features/outline/Outline.js
@@ -25,6 +25,7 @@ var DEFAULT_PRIORITY = 1000;
  *
  * @typedef {import('./OutlineProvider.js').default} OutlineProvider
  * @typedef {import('../../core/EventBus.js').default} EventBus
+ * @typedef {import('../../core/ElementRegistry.js').default} ElementRegistry
  * @typedef {import('../../draw/Styles.js').default} Styles
  */
 
@@ -34,12 +35,18 @@ var DEFAULT_PRIORITY = 1000;
  * A plugin that adds an outline to shapes and connections that may be activated and styled
  * via CSS classes.
  *
+ * The outline is created lazily, i.e. only once an element is hovered or selected
+ * for the first time. This keeps importing large diagrams fast, as we avoid
+ * creating (and laying out) an outline for every single element up front.
+ *
  * @param {EventBus} eventBus
  * @param {Styles} styles
+ * @param {ElementRegistry} elementRegistry
  */
-export default function Outline(eventBus, styles) {
+export default function Outline(eventBus, styles, elementRegistry) {
 
   this._eventBus = eventBus;
+  this._elementRegistry = elementRegistry;
 
   this.offset = 5;
 
@@ -66,36 +73,81 @@ export default function Outline(eventBus, styles) {
     return outline;
   }
 
-  // A low priortity is necessary, because outlines of labels have to be updated
-  // after the label bounds have been updated in the renderer.
-  eventBus.on([ 'shape.added', 'shape.changed' ], LOW_PRIORITY, function(event) {
-    var element = event.element,
-        gfx = event.gfx;
-
+  /**
+   * Return the outline of the given element's graphics, creating and
+   * appending it on first access.
+   *
+   * @param {Element} element
+   * @param {SVGElement} gfx
+   *
+   * @return {SVGElement} outline
+   */
+  function ensureOutline(element, gfx) {
     var outline = domQuery('.djs-outline', gfx);
 
     if (!outline) {
       outline = self.getOutline(element) || createOutline(gfx);
       svgAppend(gfx, outline);
+
+      self.updateOutline(element, outline);
     }
 
-    self.updateShapeOutline(outline, element);
+    return outline;
+  }
+
+  /**
+   * Lazily create the outline once an element is hovered or selected.
+   *
+   * @param {Element} element
+   */
+  function createElementOutline(element) {
+    var gfx = self._elementRegistry.getGraphics(element);
+
+    if (gfx) {
+      ensureOutline(element, gfx);
+    }
+  }
+
+  eventBus.on('element.hover', function(event) {
+    createElementOutline(event.element);
   });
 
-  eventBus.on([ 'connection.added', 'connection.changed' ], function(event) {
+  eventBus.on('selection.changed', function(event) {
+    forEach(event.newSelection, createElementOutline);
+  });
+
+  // Keep an already created outline in sync with its element. Elements that
+  // have not been hovered or selected yet do not have an outline; those are
+  // created (and updated) lazily via the handlers above.
+  //
+  // A low priority is necessary, because outlines of labels have to be updated
+  // after the label bounds have been updated in the renderer.
+  eventBus.on([ 'shape.changed', 'connection.changed' ], LOW_PRIORITY, function(event) {
     var element = event.element,
         gfx = event.gfx;
 
     var outline = domQuery('.djs-outline', gfx);
 
-    if (!outline) {
-      outline = createOutline(gfx);
-      svgAppend(gfx, outline);
+    if (outline) {
+      self.updateOutline(element, outline);
     }
-
-    self.updateConnectionOutline(outline, element);
   });
 }
+
+/**
+ * Updates the outline of the given element, dispatching to the shape or
+ * connection specific update depending on the element type.
+ *
+ * @param {Element} element
+ * @param {SVGElement} outline
+ */
+Outline.prototype.updateOutline = function(element, outline) {
+  if (element.waypoints) {
+    this.updateConnectionOutline(outline, element);
+  } else {
+    this.updateShapeOutline(outline, element);
+  }
+};
 
 
 /**

--- a/lib/features/space-tool/SpaceTool.js
+++ b/lib/features/space-tool/SpaceTool.js
@@ -249,7 +249,7 @@ SpaceTool.prototype.init = function(event, context) {
   }
 
   var children = [
-    ...selfAndAllChildren(root, true),
+    ...selfAndAllChildren(root),
     ...(root.attachers || [])
   ];
 

--- a/lib/util/Elements.js
+++ b/lib/util/Elements.js
@@ -61,7 +61,7 @@ export function getParents(elements) {
  * @param {Object} element
  * @param {boolean} [unique]
  */
-export function add(elements, element, unique) {
+function add(elements, element, unique) {
   var canAdd = !unique || elements.indexOf(element) === -1;
 
   if (canAdd) {

--- a/lib/util/Elements.js
+++ b/lib/util/Elements.js
@@ -93,17 +93,11 @@ export function eachElement(elements, fn, depth) {
  * @return {Element[]} found elements
  */
 export function selfAndChildren(elements, unique, maxDepth) {
-  var result = [],
-      resultSet = new Set(),
+  var result = new Set(),
       processedChildren = new Set();
 
   eachElement(elements, function(element, i, depth) {
-
-    // add element unless it was already collected
-    if (!resultSet.has(element)) {
-      result.push(element);
-      resultSet.add(element);
-    }
+    result.add(element);
 
     var children = element.children;
 
@@ -119,7 +113,7 @@ export function selfAndChildren(elements, unique, maxDepth) {
     }
   });
 
-  return result;
+  return Array.from(result);
 }
 
 /**

--- a/lib/util/Elements.js
+++ b/lib/util/Elements.js
@@ -88,7 +88,7 @@ export function eachElement(elements, fn, depth) {
  *
  * @param {Element|Element[]} elements the elements to select the children from
  * @param {boolean} [unique] deprecated, ignored; the result is always unique
- * @param {number} [maxDepth] the depth to search through or -1 for infinite
+ * @param {number} maxDepth the depth to search through or -1 for infinite
  *
  * @return {Element[]} found elements
  */
@@ -127,7 +127,7 @@ export function selfAndChildren(elements, unique, maxDepth) {
  *
  * The result is always a unique set of elements (no duplicates).
  *
- * @param {Element[]} elements to query
+ * @param {Element|Element[]} elements to query
  * @param {boolean} [allowDuplicates] deprecated, ignored; the result is always unique
  *
  * @return {Element[]} the collected elements
@@ -142,7 +142,7 @@ export function selfAndDirectChildren(elements, allowDuplicates) {
  *
  * The result is always a unique set of elements (no duplicates).
  *
- * @param {Element[]} elements to query
+ * @param {Element|Element[]} elements to query
  * @param {boolean} [allowDuplicates] deprecated, ignored; the result is always unique
  *
  * @return {Element[]} the collected elements

--- a/lib/util/Elements.js
+++ b/lib/util/Elements.js
@@ -54,25 +54,6 @@ export function getParents(elements) {
 
 
 /**
- * Adds an element to a collection and returns true if the
- * element was added.
- *
- * @param {Object[]} elements
- * @param {Object} element
- * @param {boolean} [unique]
- */
-function add(elements, element, unique) {
-  var canAdd = !unique || elements.indexOf(element) === -1;
-
-  if (canAdd) {
-    elements.push(element);
-  }
-
-  return canAdd;
-}
-
-
-/**
  * Iterate over each element in a collection, calling the iterator function `fn`
  * with (element, index, recursionDepth).
  *
@@ -103,18 +84,26 @@ export function eachElement(elements, fn, depth) {
 /**
  * Collects self + child elements up to a given depth from a list of elements.
  *
+ * The result is always a unique set of elements (no duplicates).
+ *
  * @param {Element|Element[]} elements the elements to select the children from
- * @param {boolean} unique whether to return a unique result set (no duplicates)
- * @param {number} maxDepth the depth to search through or -1 for infinite
+ * @param {boolean} [unique] deprecated, ignored; the result is always unique
+ * @param {number} [maxDepth] the depth to search through or -1 for infinite
  *
  * @return {Element[]} found elements
  */
 export function selfAndChildren(elements, unique, maxDepth) {
   var result = [],
-      processedChildren = [];
+      resultSet = new Set(),
+      processedChildren = new Set();
 
   eachElement(elements, function(element, i, depth) {
-    add(result, element, unique);
+
+    // add element unless it was already collected
+    if (!resultSet.has(element)) {
+      result.push(element);
+      resultSet.add(element);
+    }
 
     var children = element.children;
 
@@ -122,7 +111,9 @@ export function selfAndChildren(elements, unique, maxDepth) {
     if (maxDepth === -1 || depth < maxDepth) {
 
       // children exist && children not yet processed
-      if (children && add(processedChildren, children, unique)) {
+      if (children && !processedChildren.has(children)) {
+        processedChildren.add(children);
+
         return children;
       }
     }
@@ -132,28 +123,32 @@ export function selfAndChildren(elements, unique, maxDepth) {
 }
 
 /**
- * Return self + direct children for a number of elements
+ * Return self + direct children for a number of elements.
+ *
+ * The result is always a unique set of elements (no duplicates).
  *
  * @param {Element[]} elements to query
- * @param {boolean} [allowDuplicates] to allow duplicates in the result set
+ * @param {boolean} [allowDuplicates] deprecated, ignored; the result is always unique
  *
  * @return {Element[]} the collected elements
  */
 export function selfAndDirectChildren(elements, allowDuplicates) {
-  return selfAndChildren(elements, !allowDuplicates, 1);
+  return selfAndChildren(elements, true, 1);
 }
 
 
 /**
- * Return self + ALL children for a number of elements
+ * Return self + ALL children for a number of elements.
+ *
+ * The result is always a unique set of elements (no duplicates).
  *
  * @param {Element[]} elements to query
- * @param {boolean} [allowDuplicates] to allow duplicates in the result set
+ * @param {boolean} [allowDuplicates] deprecated, ignored; the result is always unique
  *
  * @return {Element[]} the collected elements
  */
 export function selfAndAllChildren(elements, allowDuplicates) {
-  return selfAndChildren(elements, !allowDuplicates, -1);
+  return selfAndChildren(elements, true, -1);
 }
 
 

--- a/test/spec/features/outline/OutlineSpec.js
+++ b/test/spec/features/outline/OutlineSpec.js
@@ -142,7 +142,7 @@ describe('features/outline - Outline', function() {
 
 
     it('should keep created outline in sync on change', inject(
-      function(canvas, eventBus, selection, elementRegistry) {
+      function(canvas, outline, eventBus, elementRegistry) {
 
         // given
         var shape = canvas.addShape({
@@ -153,19 +153,19 @@ describe('features/outline - Outline', function() {
           height: 100
         });
 
-        selection.select(shape);
-
-        var gfx = elementRegistry.getGraphics(shape);
-        var outline = domQuery('.djs-outline', gfx);
+        var outlineGfx = outline.createOutline(shape);
 
         // when
         shape.width = 200;
 
-        eventBus.fire('shape.changed', { element: shape, gfx: gfx });
+        eventBus.fire('shape.changed', {
+          element: shape,
+          gfx: elementRegistry.getGraphics(shape)
+        });
 
         // then
         // width = element.width + offset (5) * 2
-        expect(svgAttr(outline, 'width')).to.eql('210');
+        expect(svgAttr(outlineGfx, 'width')).to.eql('210');
       }
     ));
 

--- a/test/spec/features/outline/OutlineSpec.js
+++ b/test/spec/features/outline/OutlineSpec.js
@@ -28,6 +28,149 @@ describe('features/outline - Outline', function() {
   }));
 
 
+  describe('lazy creation', function() {
+
+    it('should not create outline on shape added', inject(
+      function(canvas, elementRegistry) {
+
+        // when
+        var shape = canvas.addShape({
+          id: 'test',
+          x: 10,
+          y: 10,
+          width: 100,
+          height: 100
+        });
+
+        // then
+        var gfx = elementRegistry.getGraphics(shape);
+
+        expect(domQuery('.djs-outline', gfx)).not.to.exist;
+      }
+    ));
+
+
+    it('should not create outline on connection added', inject(
+      function(canvas, elementRegistry) {
+
+        // when
+        var connection = canvas.addConnection({
+          id: 'connection',
+          waypoints: [ { x: 25, y: 25 }, { x: 115, y: 115 } ]
+        });
+
+        // then
+        var gfx = elementRegistry.getGraphics(connection);
+
+        expect(domQuery('.djs-outline', gfx)).not.to.exist;
+      }
+    ));
+
+
+    it('should create outline on hover', inject(
+      function(canvas, eventBus, elementRegistry) {
+
+        // given
+        var shape = canvas.addShape({
+          id: 'test',
+          x: 10,
+          y: 10,
+          width: 100,
+          height: 100
+        });
+
+        // when
+        eventBus.fire('element.hover', { element: shape });
+
+        // then
+        var gfx = elementRegistry.getGraphics(shape);
+
+        expect(domQuery('.djs-outline', gfx)).to.exist;
+      }
+    ));
+
+
+    it('should create outline only once', inject(
+      function(canvas, eventBus, selection, elementRegistry) {
+
+        // given
+        var shape = canvas.addShape({
+          id: 'test',
+          x: 10,
+          y: 10,
+          width: 100,
+          height: 100
+        });
+
+        // when
+        eventBus.fire('element.hover', { element: shape });
+        selection.select(shape);
+
+        // then
+        var gfx = elementRegistry.getGraphics(shape);
+
+        expect(gfx.querySelectorAll('.djs-outline')).to.have.length(1);
+      }
+    ));
+
+
+    it('should not update outline on change if not yet created', inject(
+      function(canvas, eventBus, elementRegistry) {
+
+        // given
+        var shape = canvas.addShape({
+          id: 'test',
+          x: 10,
+          y: 10,
+          width: 100,
+          height: 100
+        });
+
+        // when
+        eventBus.fire('shape.changed', {
+          element: shape,
+          gfx: elementRegistry.getGraphics(shape)
+        });
+
+        // then
+        var gfx = elementRegistry.getGraphics(shape);
+
+        expect(domQuery('.djs-outline', gfx)).not.to.exist;
+      }
+    ));
+
+
+    it('should keep created outline in sync on change', inject(
+      function(canvas, eventBus, selection, elementRegistry) {
+
+        // given
+        var shape = canvas.addShape({
+          id: 'test',
+          x: 10,
+          y: 10,
+          width: 100,
+          height: 100
+        });
+
+        selection.select(shape);
+
+        var gfx = elementRegistry.getGraphics(shape);
+        var outline = domQuery('.djs-outline', gfx);
+
+        // when
+        shape.width = 200;
+
+        eventBus.fire('shape.changed', { element: shape, gfx: gfx });
+
+        // then
+        // width = element.width + offset (5) * 2
+        expect(svgAttr(outline, 'width')).to.eql('210');
+      }
+    ));
+
+  });
+
+
   describe('select', function() {
 
     it('should add outline to shape', inject(function(selection, canvas, elementRegistry) {

--- a/test/spec/features/outline/OutlineSpec.js
+++ b/test/spec/features/outline/OutlineSpec.js
@@ -25,6 +25,7 @@ describe('features/outline - Outline', function() {
   it('should expose API', inject(function(outline) {
     expect(outline).to.exist;
     expect(outline.updateShapeOutline).to.exist;
+    expect(outline.createOutline).to.exist;
   }));
 
 
@@ -165,6 +166,67 @@ describe('features/outline - Outline', function() {
         // then
         // width = element.width + offset (5) * 2
         expect(svgAttr(outline, 'width')).to.eql('210');
+      }
+    ));
+
+
+    it('should create outline via #createOutline', inject(
+      function(canvas, outline, elementRegistry) {
+
+        // given
+        var shape = canvas.addShape({
+          id: 'test',
+          x: 10,
+          y: 10,
+          width: 100,
+          height: 100
+        });
+
+        // when
+        var created = outline.createOutline(shape);
+
+        // then
+        var gfx = elementRegistry.getGraphics(shape);
+
+        expect(created).to.exist;
+        expect(domQuery('.djs-outline', gfx)).to.equal(created);
+      }
+    ));
+
+
+    it('should create outline via #createOutline only once', inject(
+      function(canvas, outline, elementRegistry) {
+
+        // given
+        var shape = canvas.addShape({
+          id: 'test',
+          x: 10,
+          y: 10,
+          width: 100,
+          height: 100
+        });
+
+        // when
+        var first = outline.createOutline(shape);
+        var second = outline.createOutline(shape);
+
+        // then
+        var gfx = elementRegistry.getGraphics(shape);
+
+        expect(second).to.equal(first);
+        expect(gfx.querySelectorAll('.djs-outline')).to.have.length(1);
+      }
+    ));
+
+
+    it('should return null via #createOutline without graphics', inject(
+      function(outline) {
+
+        // when
+        var created = outline.createOutline({ id: 'non-existing' });
+
+        // then
+        expect(created).to.be.null;
       }
     ));
 

--- a/test/spec/features/outline/OutlineSpec.js
+++ b/test/spec/features/outline/OutlineSpec.js
@@ -219,14 +219,16 @@ describe('features/outline - Outline', function() {
     ));
 
 
-    it('should return null via #createOutline without graphics', inject(
+    it('should throw via #createOutline without graphics', inject(
       function(outline) {
 
         // when
-        var created = outline.createOutline({ id: 'non-existing' });
+        function create() {
+          outline.createOutline({ id: 'non-existing' });
+        }
 
         // then
-        expect(created).to.be.null;
+        expect(create).to.throw('cannot create outline for non-rendered element');
       }
     ));
 

--- a/test/spec/util/ElementsSpec.js
+++ b/test/spec/util/ElementsSpec.js
@@ -128,6 +128,26 @@ describe('util/Elements', function() {
       expect(result.length).to.equal(6);
       expect(ids(result)).to.eql(ids([ a ].concat(a.children).concat(child.children)));
     });
+
+
+    it('should return unique elements preserving order', function() {
+
+      // given
+      // parent listed after some of its children + duplicates
+      var a = shapeA;
+
+      // when
+      var result = selfAndDirectChildren([ shapeA1, a, shapeA1, shapeA2 ]);
+
+      // then
+      // first occurrence wins, no duplicates
+      expect(ids(result)).to.eql([
+        'a.1', 'a.1.0', 'a.1.1',
+        'a', 'a.0', 'a.2',
+        'a.2.0', 'a.2.1'
+      ]);
+    });
+
   });
 
 
@@ -144,6 +164,25 @@ describe('util/Elements', function() {
 
       // then
       expect(result.length).to.equal(14);
+    });
+
+
+    it('should always return unique result', function() {
+
+      // given
+      var a = shapeA;
+
+      // when
+      // same root passed twice + a nested descendant
+      var result = selfAndAllChildren([ a, a, shapeA21 ]);
+
+      // then
+      expect(ids(result)).to.eql([
+        'a',
+        'a.0',
+        'a.1', 'a.1.0', 'a.1.1',
+        'a.2', 'a.2.0', 'a.2.1', 'a.2.1.0'
+      ]);
     });
 
   });


### PR DESCRIPTION
### Proposed Changes

Turns outline rendering into a lazy initialization step - only renders it when actually needed, i.e. because the element was selected. Keeps outline updated once it exists.

Background to this change: Eager rendering puts a performance toll on initial import (huge diagrams) - completely unnecessary, as outlines can be "lazily" created, when needed. They are visual cues only.


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
