### PR TITLE
chore: pin github actions to commit shas

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,16 +14,16 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Use Node.js
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
         cache: 'npm'
     - name: Install dependencies
       run: npm ci
     - name: Setup project
-      uses: bpmn-io/actions/setup@latest
+      uses: bpmn-io/actions/setup@0b748d8b9d89e51077fff957a29e42135fe0dd2f # latest
     - name: Build (with coverage)
       if: matrix.browser == 'ChromeHeadless'
       env:
@@ -37,7 +37,7 @@ jobs:
       run: xvfb-run npm run all
     - name: Upload coverage
       if: matrix.browser == 'ChromeHeadless'
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         fail_ci_if_error: true
       env:
@@ -55,16 +55,16 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Use Node.js
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
         cache: 'npm'
     - name: Install dependencies
       run: npm ci
     - name: Setup project
-      uses: bpmn-io/actions/setup@latest
+      uses: bpmn-io/actions/setup@0b748d8b9d89e51077fff957a29e42135fe0dd2f # latest
     - name: Build
       env:
         TEST_BROWSERS: ${{ matrix.browser }}

--- a/.github/workflows/CODE_SCANNING.yml
+++ b/.github/workflows/CODE_SCANNING.yml
@@ -19,11 +19,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: javascript
           config: |
@@ -31,4 +31,4 @@ jobs:
               - '**/test'
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/MERGE_MAIN_TO_DEVELOP.yml
+++ b/.github/workflows/MERGE_MAIN_TO_DEVELOP.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout develop
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         token: ${{ secrets.BPMN_IO_TOKEN }}
         persist-credentials: true
@@ -27,7 +27,7 @@ jobs:
 
     - name: Notify failure on Slack
       if: failure()
-      uses: slackapi/slack-github-action@v4
+      uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
       with:
         method: chat.postMessage
         token: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
### Proposed Changes

Small drive-by contribution: this pins the action references across the four workflows to their commit shas, versions kept as comments.

A tag like `@v4`, or the floating `@latest`, is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's token. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066). With the sha, what runs is frozen to what you reviewed.

Notes:

- Renovate keeps working exactly as today: it understands sha pins with a version comment and will keep opening its bump PRs, same as its recent slack-github-action and setup-node updates.
- `bpmn-io/actions` is pinned to its current latest commit too. It is your own org so the risk model is different, drop that hunk if you prefer the moving tag.
- Heads up if the org uses an Actions allowlist: patterns written against tags (like `owner/action@v4`) stop matching once refs are shas and workflows refuse to start. Entries need to be `owner/action@*` in that case.

All shas were resolved from the upstream repos and cross checked against their tags. No logic changes, only the `uses:` lines. Found with the Plumber CLI (https://github.com/getplumber/plumber), verified on develop. I will also open a PR which adds it to CI so this does not quietly drift back, that one is a bonus, this PR stands on its own.

To try out: the diff is only `uses:` lines, and each sha can be checked against its version comment with `git ls-remote --tags https://github.com/OWNER/ACTION VERSION`.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__: none, drive-by security hardening
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__: not applicable, CI-only change
  * [x] __Steps to try out__: the sha to version cross check above
