### PR TITLE
feat(popup-menu): use auto width with max value of 300px

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -528,7 +528,6 @@
 .djs-popup {
   line-height: 1;
   box-sizing: border-box;
-  width: min-content;
   background: var(--popup-background-color);
   overflow: hidden;
   position: fixed;
@@ -536,6 +535,7 @@
   box-shadow: 0px 2px 6px var(--popup-shadow-color);
   border: solid 1px var(--popup-border-color);
   min-width: 120px;
+  max-width: 300px;
   outline: none;
   font-size: var(--popup-font-size);
   font-family: var(--popup-font-family);

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -470,7 +470,8 @@ function PopupMenuWrapper(props) {
 function getPopupStyle(props) {
   return {
     transform: `scale(${props.scale})`,
-    width: `${props.width}px`,
+    width: isDefined(props.width) ? `${props.width}px` : undefined,
+    maxWidth: isDefined(props.width) ? 'unset' : undefined,
     'transform-origin': 'top left'
   };
 }

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -232,6 +232,39 @@ describe('features/popup-menu - <PopupMenu>', function() {
   });
 
 
+  it('should NOT apply custom width if not provided', async function() {
+
+    // when
+    await createPopupMenu({
+      container
+    });
+
+    const popup = domQuery(
+      '.djs-popup', container
+    );
+
+    // then
+    expect(popup.style.width).to.eql('');
+  });
+
+
+  it('should apply custom width (over limit)', async function() {
+
+    // when
+    await createPopupMenu({
+      container,
+      width: 400
+    });
+
+    const popup = domQuery(
+      '.djs-popup', container
+    );
+
+    // then
+    expect(getComputedStyle(popup).width).to.eql('400px');
+  });
+
+
   describe('close', function() {
 
     it('should close on background click', async function() {


### PR DESCRIPTION


### Proposed Changes

This PR updates the popup menu width to use `auto` with a `max-width` of 300px instead of `min-content`. This setting works correctly for entries with icons as otherwise a line break is inserted.

Related to https://github.com/camunda/camunda-modeler/issues/6040

Try out via:

`npx @bpmn-io/sr bpmn-io/bpmn-js#remove-forced-width  -l bpmn-io/diagram-js#update-popup-menu-width` (replace menu)

<img width="333" height="471" alt="image" src="https://github.com/user-attachments/assets/54e8cc67-c554-4d15-89c1-6d223ce027a0" />


or

`npx @bpmn-io/sr bpmn-io/bpmn-js-create-append-anything#remove-forced-width  -l bpmn-io/diagram-js#update-popup-menu-width` (no changes)

or 

`npx @bpmn-io/sr bpmn-io/dmn-js -l bpmn-io/diagram-js#update-popup-menu-width`

<img width="422" height="246" alt="image" src="https://github.com/user-attachments/assets/1974eceb-dcaa-4ff5-8dc0-e1e625a7cffc" />


<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
