### PR TITLE
Migrate space tool post space computation to Set logic

### DIFF
--- a/lib/features/modeling/cmd/SpaceToolHandler.js
+++ b/lib/features/modeling/cmd/SpaceToolHandler.js
@@ -106,7 +106,8 @@ SpaceToolHandler.prototype.updateConnectionWaypoints = function(
     oldBounds
 ) {
   var self = this,
-      affectedShapes = movingShapes.concat(resizingShapes);
+      movingShapesSet = new Set(movingShapes),
+      resizingShapesSet = new Set(resizingShapes);
 
   forEach(connections, function(connection) {
     var source = connection.source,
@@ -115,7 +116,10 @@ SpaceToolHandler.prototype.updateConnectionWaypoints = function(
         axis = getAxisFromDirection(direction),
         layoutHints = {};
 
-    if (includes(affectedShapes, source) && includes(affectedShapes, target)) {
+    var sourceAffected = movingShapesSet.has(source) || resizingShapesSet.has(source),
+        targetAffected = movingShapesSet.has(target) || resizingShapesSet.has(target);
+
+    if (sourceAffected && targetAffected) {
 
       // move waypoints
       waypoints = map(waypoints, function(waypoint) {
@@ -137,18 +141,18 @@ SpaceToolHandler.prototype.updateConnectionWaypoints = function(
       self._modeling.updateWaypoints(connection, waypoints, {
         labelBehavior: false
       });
-    } else if (includes(affectedShapes, source) || includes(affectedShapes, target)) {
+    } else if (sourceAffected || targetAffected) {
 
       // re-layout connection with moved start/end
-      if (includes(movingShapes, source)) {
+      if (movingShapesSet.has(source)) {
         layoutHints.connectionStart = getMovedSourceAnchor(connection, source, delta);
-      } else if (includes(movingShapes, target)) {
+      } else if (movingShapesSet.has(target)) {
         layoutHints.connectionEnd = getMovedTargetAnchor(connection, target, delta);
-      } else if (includes(resizingShapes, source)) {
+      } else if (resizingShapesSet.has(source)) {
         layoutHints.connectionStart = getResizedSourceAnchor(
           connection, source, oldBounds[source.id]
         );
-      } else if (includes(resizingShapes, target)) {
+      } else if (resizingShapesSet.has(target)) {
         layoutHints.connectionEnd = getResizedTargetAnchor(
           connection, target, oldBounds[target.id]
         );
@@ -200,10 +204,6 @@ function shouldMoveWaypoint(waypoint, start, direction) {
   } else if (/n|w/.test(direction)) {
     return waypoint[ relevantAxis ] < start;
   }
-}
-
-function includes(array, item) {
-  return array.indexOf(item) !== -1;
 }
 
 function getBounds(shape) {


### PR DESCRIPTION
### Proposed Changes

Companion to https://github.com/bpmn-io/diagram-js/pull/1068 - Turns post space operation on the mdoel to `O(n)` over the previous `O(n^2)` (due to excessive large list traversal).

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
