### PR TITLE
chore(selection): migrate internal representation to Set

### DIFF
--- a/lib/features/selection/Selection.js
+++ b/lib/features/selection/Selection.js
@@ -21,9 +21,9 @@ export default function Selection(eventBus, canvas) {
   this._canvas = canvas;
 
   /**
-   * @type {Object[]}
+   * @type {Set<Object>}
    */
-  this._selectedElements = [];
+  this._selectedElements = new Set();
 
   var self = this;
 
@@ -45,17 +45,18 @@ Selection.$inject = [ 'eventBus', 'canvas' ];
  * @param {Object} element The element to deselect.
  */
 Selection.prototype.deselect = function(element) {
-  var selectedElements = this._selectedElements;
-
-  var idx = selectedElements.indexOf(element);
-
-  if (idx !== -1) {
-    var oldSelection = selectedElements.slice();
-
-    selectedElements.splice(idx, 1);
-
-    this._eventBus.fire('selection.changed', { oldSelection: oldSelection, newSelection: selectedElements });
+  if (!this._selectedElements.has(element)) {
+    return;
   }
+
+  var oldSelection = this.get();
+
+  this._selectedElements.delete(element);
+
+  this._eventBus.fire('selection.changed', {
+    oldSelection: oldSelection,
+    newSelection: this.get()
+  });
 };
 
 /**
@@ -64,7 +65,7 @@ Selection.prototype.deselect = function(element) {
  * @return {Object[]} The selected elements.
  */
 Selection.prototype.get = function() {
-  return this._selectedElements;
+  return Array.from(this._selectedElements);
 };
 
 /**
@@ -75,7 +76,7 @@ Selection.prototype.get = function() {
  * @return {boolean} Whether the element is selected.
  */
 Selection.prototype.isSelected = function(element) {
-  return this._selectedElements.indexOf(element) !== -1;
+  return this._selectedElements.has(element);
 };
 
 
@@ -87,8 +88,7 @@ Selection.prototype.isSelected = function(element) {
  * Defaults to `false`.
  */
 Selection.prototype.select = function(elements, add) {
-  var selectedElements = this._selectedElements,
-      oldSelection = selectedElements.slice();
+  var oldSelection = this.get();
 
   if (!isArray(elements)) {
     elements = elements ? [ elements ] : [];
@@ -107,18 +107,15 @@ Selection.prototype.select = function(elements, add) {
   // selection may be cleared by passing an empty array or null
   // to the method
   if (add) {
-    forEach(elements, function(element) {
-      if (selectedElements.indexOf(element) !== -1) {
-
-        // already selected
-        return;
-      } else {
-        selectedElements.push(element);
-      }
+    forEach(elements, element => {
+      this._selectedElements.add(element);
     });
   } else {
-    this._selectedElements = selectedElements = elements.slice();
+    this._selectedElements = new Set(elements);
   }
 
-  this._eventBus.fire('selection.changed', { oldSelection: oldSelection, newSelection: selectedElements });
+  this._eventBus.fire('selection.changed', {
+    oldSelection: oldSelection,
+    newSelection: this.get()
+  });
 };

--- a/lib/features/selection/SelectionVisuals.js
+++ b/lib/features/selection/SelectionVisuals.js
@@ -1,7 +1,3 @@
-import {
-  forEach
-} from 'min-dash';
-
 /**
  * @typedef {import('../../core/Canvas.js').default} Canvas
  * @typedef {import('../../core/EventBus.js').default} EventBus
@@ -50,20 +46,20 @@ export default function SelectionVisuals(canvas, eventBus) {
       addMarker(s, MARKER_SELECTED);
     }
 
-    var oldSelection = event.oldSelection,
-        newSelection = event.newSelection;
+    var oldSelection = new Set(event.oldSelection),
+        newSelection = new Set(event.newSelection);
 
-    forEach(oldSelection, function(e) {
-      if (newSelection.indexOf(e) === -1) {
+    for (let e of oldSelection) {
+      if (!newSelection.has(e)) {
         deselect(e);
       }
-    });
+    }
 
-    forEach(newSelection, function(e) {
-      if (oldSelection.indexOf(e) === -1) {
+    for (let e of newSelection) {
+      if (!oldSelection.has(e)) {
         select(e);
       }
-    });
+    }
   });
 }
 


### PR DESCRIPTION
### Proposed Changes

> [!NOTE]
> This is nice to have but not critical, cf. analysis below. Especially with _very small_ diagrams there is no measurable impact on linear scanning - `Set(someArray)` performs worse there.

Selection is backed of a Set - so add / remove computations happen in linear time.

This is impactful in huge diagrams - where SELECT ALL performance would otherwise be impacted super-linear due to excessive looping.

### Benchmark

Measured baseline (pre-`Set`) vs patched:

| op | size | baseline | patched | delta |
|---|---|---:|---:|---|
| `isSelected` (N probes) | S ~1k | 0.3ms | 0.2ms | |
| | M ~4k | 0.5ms | 0.3ms | |
| | L ~8k | 1.5ms | 0.6ms | **~2.5× faster** |
| `reselect all` (full `selection.changed` diff) | S ~1k | 5.0ms | 2.4ms | |
| | M ~4k | 19.2ms | 11.7ms | |
| | L ~8k | 32.5ms | 24.5ms | **~25% faster** |
| `select all` (dominated by outline DOM) | L ~8k | 744ms | 725ms | ~flat |

### Interpretation
- **`isSelected` is now O(1)** and clearly scales better than the old linear scan.
- **`reselect all`** (pure diff, no marker changes) is consistently faster; its remaining
  cost is dominated by `select`'s `canvas.findRoot` filter (O(N) parent walks), not
  membership. The quadratic worst-case is removed.
- **`select all`** is dominated by per-element outline/marker DOM work — unaffected, as
  expected.
- At ≤8k elements the membership scans were **not** a dominant bottleneck; the change is a
  safe, free improvement that removes the quadratic worst-case for even larger diagrams.
- No regressions.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
