### PR TITLE
feat(popup-menu): only scroll into view on keyboard selection

### DIFF
--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -128,6 +128,13 @@ export default function PopupMenuComponent(props) {
   const [ selectedEntry, setSelectedEntry ] = useState(entriesToShow[0]);
   const restoreSelection = useRef(null);
 
+  /**
+   * Whether the current selection was made through keyboard navigation.
+   *
+   * @type {import('@bpmn-io/diagram-js-ui').Ref<boolean>}
+   */
+  const keyboardSelection = useRef(false);
+
   useEffect(() => {
     const restore = restoreSelection.current;
 
@@ -155,15 +162,21 @@ export default function PopupMenuComponent(props) {
       nextIdx = 0;
     }
 
+    keyboardSelection.current = true;
+
     setSelectedEntry(entries[nextIdx]);
   }, [ groupedEntries, selectedEntry ]);
 
   const keyboardDrilldown = useCallback((direction) => {
     if (direction > 0 && selectedEntry && selectedEntry.entries) {
+      keyboardSelection.current = true;
+
       setNavigationStack(stack => [ ...stack, selectedEntry ]);
     }
 
     if (direction < 0 && navigationStack.length > 0) {
+      keyboardSelection.current = true;
+
       restoreSelection.current = navigationStack[navigationStack.length + direction];
       setNavigationStack(stack => stack.slice(0, direction));
     }
@@ -293,6 +306,7 @@ export default function PopupMenuComponent(props) {
             groupedEntries=${ groupedEntries }
             selectedEntry=${ selectedEntry }
             setSelectedEntry=${ setSelectedEntry }
+            keyboardSelection=${ keyboardSelection }
             onAction=${ handleEntryAction }
           />
         </div>

--- a/lib/features/popup-menu/PopupMenuList.js
+++ b/lib/features/popup-menu/PopupMenuList.js
@@ -31,9 +31,7 @@ export default function PopupMenuList(props) {
 
   const resultsRef = useRef();
 
-  // scroll selected entry into view, but only when it was selected through
-  // keyboard navigation; scrolling on mouse hover would move entries away
-  // from under the pointer
+  // scroll selected entry into view when navigating by keyboard
   useLayoutEffect(() => {
     if (!keyboardSelection || !keyboardSelection.current) {
       return;

--- a/lib/features/popup-menu/PopupMenuList.js
+++ b/lib/features/popup-menu/PopupMenuList.js
@@ -18,19 +18,29 @@ import PopupMenuItem from './PopupMenuItem.js';
  * @param {PopupMenuGroup[]} props.groupedEntries
  * @param {PopupMenuEntry} props.selectedEntry
  * @param {(entry: PopupMenuEntry | null) => void} props.setSelectedEntry
+ * @param {import('@bpmn-io/diagram-js-ui').Ref<boolean>} props.keyboardSelection
  */
 export default function PopupMenuList(props) {
   const {
     selectedEntry,
     setSelectedEntry,
     groupedEntries,
+    keyboardSelection,
     ...restProps
   } = props;
 
   const resultsRef = useRef();
 
-  // scroll to selected result
+  // scroll selected entry into view, but only when it was selected through
+  // keyboard navigation; scrolling on mouse hover would move entries away
+  // from under the pointer
   useLayoutEffect(() => {
+    if (!keyboardSelection || !keyboardSelection.current) {
+      return;
+    }
+
+    keyboardSelection.current = false;
+
     const containerEl = resultsRef.current;
 
     if (!containerEl)

--- a/test/spec/features/popup-menu/PopupMenuSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuSpec.js
@@ -1485,6 +1485,119 @@ describe('features/popup-menu', function() {
   });
 
 
+  describe('scroll selected into view', function() {
+
+    afterEach(restore);
+
+
+    var entries = [
+      { id: '1', label: 'Entry 1' },
+      { id: '2', label: 'Entry 2' },
+      { id: '3', label: 'Entry 3' }
+    ];
+
+    var testMenuProvider = {
+      getEntries: function() {
+        return entries;
+      }
+    };
+
+
+    it('should NOT scroll on open', inject(async function(popupMenu) {
+
+      // given
+      var scrollSpy = spyScrollIntoView();
+
+      popupMenu.registerProvider('test-menu', testMenuProvider);
+
+      // when
+      await act(function() {
+        popupMenu.open({}, 'test-menu', { x: 100, y: 100 });
+      });
+
+      // then
+      expect(scrollSpy).not.to.have.been.called;
+    }));
+
+
+    it('should scroll on keyboard navigation', inject(async function(popupMenu) {
+
+      // given
+      popupMenu.registerProvider('test-menu', testMenuProvider);
+
+      await act(function() {
+        popupMenu.open({}, 'test-menu', { x: 100, y: 100 });
+      });
+
+      var scrollSpy = spyScrollIntoView();
+
+      // when
+      await act(function() {
+        queryPopup('.djs-popup').dispatchEvent(keyDown('ArrowDown'));
+      });
+
+      // then
+      await expectSelected('Entry 2');
+
+      expect(scrollSpy).to.have.been.called;
+    }));
+
+
+    it('should NOT scroll on mouse hover', inject(async function(popupMenu) {
+
+      // given
+      popupMenu.registerProvider('test-menu', testMenuProvider);
+
+      await act(function() {
+        popupMenu.open({}, 'test-menu', { x: 100, y: 100 });
+      });
+
+      var scrollSpy = spyScrollIntoView();
+
+      // when
+      await act(function() {
+        queryEntry('3').dispatchEvent(new MouseEvent('mouseenter'));
+      });
+
+      // then
+      await expectSelected('Entry 3');
+
+      expect(scrollSpy).not.to.have.been.called;
+    }));
+
+
+    it('should NOT scroll on mouse hover after keyboard navigation', inject(async function(popupMenu) {
+
+      // given
+      popupMenu.registerProvider('test-menu', testMenuProvider);
+
+      await act(function() {
+        popupMenu.open({}, 'test-menu', { x: 100, y: 100 });
+      });
+
+      // navigate with keyboard first
+      await act(function() {
+        queryPopup('.djs-popup').dispatchEvent(keyDown('ArrowDown'));
+      });
+
+      await expectSelected('Entry 2');
+
+      var scrollSpy = spyScrollIntoView();
+
+      // when
+      await act(function() {
+        queryEntry('3').dispatchEvent(new MouseEvent('mouseenter'));
+      });
+
+      // then
+      await expectSelected('Entry 3');
+
+      expect(scrollSpy).not.to.have.been.called;
+    }));
+
+  });
+
+
   describe('search', function() {
 
     var testMenuProvider = {
@@ -3086,6 +3199,30 @@ async function expectSelected(expectedSelectedEntryLabel) {
  */
 function keyUp(key) {
   return new KeyboardEvent('keyup', { key, bubbles: true });
+}
+
+/**
+ * @param {string} key
+ *
+ * @return {KeyboardEvent}
+ */
+function keyDown(key) {
+  return new KeyboardEvent('keydown', { key, bubbles: true });
+}
+
+/**
+ * Spy on the scroll-into-view mechanism used by the popup menu list.
+ *
+ * @return {import('sinon').SinonSpy}
+ */
+function spyScrollIntoView() {
+  var proto = window.HTMLElement.prototype;
+
+  var method = typeof proto.scrollIntoViewIfNeeded === 'function'
+    ? 'scrollIntoViewIfNeeded'
+    : 'scrollIntoView';
+
+  return spy(proto, method);
 }
 
 /**


### PR DESCRIPTION
### Proposed Changes

This PR ensures that scroll into view behavior by popup menu is only executed when keyboard navigation is happening - it otherwise causes annoying glitches when the user scrolls with mouse on the top / bottom of the popup menu.

#### Old

<img width="805" height="664" alt="capture IoHVaq_optimized" src="https://github.com/user-attachments/assets/2b31c8a8-ba45-438a-87d3-4cc4fee3ca32" />

#### Fixed (new :sparkles:)

<img width="709" height="664" alt="capture wrBEqX_optimized" src="https://github.com/user-attachments/assets/a34badd9-1397-4342-964d-b3596ba5da75" />

---

Try out via

```
npx @bpmn-io/sr bpmn-io/bpmn-js -l bpmn-io/diagram-js#scroll-view-keyboard-selection
```

---

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
