### PR TITLE
feat: support popup width as string (e.g. css-variable)

### DIFF
--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -468,10 +468,14 @@ function PopupMenuWrapper(props) {
 // helpers //////////////////////
 
 function getPopupStyle(props) {
+  const { width } = props;
+
+  const normalizedWidth = typeof width === 'number' ? `${width}px` : width;
+
   return {
     transform: `scale(${props.scale})`,
-    width: isDefined(props.width) ? `${props.width}px` : undefined,
-    maxWidth: isDefined(props.width) ? 'unset' : undefined,
+    width: isDefined(width) ? normalizedWidth : undefined,
+    maxWidth: isDefined(width) ? 'unset' : undefined,
     'transform-origin': 'top left'
   };
 }

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -50,7 +50,7 @@ const ids = new Ids('djs-popup');
  * @param {string} [props.title]
  * @param {boolean} [props.search]
  * @param {PopupMenuEmptyPlaceholder} [props.emptyPlaceholder]
- * @param {number} [props.width]
+ * @param {number|string} [props.width]
  * @param {searchFn} props.searchFn
  */
 export default function PopupMenuComponent(props) {

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -232,6 +232,24 @@ describe('features/popup-menu - <PopupMenu>', function() {
   });
 
 
+  it('should apply custom width via css variable', async function() {
+
+    // when
+    await createPopupMenu({
+      container,
+      width: 'var(--foo, 360px)'
+    });
+
+    const popup = domQuery(
+      '.djs-popup', container
+    );
+
+    // then
+    expect(popup.style.width).to.eql('var(--foo, 360px)');
+    expect(getComputedStyle(popup).width).to.eql('360px');
+  });
+
+
   it('should NOT apply custom width if not provided', async function() {
 
     // when


### PR DESCRIPTION
### Proposed Changes

Support to provided popup width as string (e.g. css-variable):
```
 width: 'var(--replace-popup-width, 300px)'
```

Try it with bpmn-js:

```
npx @bpmn-io/sr bpmn-io/bpmn-js#replace-menu-grouping -l bpmn-io/diagram-js#string-popup-width
```


https://github.com/user-attachments/assets/56bb5c1a-d0f9-4d45-8b7e-f9dd69f7eb2e


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
