### PR TITLE
feat: keep selection visible on elements.changed via API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 _**Note:** Yet to be released changes appear here._
 
 * `FEAT`: add feature to keep selection visible ([#1038](https://github.com/bpmn-io/diagram-js/pull/1038))
+* `FEAT`: keep selection visible on element resize and move via API ([#1079](https://github.com/bpmn-io/diagram-js/pull/1079))
 
 ## 15.22.0
 

--- a/lib/features/keep-selection-visible/KeepSelectionVisible.js
+++ b/lib/features/keep-selection-visible/KeepSelectionVisible.js
@@ -6,15 +6,20 @@ import { asTRBL } from '../../layout/LayoutUtil.js';
 var UPDATE_DEBOUNCE_INTERVAL = 300;
 
 /**
- * Keeps the current selection visible when the canvas container is resized,
- * provided the selection was already visible before the resize. If the selection
- * was out of view, this is a no-op.
+ * Keeps the current selection visible whenever a change may have pushed it
+ * out of view, provided the selection was visible before the change. If the
+ * selection was out of view, this is a no-op.
+ *
+ * The behavior reacts to canvas resizing and any element change (move,
+ * resize, etc.) out of the box. Additional triggers can hook into it via
+ * {@link KeepSelectionVisible#keepVisible}.
  *
  * @param {import('../../core/EventBus').default} eventBus
  * @param {import('../../core/Canvas').default} canvas
  * @param {import('../selection/Selection').default} selection
+ * @param {import('didi').Injector} injector
  */
-export default function KeepSelectionVisible(eventBus, canvas, selection) {
+export default function KeepSelectionVisible(eventBus, canvas, selection, injector) {
 
   this._selectionWasVisible = false;
 
@@ -29,7 +34,15 @@ export default function KeepSelectionVisible(eventBus, canvas, selection) {
   eventBus.on('canvas.viewbox.changed', updateSelectionVisible);
   eventBus.on('selection.changed', updateSelectionVisible);
 
-  eventBus.on('canvas.resized', () => {
+  /**
+   * Scrolls the current selection back into view, provided it was visible
+   * before the change that triggered this call. If the selection was out
+   * of view or is still visible, this is a no-op.
+   *
+   * Invoke this after any change that may have pushed the selection
+   * out of view.
+   */
+  this.keepVisible = () => {
     var selected = selection.get();
 
     if (!selected.length) {
@@ -49,6 +62,25 @@ export default function KeepSelectionVisible(eventBus, canvas, selection) {
     // we ensure that selection scrolling always happens on the current root
     // (no root switch happens)
     canvas.scrollToElement(selected.concat(currentRoot));
+  };
+
+  eventBus.on('canvas.resized', this.keepVisible);
+
+  var dragging = injector.get('dragging', false);
+
+  eventBus.on('elements.changed', (event) => {
+    if (dragging && dragging.context()) {
+      return;
+    }
+
+    var changed = event.elements;
+    var selected = selection.get();
+
+    if (!changed.some(element => selected.includes(element))) {
+      return;
+    }
+
+    this.keepVisible();
   });
 
   function isSelectionVisible() {
@@ -77,5 +109,6 @@ export default function KeepSelectionVisible(eventBus, canvas, selection) {
 KeepSelectionVisible.$inject = [
   'eventBus',
   'canvas',
-  'selection'
+  'selection',
+  'injector'
 ];

--- a/test/spec/features/keep-selection-visible/KeepSelectionVisibleSpec.js
+++ b/test/spec/features/keep-selection-visible/KeepSelectionVisibleSpec.js
@@ -7,6 +7,8 @@ import {
 } from 'test/TestHelper';
 
 import coreModule from 'lib/core';
+import draggingModule from 'lib/features/dragging';
+import modelingModule from 'lib/features/modeling';
 import selectionModule from 'lib/features/selection';
 import keepSelectionVisibleModule from 'lib/features/keep-selection-visible';
 
@@ -231,6 +233,70 @@ describe('features/keep-selection-visible', function() {
   });
 
 
+  describe('#keepVisible', function() {
+
+    it('should scroll selection into view when invoked', inject(
+      function(canvas, keepSelectionVisible, selection) {
+
+        // given
+        act(() => {
+          selection.select(shape3);
+        });
+
+        shape3.x = 1200;
+
+        // when
+        keepSelectionVisible.keepVisible();
+
+        // then
+        expectSelectionInView(canvas, selection);
+      }
+    ));
+
+
+    it('should NOT scroll when selection still visible', inject(
+      function(canvas, keepSelectionVisible, selection) {
+
+        // given
+        act(() => {
+          selection.select(shape3);
+        });
+
+        var viewboxBefore = canvas.viewbox();
+
+        // when
+        keepSelectionVisible.keepVisible();
+
+        // then
+        expectViewboxUnchanged(canvas, viewboxBefore);
+      }
+    ));
+
+
+    it('should NOT scroll when selection was not visible before', inject(
+      function(canvas, keepSelectionVisible, selection) {
+
+        // given
+        act(() => {
+          selection.select(shape1);
+          canvas.scroll({ dx: -2000, dy: 0 });
+        });
+
+        var viewboxBefore = canvas.viewbox();
+
+        shape1.x = 1200;
+
+        // when
+        keepSelectionVisible.keepVisible();
+
+        // then
+        expectViewboxUnchanged(canvas, viewboxBefore);
+      }
+    ));
+
+  });
+
+
   describe('visibility flag tracking', function() {
 
     it('should not bring selection back after user scrolls it away', inject(
@@ -275,6 +341,153 @@ describe('features/keep-selection-visible', function() {
     ));
 
   });
+
+  describe('scroll adjustment on element change', function() {
+
+    beforeEach(bootstrapDiagram({
+      modules: [
+        coreModule,
+        draggingModule,
+        modelingModule,
+        selectionModule,
+        keepSelectionVisibleModule
+      ],
+      canvas: {
+        width: 800,
+        height: 600
+      }
+    }));
+
+    beforeEach(inject(function(canvas) {
+
+      shape1 = canvas.addShape({
+        id: 'shape1', x: 700, y: 200, width: 100, height: 100
+      });
+
+      shape3 = canvas.addShape({
+        id: 'shape3', x: 10, y: 10, width: 100, height: 100
+      });
+    }));
+
+
+    it('should keep selection visible when selected element is moved via API', inject(
+      function(canvas, modeling, selection) {
+
+        // given
+        act(() => {
+          selection.select(shape3);
+        });
+
+        // when
+        modeling.moveElements([ shape3 ], { x: 1200, y: 0 });
+
+        // then
+        expectSelectionInView(canvas, selection);
+      }
+    ));
+
+
+    it('should keep selection visible when selected element is resized via API', inject(
+      function(canvas, modeling, selection) {
+
+        // given
+        act(() => {
+          selection.select(shape3);
+        });
+
+        // when
+        modeling.resizeShape(shape3, { x: 500, y: 10, width: 400, height: 100 });
+
+        // then
+        expectSelectionInView(canvas, selection);
+      }
+    ));
+
+
+    it('should keep selection visible on undo', inject(
+      function(canvas, commandStack, modeling, selection) {
+
+        // given
+        act(() => {
+          selection.select(shape3);
+        });
+
+        act(() => {
+          modeling.moveElements([ shape3 ], { x: 1200, y: 0 });
+        });
+
+        // when
+        commandStack.undo();
+
+        // then
+        expectSelectionInView(canvas, selection);
+      }
+    ));
+
+
+    it('should NOT scroll when unselected element is moved via API', inject(
+      function(canvas, modeling, selection) {
+
+        // given
+        act(() => {
+          selection.select(shape3);
+        });
+
+        var viewboxBefore = canvas.viewbox();
+
+        // when
+        modeling.moveElements([ shape1 ], { x: 1200, y: 0 });
+
+        // then
+        expectViewboxUnchanged(canvas, viewboxBefore);
+      }
+    ));
+
+
+    it('should NOT scroll when selection was not visible before', inject(
+      function(canvas, modeling, selection) {
+
+        // given
+        act(() => {
+          selection.select(shape1);
+          canvas.scroll({ dx: -2000, dy: 0 });
+        });
+
+        var viewboxBefore = canvas.viewbox();
+
+        // when
+        modeling.moveElements([ shape1 ], { x: 100, y: 0 });
+
+        // then
+        expectViewboxUnchanged(canvas, viewboxBefore);
+      }
+    ));
+
+
+    it('should NOT scroll when element is moved interactively', inject(
+      function(canvas, dragging, modeling, selection) {
+
+        // given
+        act(() => {
+          selection.select(shape3);
+        });
+
+        var viewboxBefore = canvas.viewbox();
+
+        dragging.context = function() {
+          return {};
+        };
+
+        // when
+        modeling.moveElements([ shape3 ], { x: 1200, y: 0 });
+
+        // then
+        expectViewboxUnchanged(canvas, viewboxBefore);
+      }
+    ));
+
+  });
+
 
 });
 


### PR DESCRIPTION
### Proposed Changes

This pull request is aimed to address https://github.com/bpmn-io/diagram-js/pull/1038#discussion_r3537160896.

While https://github.com/bpmn-io/diagram-js/pull/1038 introduces the "keep selection visible" feature for `canvas.resized` for user-interactions, this pull request introduces a behavior to cover events like `elements.moved` and `shape.resized` to keep the modified selection in the view upon commands via the API.

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
