### PR TITLE
Allow `Canvas#scrollToElement` and `Canvas#findRoot` to handle multiple elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+* `FEAT`: allow `Canvas#findRoot` to find shared root for multiple elements ([#1075](https://github.com/bpmn-io/diagram-js/pull/1075))
+
 ## 15.19.0
 
 _Improves rendering and editing of larger diagrams significantly._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 _**Note:** Yet to be released changes appear here._
 
 * `FEAT`: allow `Canvas#findRoot` to find shared root for multiple elements ([#1075](https://github.com/bpmn-io/diagram-js/pull/1075))
+* `FEAT`: support scrolling to multiple elements via `Canvas#scrollToElement` ([#1075](https://github.com/bpmn-io/diagram-js/pull/1075))
 
 ## 15.19.0
 

--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -6,7 +6,8 @@ import {
   debounce,
   bind,
   reduce,
-  find
+  find,
+  isArray
 } from 'min-dash';
 
 import {
@@ -582,9 +583,7 @@ Canvas.prototype.getActiveLayer = function() {
  * @return {RootLike|undefined} The root of the element.
  */
 Canvas.prototype.findRoot = function(element) {
-  if (typeof element === 'string') {
-    element = this._elementRegistry.get(element);
-  }
+  element = this._resolveElement(element);
 
   if (!element) {
     return;
@@ -614,6 +613,33 @@ Canvas.prototype._findPlaneForRoot = function(rootElement) {
   });
 };
 
+/**
+ * @param {ElementOrIdentifier} element
+ *
+ * @return {ShapeLike|ConnectionLike|RootLike|undefined}
+ */
+Canvas.prototype._resolveElement = function(element) {
+
+  if (typeof element === 'string') {
+    return this._elementRegistry.get(element);
+  }
+
+  return element;
+};
+
+/**
+ * @param {ElementOrIdentifier|ElementOrIdentifier[]} elements
+ *
+ * @return {Array<ShapeLike|ConnectionLike|RootLike>}
+ */
+Canvas.prototype._resolveElements = function(elements) {
+
+  if (!isArray(elements)) {
+    elements = [ elements ];
+  }
+
+  return elements.map(element => this._resolveElement(element)).filter(Boolean);
+};
 
 /**
  * Returns the html element that encloses the
@@ -631,9 +657,7 @@ Canvas.prototype.getContainer = function() {
 Canvas.prototype._updateMarker = function(element, marker, add) {
   let container;
 
-  if (!element.id) {
-    element = this._elementRegistry.get(element);
-  }
+  element = this._resolveElement(element);
 
   element.markers = element.markers || new Set();
 
@@ -716,9 +740,7 @@ Canvas.prototype.removeMarker = function(element, marker) {
  * @param {string} marker The marker.
  */
 Canvas.prototype.hasMarker = function(element, marker) {
-  if (!element.id) {
-    element = this._elementRegistry.get(element);
-  }
+  element = this._resolveElement(element);
 
   if (!element.markers) {
     return false;
@@ -815,9 +837,7 @@ Canvas.prototype.addRootElement = function(rootElement) {
  */
 Canvas.prototype.removeRootElement = function(rootElement) {
 
-  if (typeof rootElement === 'string') {
-    rootElement = this._elementRegistry.get(rootElement);
-  }
+  rootElement = this._resolveElement(rootElement);
 
   const plane = this._findPlaneForRoot(rootElement);
 
@@ -1323,9 +1343,7 @@ Canvas.prototype.scroll = function(delta) {
 Canvas.prototype.scrollToElement = function(element, padding) {
   let defaultPadding = 100;
 
-  if (typeof element === 'string') {
-    element = this._elementRegistry.get(element);
-  }
+  element = this._resolveElement(element);
 
   // set to correct rootElement
   const rootElement = this.findRoot(element);

--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -1352,32 +1352,44 @@ Canvas.prototype.scroll = function(delta) {
 };
 
 /**
- * Scrolls the viewbox to contain the given element.
+ * Scrolls the viewbox to contain the given element or elements.
  * Optionally specify a padding to be applied to the edges.
  *
- * @param {ElementOrIdentifier} element The element to scroll to or its ID.
+ * The canvas navigates to the shared root of the element(s). If no shared
+ * root can be found, no navigation is performed.
+ *
+ * @param {ElementOrIdentifier|ElementOrIdentifier[]} element The element(s) to scroll to or their ID(s).
  * @param {RectTRBL|number} [padding=100] The padding to be applied. Can also specify top, bottom, left and right.
  */
 Canvas.prototype.scrollToElement = function(element, padding) {
   let defaultPadding = 100;
 
-  element = this._resolveElement(element);
+  const elements = this._resolveElements(element);
 
-  // set to correct rootElement
-  const rootElement = this.findRoot(element);
+  if (!elements.length) {
+    return;
+  }
+
+  const rootElement = this.findRoot(elements);
+
+  if (!rootElement) {
+    return;
+  }
 
   if (rootElement !== this.getRootElement()) {
     this.setRootElement(rootElement);
   }
 
-  // element is rootElement, do not change viewport
-  if (rootElement === element) {
+  const visibleElements = elements.filter(e => e != rootElement);
+
+  if (!visibleElements.length) {
     return;
   }
 
   if (!padding) {
     padding = {};
   }
+
   if (typeof padding === 'number') {
     defaultPadding = padding;
   }
@@ -1389,7 +1401,7 @@ Canvas.prototype.scrollToElement = function(element, padding) {
     left: padding.left || defaultPadding
   };
 
-  const elementBounds = getBoundingBox(element),
+  const elementBounds = getBoundingBox(visibleElements),
         elementTrbl = asTRBL(elementBounds),
         viewboxBounds = this.viewbox(),
         zoom = this.zoom();

--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -45,6 +45,8 @@ import {
  * @typedef {import('./Types.js').ParentLike } ParentLike
  * @typedef {import('./Types.js').ShapeLike} ShapeLike
  *
+ * @typedef {ShapeLike|ConnectionLike|RootLike|string} ElementOrIdentifier
+ *
  * @typedef { {
  *   container?: HTMLElement;
  *   deferUpdate?: boolean;
@@ -576,24 +578,40 @@ Canvas.prototype.getActiveLayer = function() {
 
 
 /**
- * Returns the plane which contains the given element.
+ * Returns the plane which contains the given element(s).
  *
- * @param {ShapeLike|ConnectionLike|string} element The element or its ID.
+ * If multiple elements are passed, the shared plane is returned
+ * (or undefined if no shared plane exists).
+ *
+ * @param {ElementOrIdentifier|ElementOrIdentifier[]} element
  *
  * @return {RootLike|undefined} The root of the element.
  */
 Canvas.prototype.findRoot = function(element) {
-  element = this._resolveElement(element);
 
-  if (!element) {
-    return;
+  const elements = this._resolveElements(element);
+
+  let root;
+
+  for (const element of elements) {
+    const plane = this._findPlaneForRoot(
+      findRoot(element)
+    );
+
+    if (!plane) {
+      return;
+    }
+
+    if (root && plane.rootElement !== root) {
+
+      // no shared root
+      return undefined;
+    }
+
+    root = plane.rootElement;
   }
 
-  const plane = this._findPlaneForRoot(
-    findRoot(element)
-  ) || {};
-
-  return plane.rootElement;
+  return root;
 };
 
 /**
@@ -1337,7 +1355,7 @@ Canvas.prototype.scroll = function(delta) {
  * Scrolls the viewbox to contain the given element.
  * Optionally specify a padding to be applied to the edges.
  *
- * @param {ShapeLike|ConnectionLike|string} element The element to scroll to or its ID.
+ * @param {ElementOrIdentifier} element The element to scroll to or its ID.
  * @param {RectTRBL|number} [padding=100] The padding to be applied. Can also specify top, bottom, left and right.
  */
 Canvas.prototype.scrollToElement = function(element, padding) {

--- a/lib/core/Canvas.spec.ts
+++ b/lib/core/Canvas.spec.ts
@@ -98,6 +98,8 @@ canvas.findRoot(shapeLike);
 
 canvas.findRoot(connectionLike);
 
+canvas.findRoot([ shape1, connectionLike ]);
+
 canvas.getAbsoluteBBox(shape1);
 
 canvas.getAbsoluteBBox(shapeLike);

--- a/lib/core/Canvas.spec.ts
+++ b/lib/core/Canvas.spec.ts
@@ -179,6 +179,10 @@ canvas.scrollToElement(shapeLike);
 
 canvas.scrollToElement(connectionLike);
 
+canvas.scrollToElement([ shape1, connection ]);
+
+canvas.scrollToElement([ shapeLike, connectionLike ]);
+
 canvas.setRootElement(root);
 
 canvas.showLayer('foo');

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -1776,7 +1776,130 @@ describe('core/Canvas', function() {
 
       // then
       expect(canvas.getRootElement()).to.equal(shapeRoot);
+    }));
 
+
+    it('scrolls multiple elements into view', inject(function(canvas) {
+
+      // given
+      var shape1 = canvas.addShape({
+        id: 's1',
+        x: 650, y: 650,
+        width: 50, height: 50
+      });
+
+      var shape2 = canvas.addShape({
+        id: 's2',
+        x: 700, y: 700,
+        width: 50, height: 50
+      });
+
+      // when
+      canvas.scrollToElement([ shape1, shape2 ]);
+
+      // then
+      var newViewbox = canvas.viewbox();
+      expect(newViewbox.x).to.equal(350);
+      expect(newViewbox.y).to.equal(350);
+
+    }));
+
+
+    it('switches to shared root for a collection of elements', inject(function(canvas) {
+
+      // given
+      var shapeRoot = canvas.addRootElement({ id: 'root' });
+
+      var shape = canvas.addShape({
+        id: 's0',
+        x: 0, y: 0,
+        width: 10, height: 10
+      }, shapeRoot);
+
+      var otherRoot = canvas.addRootElement(null);
+      canvas.setRootElement(otherRoot);
+
+      // when
+      canvas.scrollToElement([ shape ]);
+
+      // then
+      expect(canvas.getRootElement()).to.equal(shapeRoot);
+    }));
+
+
+    it('switches to shared root included in collection of elements', inject(function(canvas) {
+
+      // given
+      var shapeRoot = canvas.addRootElement({ id: 'root' });
+
+      var shape = canvas.addShape({
+        id: 's0',
+        x: 0, y: 0,
+        width: 10, height: 10
+      }, shapeRoot);
+
+      var otherRoot = canvas.addRootElement(null);
+      canvas.setRootElement(otherRoot);
+
+      // when
+      canvas.scrollToElement([ shape, shapeRoot ]);
+
+      // then
+      var newViewbox = canvas.viewbox();
+
+      expect(canvas.getRootElement()).to.equal(shapeRoot);
+      expect(newViewbox.x).to.equal(-100);
+      expect(newViewbox.y).to.equal(-100);
+    }));
+
+
+    it('bails if no shared root for a collection of elements', inject(function(canvas) {
+
+      // given
+      var rootA = canvas.addRootElement({ id: 'rootA' });
+      var shapeA = canvas.addShape({
+        id: 'shapeA',
+        x: 0, y: 0,
+        width: 10, height: 10
+      }, rootA);
+
+      var rootB = canvas.addRootElement({ id: 'rootB' });
+      var shapeB = canvas.addShape({
+        id: 'shapeB',
+        x: 650, y: 650,
+        width: 50, height: 50
+      }, rootB);
+
+      canvas.setRootElement(rootA);
+
+      var initialViewbox = canvas.viewbox();
+
+      // when
+      canvas.scrollToElement([ shapeA, shapeB ]);
+
+      // then
+      var newViewbox = canvas.viewbox();
+
+      expect(canvas.getRootElement()).to.equal(rootA);
+      expect(newViewbox.x).to.equal(initialViewbox.x);
+      expect(newViewbox.y).to.equal(initialViewbox.y);
+    }));
+
+
+    it('bails for multiple root elements as arguments', inject(function(canvas) {
+
+      // given
+      var shapeRoot = canvas.addRootElement({ id: 'root' });
+      var otherRoot = canvas.addRootElement({ id: 'other-root' });
+      var defaultRoot = canvas.addRootElement(null);
+
+      canvas.setRootElement(defaultRoot);
+
+      // when
+      canvas.scrollToElement([ shapeRoot, otherRoot ]);
+
+      // then
+      expect(canvas.getRootElement()).to.equal(defaultRoot);
     }));
 
   });
@@ -2902,4 +3025,3 @@ function expectChildren(parent, children) {
   });
 
 }
-

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -877,6 +877,54 @@ describe('core/Canvas', function() {
     }));
 
 
+    describe('#findRoot', function() {
+
+      it('should find self for root element', inject(function(canvas) {
+
+        // given
+        var root = canvas.setRootElement({ id: 'root' });
+
+        // when
+        var foundRoot = canvas.findRoot(root);
+
+        // then
+        expect(foundRoot).to.equal(root);
+      }));
+
+
+      it('should find shared root for multiple elements', inject(function(canvas) {
+
+        // given
+        var root = canvas.setRootElement({ id: 'root' });
+        var shape = canvas.addShape({ id: 'shape', x: 10, y: 10, width: 100, height: 100 }, root);
+
+        // when
+        var foundRoot = canvas.findRoot([ root, shape ]);
+
+        // then
+        expect(foundRoot).to.equal(root);
+      }));
+
+
+      it('should not find root for elements on different roots', inject(function(canvas) {
+
+        // given
+        var rootA = canvas.setRootElement({ id: 'rootA' });
+        var shapeA = canvas.addShape({ id: 'shapeA', x: 10, y: 10, width: 100, height: 100 }, rootA);
+
+        var rootB = canvas.addRootElement({ id: 'rootB' });
+        canvas.addShape({ id: 'shapeB', x: 20, y: 20, width: 100, height: 100 }, rootB);
+
+        // when
+        var foundRoot = canvas.findRoot([ shapeA, 'shapeB' ]);
+
+        // then
+        expect(foundRoot).not.to.exist;
+      }));
+
+    });
+
+
     describe('#removeRootElement', function() {
 
       it('should remove root element', inject(function(canvas, elementRegistry) {


### PR DESCRIPTION
### Proposed Changes

In line with many of our APIs:

* `Canvas#scrollToElement` can handle multiple elements - bails if elements are not on the same plane
* `Canvas#findRoot` can handle multiple elements, finds the shared root

This gives users a simple way to determine if elements are drawn together / allows them to "ensure the elements are shown".

Foundation for #1038 

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
