### PR TITLE
`Elements#selfAndChildren` always returns unique elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 _**Note:** Yet to be released changes appear here._
 
 * `FEAT`: defer outline rendering until needed ([#1064](https://github.com/bpmn-io/diagram-js/pull/1064))
+* `FIX`: collect `Elements#selfAndChildren` unique results in linear time ([#1065](https://github.com/bpmn-io/diagram-js/pull/1065))
 * `FIX`: build element copy tree in linear time ([#1066](https://github.com/bpmn-io/diagram-js/pull/1066))
 * `FIX`: improve `Elements#getParents` utility to resolve in linear time ([#1065](https://github.com/bpmn-io/diagram-js/pull/1065))
 * `FIX`: avoid layout thrashing when creating element previews ([#1063](https://github.com/bpmn-io/diagram-js/pull/1063))
 * `FIX`: resolve affected edges in move preview in linear time ([#1063](https://github.com/bpmn-io/diagram-js/pull/1063))
 * `FIX`: only re-order children when actual order changed ([#1062](https://github.com/bpmn-io/diagram-js/pull/1062))
+* `CHORE`: always return unique `Elements#selfAndChildren` results; `unique` / `allowDuplicates` flags are deprecated and ignored ([#1065](https://github.com/bpmn-io/diagram-js/pull/1065))
 
 ## 15.18.1
 

--- a/lib/features/move/MovePreview.js
+++ b/lib/features/move/MovePreview.js
@@ -59,7 +59,7 @@ export default function MovePreview(
   }
 
   function getAllDraggedElements(shapes) {
-    var allShapes = selfAndAllChildren(shapes, true);
+    var allShapes = selfAndAllChildren(shapes);
 
     var allConnections = allShapes.flatMap(shape =>
       (shape.incoming || []).concat(shape.outgoing || [])

--- a/lib/features/space-tool/SpaceTool.js
+++ b/lib/features/space-tool/SpaceTool.js
@@ -249,7 +249,7 @@ SpaceTool.prototype.init = function(event, context) {
   }
 
   var children = [
-    ...selfAndAllChildren(root, true),
+    ...selfAndAllChildren(root),
     ...(root.attachers || [])
   ];
 

--- a/lib/util/Elements.js
+++ b/lib/util/Elements.js
@@ -61,7 +61,7 @@ export function getParents(elements) {
  * @param {Object} element
  * @param {boolean} [unique]
  */
-export function add(elements, element, unique) {
+function add(elements, element, unique) {
   var canAdd = !unique || elements.indexOf(element) === -1;
 
   if (canAdd) {

--- a/lib/util/Elements.js
+++ b/lib/util/Elements.js
@@ -93,17 +93,11 @@ export function eachElement(elements, fn, depth) {
  * @return {Element[]} found elements
  */
 export function selfAndChildren(elements, unique, maxDepth) {
-  var result = [],
-      resultSet = new Set(),
+  var result = new Set(),
       processedChildren = new Set();
 
   eachElement(elements, function(element, i, depth) {
-
-    // add element unless it was already collected
-    if (!resultSet.has(element)) {
-      result.push(element);
-      resultSet.add(element);
-    }
+    result.add(element);
 
     var children = element.children;
 
@@ -119,7 +113,7 @@ export function selfAndChildren(elements, unique, maxDepth) {
     }
   });
 
-  return result;
+  return Array.from(result);
 }
 
 /**

--- a/lib/util/Elements.js
+++ b/lib/util/Elements.js
@@ -88,7 +88,7 @@ export function eachElement(elements, fn, depth) {
  *
  * @param {Element|Element[]} elements the elements to select the children from
  * @param {boolean} [unique] deprecated, ignored; the result is always unique
- * @param {number} [maxDepth] the depth to search through or -1 for infinite
+ * @param {number} maxDepth the depth to search through or -1 for infinite
  *
  * @return {Element[]} found elements
  */
@@ -127,7 +127,7 @@ export function selfAndChildren(elements, unique, maxDepth) {
  *
  * The result is always a unique set of elements (no duplicates).
  *
- * @param {Element[]} elements to query
+ * @param {Element|Element[]} elements to query
  * @param {boolean} [allowDuplicates] deprecated, ignored; the result is always unique
  *
  * @return {Element[]} the collected elements
@@ -142,7 +142,7 @@ export function selfAndDirectChildren(elements, allowDuplicates) {
  *
  * The result is always a unique set of elements (no duplicates).
  *
- * @param {Element[]} elements to query
+ * @param {Element|Element[]} elements to query
  * @param {boolean} [allowDuplicates] deprecated, ignored; the result is always unique
  *
  * @return {Element[]} the collected elements

--- a/lib/util/Elements.js
+++ b/lib/util/Elements.js
@@ -54,25 +54,6 @@ export function getParents(elements) {
 
 
 /**
- * Adds an element to a collection and returns true if the
- * element was added.
- *
- * @param {Object[]} elements
- * @param {Object} element
- * @param {boolean} [unique]
- */
-function add(elements, element, unique) {
-  var canAdd = !unique || elements.indexOf(element) === -1;
-
-  if (canAdd) {
-    elements.push(element);
-  }
-
-  return canAdd;
-}
-
-
-/**
  * Iterate over each element in a collection, calling the iterator function `fn`
  * with (element, index, recursionDepth).
  *
@@ -103,18 +84,26 @@ export function eachElement(elements, fn, depth) {
 /**
  * Collects self + child elements up to a given depth from a list of elements.
  *
+ * The result is always a unique set of elements (no duplicates).
+ *
  * @param {Element|Element[]} elements the elements to select the children from
- * @param {boolean} unique whether to return a unique result set (no duplicates)
- * @param {number} maxDepth the depth to search through or -1 for infinite
+ * @param {boolean} [unique] deprecated, ignored; the result is always unique
+ * @param {number} [maxDepth] the depth to search through or -1 for infinite
  *
  * @return {Element[]} found elements
  */
 export function selfAndChildren(elements, unique, maxDepth) {
   var result = [],
-      processedChildren = [];
+      resultSet = new Set(),
+      processedChildren = new Set();
 
   eachElement(elements, function(element, i, depth) {
-    add(result, element, unique);
+
+    // add element unless it was already collected
+    if (!resultSet.has(element)) {
+      result.push(element);
+      resultSet.add(element);
+    }
 
     var children = element.children;
 
@@ -122,7 +111,9 @@ export function selfAndChildren(elements, unique, maxDepth) {
     if (maxDepth === -1 || depth < maxDepth) {
 
       // children exist && children not yet processed
-      if (children && add(processedChildren, children, unique)) {
+      if (children && !processedChildren.has(children)) {
+        processedChildren.add(children);
+
         return children;
       }
     }
@@ -132,28 +123,32 @@ export function selfAndChildren(elements, unique, maxDepth) {
 }
 
 /**
- * Return self + direct children for a number of elements
+ * Return self + direct children for a number of elements.
+ *
+ * The result is always a unique set of elements (no duplicates).
  *
  * @param {Element[]} elements to query
- * @param {boolean} [allowDuplicates] to allow duplicates in the result set
+ * @param {boolean} [allowDuplicates] deprecated, ignored; the result is always unique
  *
  * @return {Element[]} the collected elements
  */
 export function selfAndDirectChildren(elements, allowDuplicates) {
-  return selfAndChildren(elements, !allowDuplicates, 1);
+  return selfAndChildren(elements, true, 1);
 }
 
 
 /**
- * Return self + ALL children for a number of elements
+ * Return self + ALL children for a number of elements.
+ *
+ * The result is always a unique set of elements (no duplicates).
  *
  * @param {Element[]} elements to query
- * @param {boolean} [allowDuplicates] to allow duplicates in the result set
+ * @param {boolean} [allowDuplicates] deprecated, ignored; the result is always unique
  *
  * @return {Element[]} the collected elements
  */
 export function selfAndAllChildren(elements, allowDuplicates) {
-  return selfAndChildren(elements, !allowDuplicates, -1);
+  return selfAndChildren(elements, true, -1);
 }
 
 

--- a/test/spec/util/ElementsSpec.js
+++ b/test/spec/util/ElementsSpec.js
@@ -128,6 +128,26 @@ describe('util/Elements', function() {
       expect(result.length).to.equal(6);
       expect(ids(result)).to.eql(ids([ a ].concat(a.children).concat(child.children)));
     });
+
+
+    it('should return unique elements preserving order', function() {
+
+      // given
+      // parent listed after some of its children + duplicates
+      var a = shapeA;
+
+      // when
+      var result = selfAndDirectChildren([ shapeA1, a, shapeA1, shapeA2 ]);
+
+      // then
+      // first occurrence wins, no duplicates
+      expect(ids(result)).to.eql([
+        'a.1', 'a.1.0', 'a.1.1',
+        'a', 'a.0', 'a.2',
+        'a.2.0', 'a.2.1'
+      ]);
+    });
+
   });
 
 
@@ -144,6 +164,25 @@ describe('util/Elements', function() {
 
       // then
       expect(result.length).to.equal(14);
+    });
+
+
+    it('should always return unique result', function() {
+
+      // given
+      var a = shapeA;
+
+      // when
+      // same root passed twice + a nested descendant
+      var result = selfAndAllChildren([ a, a, shapeA21 ]);
+
+      // then
+      expect(ids(result)).to.eql([
+        'a',
+        'a.0',
+        'a.1', 'a.1.0', 'a.1.1',
+        'a.2', 'a.2.0', 'a.2.1', 'a.2.1.0'
+      ]);
     });
 
   });


### PR DESCRIPTION
### Proposed Changes

* Remove internal `add` method from `Elements` - if you desire a collection utility, use the one from `Collections`, or roll your own.
* Migrate `Elements#selfAndChildren` to use `Set` internally - allows us to drop past `unique` / `allowDuplicates` behavior - we always return de-duplicated results

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
