### PR TITLE
test(bendpoints): keep element.mousemove working after element.out

### DIFF
--- a/test/spec/features/bendpoints/BendpointsSpec.js
+++ b/test/spec/features/bendpoints/BendpointsSpec.js
@@ -770,6 +770,56 @@ describe('features/bendpoints', function() {
 
   });
 
+
+  describe('interaction events', function() {
+
+    // dispatch a native DOM mouse event so it passes through the actual
+    // interaction event delegation that is wired up on the root SVG element
+    function triggerMouseEvent(type, gfx) {
+      var event = document.createEvent('MouseEvent');
+
+      event.initMouseEvent(
+        type, true, true, window,
+        0, 0, 0, 0, 0,
+        false, false, false, false, 0, null
+      );
+
+      return gfx.dispatchEvent(event);
+    }
+
+
+    // ensure the bendpoints feature does not de-register the global
+    // <element.mousemove> interaction event as a side effect of handling
+    // <element.out> on the root element
+    //
+    // cf. https://github.com/bpmn-io/diagram-js/issues/965
+    it('should keep firing <element.mousemove> after <element.out> on root', inject(
+      function(canvas, eventBus, elementRegistry) {
+
+        // given
+        var rootGfx = elementRegistry.getGraphics(canvas.getRootElement()),
+            shapeGfx = elementRegistry.getGraphics(shape1);
+
+        // leaving the root SVG element
+        triggerMouseEvent('mouseout', rootGfx);
+
+        var moveSpy = spy();
+
+        eventBus.once('element.mousemove', moveSpy);
+
+        // when
+        // moving the mouse over a shape
+        triggerMouseEvent('mousemove', shapeGfx);
+
+        // then
+        // <element.mousemove> is still propagated to the shape
+        expect(moveSpy).to.have.been.calledOnce;
+        expect(moveSpy.getCall(0).args[0].element).to.equal(shape1);
+      }
+    ));
+
+  });
+
 });
 
 


### PR DESCRIPTION
### Proposed Changes

Adds a focused regression test guarding against the interaction event side effect reported in #965: leaving the root SVG element used to de-register the global `element.mousemove` interaction event, so it stopped propagating to all elements.

The underlying fix already landed on `develop` via 664d5d6f (`chore(bendpoints): don't double register listener`). This adds the missing test coverage.

The test is verified to be effective: it **fails** when the old `element.out` side effect is reintroduced (`element.mousemove` fires 0 times) and **passes** against current `develop`.

Supersedes the test coverage attempted in #979 (which no longer compiled against `develop` and passed even with the bug present).

Related to #965
Related to #978

### Checklist

* [x] **Brief textual description** of the changes present
* [x] Related issue linked