### PR TITLE
Correct popup menu help link not triggering via `ENTER`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+## 15.20.1
+
+ * `FIX`: allow triggering popup menu documentation link via `ENTER` ([#1076](https://github.com/bpmn-io/diagram-js/pull/1076))
+
 ## 15.20.0
 
 * `FEAT`: improve aural interface / accessibility of popup menu ([#1059](https://github.com/bpmn-io/diagram-js/pull/1059), [#735](https://github.com/bpmn-io/diagram-js/issues/735))

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -207,6 +207,14 @@ export default function PopupMenuComponent(props) {
 
   const handleKeyDown = useCallback(event => {
     if (event.key === 'Enter' && selectedEntry) {
+      const target = event.target;
+      const isNativeActionTarget = !!domClosest(target, 'a, button', true);
+
+      // let native controls handle <Enter> themselves
+      if (isNativeActionTarget) {
+        return;
+      }
+
       if (selectedEntry.disabled) {
         return;
       }

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -1927,6 +1927,24 @@ describe('features/popup-menu - <PopupMenu>', function() {
         expect(document.activeElement).to.equal(link);
       });
 
+
+      it('should not trigger selected entry when pressing <Enter> on footer documentation link', async function() {
+
+        // given
+        const onSelect = spy();
+
+        await createPopupMenu({ container, entries: docEntries, onSelect });
+
+        const link = domQuery('.djs-popup-footer-docs', container);
+
+        // when
+        link.focus();
+        fireEvent.keyDown(link, { key: 'Enter' });
+
+        // then
+        expect(onSelect).not.to.have.been.called;
+      });
+
     });
 
 


### PR DESCRIPTION
### Proposed Changes

Previously, we'd still handle ENTER in the popup menu, trigger
the respective (selected) entry, regardless of whether focus was
on the documentation link in the footer.

Related to #1059 

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
