### PR TITLE
Async restore focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+* `DEPS`: update to `min-dash@5.1.0`
+
 ## 15.21.0
 
 * `FEAT`: use auto width with max value of 300px for popup menu ([#1078](https://github.com/bpmn-io/diagram-js/pull/1078))

--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -273,6 +273,13 @@ Canvas.prototype._init = function(config) {
     this._viewboxChanged = debounce(bind(this._viewboxChanged, this), 300);
   }
 
+  /**
+   * Schedule focus restoration.
+   *
+   * @type {import('min-dash').DebouncedFunction<typeof this.restoreFocus>}
+   */
+  this._restoreFocus = debounce(this._restoreFocus, 0);
+
   eventBus.on('diagram.init', () => {
 
     /**
@@ -311,6 +318,8 @@ Canvas.prototype._init = function(config) {
 };
 
 Canvas.prototype._destroy = function() {
+  this._restoreFocus.cancel();
+
   this._eventBus.fire('canvas.destroy', {
     svg: this._svg,
     viewport: this._viewport
@@ -374,9 +383,17 @@ Canvas.prototype.focus = function() {
 };
 
 /**
-* Sets focus on the canvas SVG element if `document.body` is currently focused.
-*/
+ * Restores focus on the canvas SVG element if `document.body` is
+ * currently focused.
+ *
+ * Safely executes on the next render cycle - never prevents pending
+ * (in flight) user clicks.
+ */
 Canvas.prototype.restoreFocus = function() {
+  this._restoreFocus();
+};
+
+Canvas.prototype._restoreFocus = function() {
   if (document.activeElement === document.body) {
     this.focus();
   }

--- a/lib/core/Canvas.js
+++ b/lib/core/Canvas.js
@@ -4,7 +4,6 @@ import {
   forEach,
   every,
   debounce,
-  bind,
   reduce,
   find,
   isArray
@@ -270,7 +269,7 @@ Canvas.prototype._init = function(config) {
   // debounce canvas.viewbox.changed events when deferUpdate is set
   // to help with potential performance issues
   if (config.deferUpdate) {
-    this._viewboxChanged = debounce(bind(this._viewboxChanged, this), 300);
+    this._viewboxChanged = debounce(this._viewboxChanged, 300);
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "clsx": "^2.1.1",
         "didi": "^11.0.0",
         "inherits-browser": "^0.1.0",
-        "min-dash": "^5.0.0",
+        "min-dash": "^5.1.0",
         "min-dom": "^5.3.0",
         "object-refs": "^0.4.0",
         "path-intersection": "^4.1.0",
@@ -5517,9 +5517,9 @@
       }
     },
     "node_modules/min-dash": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
-      "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.1.0.tgz",
+      "integrity": "sha512-HAvN6XzmCQj+js43G9sJRRw8kj/7DvoxN7qhoIN9Xo5ZN1NMljtpyKs/NunXmw0QSWwlgZzNv6tLeEa4xaZ0tg==",
       "license": "MIT"
     },
     "node_modules/min-dom": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "clsx": "^2.1.1",
     "didi": "^11.0.0",
     "inherits-browser": "^0.1.0",
-    "min-dash": "^5.0.0",
+    "min-dash": "^5.1.0",
     "min-dom": "^5.3.0",
     "object-refs": "^0.4.0",
     "path-intersection": "^4.1.0",

--- a/test/spec/core/CanvasSpec.js
+++ b/test/spec/core/CanvasSpec.js
@@ -198,8 +198,15 @@ describe('core/Canvas', function() {
 
   describe('focus handling <config.autoFocus>', function() {
 
+    var clock;
+
     beforeEach(function() {
       container = TestContainer.get(this);
+      clock = useFakeTimers();
+    });
+
+    afterEach(function() {
+      clock.restore();
     });
 
     beforeEach(createDiagram({
@@ -214,6 +221,8 @@ describe('core/Canvas', function() {
       // given
       var svg = container.querySelector('svg');
 
+      document.body.focus();
+
       // when
       eventBus.fire('element.hover', {
         element: canvas.getRootElement(),
@@ -221,6 +230,10 @@ describe('core/Canvas', function() {
       });
 
       // then
+      expect(document.activeElement).to.equal(document.body);
+
+      clock.tick(0);
+
       expect(document.activeElement).to.equal(svg);
     }));
 
@@ -360,6 +373,70 @@ describe('core/Canvas', function() {
       // then
       // focus is not triggered again
       expect(refocusSpy).not.to.have.been.called;
+    }));
+
+  });
+
+
+  describe('#restoreFocus', function() {
+
+    var clock;
+
+    /**
+     * @type { HTMLElement }
+     */
+    let inputEl;
+
+    beforeEach(function() {
+      container = TestContainer.get(this);
+      clock = useFakeTimers();
+    });
+
+    afterEach(function() {
+      clock.restore();
+      inputEl && inputEl.remove();
+    });
+
+    beforeEach(createDiagram());
+
+
+    it('should restore focus asynchronously', inject(function(canvas) {
+
+      // given
+      var svg = container.querySelector('svg');
+
+      document.body.focus();
+
+      // when
+      canvas.restoreFocus();
+
+      // then
+      expect(document.activeElement).to.equal(document.body);
+
+      // but when...
+      clock.tick(0);
+
+      // then
+      expect(document.activeElement).to.equal(svg);
+    }));
+
+
+    it('should not restore focus if document focus changed in the meantime', inject(function(canvas) {
+
+      // given
+      inputEl = document.createElement('input');
+
+      document.body.appendChild(inputEl);
+      document.body.focus();
+
+      // when
+      canvas.restoreFocus();
+      inputEl.focus();
+
+      // then
+      clock.tick(0);
+
+      expect(document.activeElement).to.equal(inputEl);
     }));
 
   });


### PR DESCRIPTION
### Proposed Changes

Ensures that this API can be safely used from any event handler,
any interaction sequence.

Up to now, restoration was _SYNCHRONOUS_, meaning that when restore was
executed (forced) then user clicks were ignored.

Sequence:

* user <click> elsewhere
* <focusout> or <blur> of an element
* triggering restore
* <click> (focus other element) was discarded

With the new change, user <click> always yields the relevant effect.

Related to https://github.com/bpmn-io/diagram-js-direct-editing/pull/74

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
