### PR TITLE
Further (minor) adjustments to improve `create` and `move` operations in large diagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,16 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 _**Note:** Yet to be released changes appear here._
 
 * `FEAT`: defer outline rendering until needed ([#1064](https://github.com/bpmn-io/diagram-js/pull/1064))
-* `FEAT`: various improvements to improve space tool performance ([#1068](https://github.com/bpmn-io/diagram-js/pull/1068))
-* `FIX`: collect `Elements#selfAndChildren` unique results in linear time ([#1065](https://github.com/bpmn-io/diagram-js/pull/1065))
-* `FIX`: build element copy tree in linear time ([#1066](https://github.com/bpmn-io/diagram-js/pull/1066))
-* `FIX`: improve `Elements#getParents` utility to resolve in linear time ([#1065](https://github.com/bpmn-io/diagram-js/pull/1065))
-* `FIX`: avoid layout thrashing when creating element previews ([#1063](https://github.com/bpmn-io/diagram-js/pull/1063))
-* `FIX`: resolve affected edges in move preview in linear time ([#1063](https://github.com/bpmn-io/diagram-js/pull/1063))
 * `FIX`: only re-order children when actual order changed ([#1062](https://github.com/bpmn-io/diagram-js/pull/1062))
 * `FIX`: do not show floating bendpoint at `(0|0)` position ([#1061](https://github.com/bpmn-io/diagram-js/pull/1061))
+* `CHORE`: build element copy tree in linear time ([#1066](https://github.com/bpmn-io/diagram-js/pull/1066))
+* `CHORE`: collect `Elements#selfAndChildren` unique results in linear time ([#1065](https://github.com/bpmn-io/diagram-js/pull/1065))
 * `CHORE`: always return unique `Elements#selfAndChildren` results; `unique` / `allowDuplicates` flags are deprecated and ignored ([#1065](https://github.com/bpmn-io/diagram-js/pull/1065))
+* `CHORE`: improve `Elements#getParents` utility to resolve in linear time ([#1065](https://github.com/bpmn-io/diagram-js/pull/1065))
+* `CHORE`: avoid layout thrashing when creating element previews ([#1063](https://github.com/bpmn-io/diagram-js/pull/1063))
+* `CHORE`: resolve affected edges in move preview in linear time ([#1063](https://github.com/bpmn-io/diagram-js/pull/1063))
+* `CHORE`: various improvements to improve space tool performance ([#1068](https://github.com/bpmn-io/diagram-js/pull/1068))
+* `CHORE`: minor performance improvements to label support and element creation ([#1071](https://github.com/bpmn-io/diagram-js/pull/1071))
 
 ## 15.18.1
 

--- a/lib/features/label-support/LabelSupport.js
+++ b/lib/features/label-support/LabelSupport.js
@@ -56,28 +56,26 @@ export default function LabelSupport(injector, eventBus, modeling) {
   movePreview && eventBus.on('shape.move.start', LOW_PRIORITY, function(e) {
 
     var context = e.context,
-        shapes = context.shapes;
+        shapeSet = new Set(context.shapes),
+        labelSet = new Set();
 
-    var labels = [];
+    for (const shape of shapeSet) {
 
-    forEach(shapes, function(element) {
+      for (const label of shape.labels) {
 
-      forEach(element.labels, function(label) {
-
-        if (!label.hidden && context.shapes.indexOf(label) === -1) {
-          labels.push(label);
+        if (!label.hidden && !shapeSet.has(label)) {
+          labelSet.add(label);
         }
 
-        if (element.labelTarget) {
-          labels.push(element);
+        if (shape.labelTarget) {
+          labelSet.add(shape);
         }
-      });
-    });
+      }
+    }
 
-    forEach(labels, function(label) {
+    for (const label of labelSet) {
       movePreview.makeDraggable(context, label, true);
-    });
-
+    }
   });
 
   // add all labels to move closure
@@ -168,11 +166,12 @@ LabelSupport.$inject = [
  * @return {Element[]} filtered
  */
 function removeLabels(elements) {
+  var elementsSet = new Set(elements);
 
   return filter(elements, function(element) {
 
     // filter out labels that are move together
     // with their label targets
-    return elements.indexOf(element.labelTarget) === -1;
+    return !elementsSet.has(element.labelTarget);
   });
 }

--- a/lib/features/modeling/cmd/CreateElementsHandler.js
+++ b/lib/features/modeling/cmd/CreateElementsHandler.js
@@ -79,7 +79,7 @@ CreateElementsHandler.prototype.preExecute = function(context) {
     });
   });
 
-  var parents = getParents(elements);
+  var parentsSet = new Set(getParents(elements));
 
   var cache = {};
 
@@ -107,7 +107,7 @@ CreateElementsHandler.prototype.preExecute = function(context) {
 
     var createShapeHints = assign({}, hints);
 
-    if (parents.indexOf(element) === -1) {
+    if (!parentsSet.has(element)) {
       createShapeHints.autoResize = false;
     }
 


### PR DESCRIPTION
### Proposed Changes

> [!NOTE]
> This is nice to have but not critical. Especially with _very small_ diagrams there is no measurable impact on linear scanning - `Set(someArray)` performs worse there.

Adds adjustments that would otherwise `O(n^2)` - negatively impacting create and move operations in larger diagrams:

* Preview: Label support remove label now linear
* Modeling: Create parent check now linear

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
