### PR TITLE
fix(PopupMenu): position doc icon top right

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -681,10 +681,32 @@
   text-decoration: none;
 }
 
-.djs-popup-entry-chevron {
+.djs-popup-entry-actions {
+  container-type: size;
+  position: relative;
+  align-self: stretch;
+  width: 34px;
+  margin-left: 6px;
+}
+
+.djs-popup-entry-actions-inner {
+  position: absolute;
+  inset: 0;
   display: flex;
   align-items: center;
-  margin-left: 6px;
+  justify-content: center;
+  gap: 2px;
+}
+
+.djs-popup-entry-action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+}
+
+.djs-popup-entry-chevron {
   color: var(--popup-description-color);
 }
 
@@ -816,20 +838,36 @@
 }
 
 .djs-popup-entry-docs {
-  display: none;
-  margin-left: 3px;
+  visibility: hidden;
   color: var(--popup-description-color);
+}
+
+.djs-popup-entry-actions-spacer {
+  display: none;
+  width: 0;
+  height: 16px;
 }
 
 .djs-popup-body .entry:focus-within .djs-popup-entry-docs,
 .djs-popup-body .entry:focus .djs-popup-entry-docs,
 .djs-popup-body .entry:hover .djs-popup-entry-docs {
-  display: inline;
+  visibility: visible;
 }
 
-.djs-popup-entry-docs svg {
-  vertical-align: middle;
-  margin: 2px;
+@container (min-height: 34px) {
+  .djs-popup-entry-actions-inner {
+    flex-direction: column;
+    align-items: flex-end;
+  }
+
+  .djs-popup-entry-docs {
+    margin-bottom: auto;
+  }
+
+  .djs-popup-entry-actions-spacer {
+    display: block;
+    margin-top: auto;
+  }
 }
 
 /**

--- a/lib/features/popup-menu/PopupMenuItem.js
+++ b/lib/features/popup-menu/PopupMenuItem.js
@@ -66,9 +66,20 @@ export default function PopupMenuItem(props) {
               ${ entry.label }
             </span>
           ` : null }
-
+        </span>
+        ${ entry.description && html`
+          <span
+            class="djs-popup-entry-description"
+          >
+            ${ entry.description }
+          </span>
+        ` }
+      </div>
+      ${ (entry.documentationRef || entry.entries) && html`
+        <div class="djs-popup-entry-actions">
+          <div class="djs-popup-entry-actions-inner">
           ${ entry.documentationRef && html`
-            <a class="djs-popup-entry-docs"
+            <a class="djs-popup-entry-action djs-popup-entry-docs"
               href=${ entry.documentationRef }
               onClick=${ (event) => event.stopPropagation() }
               title="Open element documentation"
@@ -81,20 +92,17 @@ export default function PopupMenuItem(props) {
               </svg>
             </a>
           ` }
-        </span>
-        ${ entry.description && html`
-          <span
-            class="djs-popup-entry-description"
-          >
-            ${ entry.description }
-          </span>
-        ` }
-      </div>
-      ${ entry.entries && html`
-        <div class="djs-popup-entry-chevron" aria-hidden="true">
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M3.96967 1.46967C4.26256 1.17678 4.73744 1.17678 5.03033 1.46967L9.03033 5.46967C9.32322 5.76256 9.32322 6.23744 9.03033 6.53033L5.03033 10.5303C4.73744 10.8232 4.26256 10.8232 3.96967 10.5303C3.67678 10.2374 3.67678 9.76256 3.96967 9.46967L7.43934 6L3.96967 2.53033C3.67678 2.23744 3.67678 1.76256 3.96967 1.46967Z" fill="currentColor"/>
-          </svg>
+          ${ entry.entries && html`
+            <div class="djs-popup-entry-action djs-popup-entry-chevron" aria-hidden="true">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path fill-rule="evenodd" clip-rule="evenodd" d="M3.96967 1.46967C4.26256 1.17678 4.73744 1.17678 5.03033 1.46967L9.03033 5.46967C9.32322 5.76256 9.32322 6.23744 9.03033 6.53033L5.03033 10.5303C4.73744 10.8232 4.26256 10.8232 3.96967 10.5303C3.67678 10.2374 3.67678 9.76256 3.96967 9.46967L7.43934 6L3.96967 2.53033C3.67678 2.23744 3.67678 1.76256 3.96967 1.46967Z" fill="currentColor"/>
+              </svg>
+            </div>
+          ` }
+          ${ entry.documentationRef && html`
+            <div class="djs-popup-entry-actions-spacer" aria-hidden="true"></div>
+          ` }
+          </div>
         </div>
       ` }
     </li>


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/6027

### Proposed Changes

Consistently position the doc icon in the top right corner of an entry, or inline with the chevron if one-line.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/2533edea-6f86-4c76-a2f8-d0574f585b29" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/abc65302-f54f-438a-832d-595018cacb6e" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/0dbf3f64-8056-4ad0-ac50-fbf29c4d0719" />

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
