### PR TITLE
Spacetool performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 _**Note:** Yet to be released changes appear here._
 
 * `FEAT`: defer outline rendering until needed ([#1064](https://github.com/bpmn-io/diagram-js/pull/1064))
+* `FEAT`: various improvements to improve space tool performance ([#1068](https://github.com/bpmn-io/diagram-js/pull/1068))
 * `FIX`: collect `Elements#selfAndChildren` unique results in linear time ([#1065](https://github.com/bpmn-io/diagram-js/pull/1065))
 * `FIX`: build element copy tree in linear time ([#1066](https://github.com/bpmn-io/diagram-js/pull/1066))
 * `FIX`: improve `Elements#getParents` utility to resolve in linear time ([#1065](https://github.com/bpmn-io/diagram-js/pull/1065))

--- a/lib/features/modeling/cmd/SpaceToolHandler.js
+++ b/lib/features/modeling/cmd/SpaceToolHandler.js
@@ -106,7 +106,8 @@ SpaceToolHandler.prototype.updateConnectionWaypoints = function(
     oldBounds
 ) {
   var self = this,
-      affectedShapes = movingShapes.concat(resizingShapes);
+      movingShapesSet = new Set(movingShapes),
+      resizingShapesSet = new Set(resizingShapes);
 
   forEach(connections, function(connection) {
     var source = connection.source,
@@ -115,7 +116,10 @@ SpaceToolHandler.prototype.updateConnectionWaypoints = function(
         axis = getAxisFromDirection(direction),
         layoutHints = {};
 
-    if (includes(affectedShapes, source) && includes(affectedShapes, target)) {
+    var sourceAffected = movingShapesSet.has(source) || resizingShapesSet.has(source),
+        targetAffected = movingShapesSet.has(target) || resizingShapesSet.has(target);
+
+    if (sourceAffected && targetAffected) {
 
       // move waypoints
       waypoints = map(waypoints, function(waypoint) {
@@ -137,18 +141,18 @@ SpaceToolHandler.prototype.updateConnectionWaypoints = function(
       self._modeling.updateWaypoints(connection, waypoints, {
         labelBehavior: false
       });
-    } else if (includes(affectedShapes, source) || includes(affectedShapes, target)) {
+    } else if (sourceAffected || targetAffected) {
 
       // re-layout connection with moved start/end
-      if (includes(movingShapes, source)) {
+      if (movingShapesSet.has(source)) {
         layoutHints.connectionStart = getMovedSourceAnchor(connection, source, delta);
-      } else if (includes(movingShapes, target)) {
+      } else if (movingShapesSet.has(target)) {
         layoutHints.connectionEnd = getMovedTargetAnchor(connection, target, delta);
-      } else if (includes(resizingShapes, source)) {
+      } else if (resizingShapesSet.has(source)) {
         layoutHints.connectionStart = getResizedSourceAnchor(
           connection, source, oldBounds[source.id]
         );
-      } else if (includes(resizingShapes, target)) {
+      } else if (resizingShapesSet.has(target)) {
         layoutHints.connectionEnd = getResizedTargetAnchor(
           connection, target, oldBounds[target.id]
         );
@@ -200,10 +204,6 @@ function shouldMoveWaypoint(waypoint, start, direction) {
   } else if (/n|w/.test(direction)) {
     return waypoint[ relevantAxis ] < start;
   }
-}
-
-function includes(array, item) {
-  return array.indexOf(item) !== -1;
 }
 
 function getBounds(shape) {

--- a/lib/features/space-tool/SpaceTool.js
+++ b/lib/features/space-tool/SpaceTool.js
@@ -296,24 +296,30 @@ SpaceTool.prototype.calculateAdjustments = function(elements, axis, delta, start
   var movingShapes = [],
       resizingShapes = [];
 
+  var movingShapesSet = new Set(),
+      resizingShapesSet = new Set();
+
   var attachers = [],
       connections = [];
 
   function moveShape(shape) {
-    if (!movingShapes.includes(shape)) {
+    if (!movingShapesSet.has(shape)) {
+      movingShapesSet.add(shape);
       movingShapes.push(shape);
     }
 
     var label = shape.label;
 
     // move external label if its label target is moving
-    if (label && !movingShapes.includes(label)) {
+    if (label && !movingShapesSet.has(label)) {
+      movingShapesSet.add(label);
       movingShapes.push(label);
     }
   }
 
   function resizeShape(shape) {
-    if (!resizingShapes.includes(shape)) {
+    if (!resizingShapesSet.has(shape)) {
+      resizingShapesSet.add(shape);
       resizingShapes.push(shape);
     }
   }
@@ -372,18 +378,14 @@ SpaceTool.prototype.calculateAdjustments = function(elements, axis, delta, start
     }
   });
 
-  var allShapes = movingShapes.concat(resizingShapes);
-
   // move attacher if its mid is after space tool and its host is moving or resizing
   forEach(attachers, function(attacher) {
     var host = attacher.host;
 
-    if (includes(allShapes, host)) {
+    if (movingShapesSet.has(host) || resizingShapesSet.has(host)) {
       moveShape(attacher);
     }
   });
-
-  allShapes = movingShapes.concat(resizingShapes);
 
   // move external label if its label target's (connection) source and target are moving
   forEach(connections, function(connection) {
@@ -391,8 +393,8 @@ SpaceTool.prototype.calculateAdjustments = function(elements, axis, delta, start
         target = connection.target,
         label = connection.label;
 
-    if (includes(allShapes, source)
-      && includes(allShapes, target)
+    if ((movingShapesSet.has(source) || resizingShapesSet.has(source))
+      && (movingShapesSet.has(target) || resizingShapesSet.has(target))
       && label) {
       moveShape(label);
     }

--- a/lib/features/space-tool/SpaceTool.js
+++ b/lib/features/space-tool/SpaceTool.js
@@ -489,6 +489,9 @@ function getSpaceToolConstraints(elements, axis, direction, start, minDimensions
       min,
       max;
 
+  var movingShapesSet = new Set(movingShapes),
+      resizingShapesSet = new Set(resizingShapes);
+
   forEach(resizingShapes, function(resizingShape) {
     var attachers = resizingShape.attachers,
         children = resizingShape.children;
@@ -499,13 +502,13 @@ function getSpaceToolConstraints(elements, axis, direction, start, minDimensions
     var nonMovingResizingChildren = filter(children, function(child) {
       return !isConnection(child) &&
         !isLabel(child) &&
-        !includes(movingShapes, child) &&
-        !includes(resizingShapes, child);
+        !movingShapesSet.has(child) &&
+        !resizingShapesSet.has(child);
     });
 
     // find children that are moving
     var movingChildren = filter(children, function(child) {
-      return !isConnection(child) && !isLabel(child) && includes(movingShapes, child);
+      return !isConnection(child) && !isLabel(child) && movingShapesSet.has(child);
     });
 
     var minOrMax,
@@ -556,7 +559,7 @@ function getSpaceToolConstraints(elements, axis, direction, start, minDimensions
 
     if (attachers && attachers.length) {
       attachers.forEach(function(attacher) {
-        if (includes(movingShapes, attacher)) {
+        if (movingShapesSet.has(attacher)) {
           movingAttachers.push(attacher);
         } else {
           nonMovingAttachers.push(attacher);
@@ -629,10 +632,6 @@ function getSpaceToolConstraints(elements, axis, direction, start, minDimensions
   });
 
   return spaceToolConstraints;
-}
-
-function includes(array, item) {
-  return array.indexOf(item) !== -1;
 }
 
 function isAttacher(element) {

--- a/lib/features/space-tool/SpaceToolPreview.js
+++ b/lib/features/space-tool/SpaceToolPreview.js
@@ -132,53 +132,30 @@ export default function SpaceToolPreview(
       // shapes
       addPreviewGfx(movingShapes, dragGroup);
 
-      // connections
-      var movingConnections = context.movingConnections = elementRegistry.filter(function(element) {
-        var sourceIsMoving = false;
+      // connections whose source *and* target are moving or resizing
+      var adjustedShapes = new Set(movingShapes);
 
-        forEach(movingShapes, function(shape) {
-          forEach(shape.outgoing, function(connection) {
-            if (element === connection) {
-              sourceIsMoving = true;
-            }
-          });
-        });
-
-        var targetIsMoving = false;
-
-        forEach(movingShapes, function(shape) {
-          forEach(shape.incoming, function(connection) {
-            if (element === connection) {
-              targetIsMoving = true;
-            }
-          });
-        });
-
-        var sourceIsResizing = false;
-
-        forEach(resizingShapes, function(shape) {
-          forEach(shape.outgoing, function(connection) {
-            if (element === connection) {
-              sourceIsResizing = true;
-            }
-          });
-        });
-
-        var targetIsResizing = false;
-
-        forEach(resizingShapes, function(shape) {
-          forEach(shape.incoming, function(connection) {
-            if (element === connection) {
-              targetIsResizing = true;
-            }
-          });
-        });
-
-        return isConnection(element)
-          && (sourceIsMoving || sourceIsResizing)
-          && (targetIsMoving || targetIsResizing);
+      forEach(resizingShapes, function(shape) {
+        adjustedShapes.add(shape);
       });
 
+      var seenConnections = new Set();
+
+      var movingConnections = context.movingConnections = [];
+
+      adjustedShapes.forEach(function(shape) {
+        forEach(shape.outgoing, function(connection) {
+          if (seenConnections.has(connection)
+            || !isConnection(connection)
+            || !adjustedShapes.has(connection.target)) {
+            return;
+          }
+
+          seenConnections.add(connection);
+
+          movingConnections.push(connection);
+        });
+      });
 
       addPreviewGfx(movingConnections, dragGroup);
 

--- a/lib/features/space-tool/SpaceUtil.js
+++ b/lib/features/space-tool/SpaceUtil.js
@@ -55,7 +55,15 @@ export function getDirection(axis, delta) {
 export function getWaypointsUpdatingConnections(movingShapes, resizingShapes) {
   var waypointsUpdatingConnections = [];
 
-  forEach(movingShapes.concat(resizingShapes), function(shape) {
+  var adjustedShapes = new Set(movingShapes);
+
+  forEach(resizingShapes, function(shape) {
+    adjustedShapes.add(shape);
+  });
+
+  var seenConnections = new Set();
+
+  adjustedShapes.forEach(function(shape) {
     var incoming = shape.incoming,
         outgoing = shape.outgoing;
 
@@ -63,12 +71,11 @@ export function getWaypointsUpdatingConnections(movingShapes, resizingShapes) {
       var source = connection.source,
           target = connection.target;
 
-      if (includes(movingShapes, source) ||
-        includes(movingShapes, target) ||
-        includes(resizingShapes, source) ||
-        includes(resizingShapes, target)) {
+      if (adjustedShapes.has(source) || adjustedShapes.has(target)) {
 
-        if (!includes(waypointsUpdatingConnections, connection)) {
+        if (!seenConnections.has(connection)) {
+          seenConnections.add(connection);
+
           waypointsUpdatingConnections.push(connection);
         }
       }
@@ -76,10 +83,6 @@ export function getWaypointsUpdatingConnections(movingShapes, resizingShapes) {
   });
 
   return waypointsUpdatingConnections;
-}
-
-function includes(array, item) {
-  return array.indexOf(item) !== -1;
 }
 
 /**


### PR DESCRIPTION
### Proposed Changes

This PR addresses several issues that previously made space tool super-linear:

* Resolve moving connections in linear time
* Use sets for shape membership in calculateAdjustments
* Use sets for membership in constraint/connection resolution

This turns space tool (preview) into a _linear_ operation:

| size | elements | before | after (this PR) | total speedup |
|------|----------|--------------------|-----------------------|---------------|
| S    | 1049     | 595.2              | 268.4                 | 2.2x          |
| M    | 4099     | 5203.1            | 1336.3                | 3.9x          |
| L    | 8099     | 20285.9          | 2802.6                | 7.2x          |


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
