### PR TITLE
fix(outline): do not create outline for root element

### DIFF
--- a/lib/features/outline/Outline.js
+++ b/lib/features/outline/Outline.js
@@ -18,6 +18,8 @@ import {
   isFunction
 } from 'min-dash';
 
+import { isRoot } from '../../util/ModelUtil.js';
+
 var DEFAULT_PRIORITY = 1000;
 
 /**
@@ -60,6 +62,13 @@ export default function Outline(eventBus, styles, elementRegistry) {
    * @param {Element} element
    */
   function createElementOutline(element) {
+
+    // root elements have no outline; creating one would append a never-updated
+    // rect to the untransformed root layer, polluting getActiveLayer().getBBox()
+    if (isRoot(element)) {
+      return;
+    }
+
     self.createOutline(element);
   }
 

--- a/test/spec/features/outline/OutlineSpec.js
+++ b/test/spec/features/outline/OutlineSpec.js
@@ -91,6 +91,40 @@ describe('features/outline - Outline', function() {
     ));
 
 
+    it('should not create outline for root on hover', inject(
+      function(canvas, eventBus, elementRegistry) {
+
+        // given
+        var root = canvas.getRootElement();
+
+        // when
+        eventBus.fire('element.hover', { element: root });
+
+        // then
+        var gfx = elementRegistry.getGraphics(root);
+
+        expect(domQuery('.djs-outline', gfx)).not.to.exist;
+      }
+    ));
+
+
+    it('should not create outline for root on selection', inject(
+      function(canvas, eventBus, elementRegistry) {
+
+        // given
+        var root = canvas.getRootElement();
+
+        // when
+        eventBus.fire('selection.changed', { newSelection: [ root ] });
+
+        // then
+        var gfx = elementRegistry.getGraphics(root);
+
+        expect(domQuery('.djs-outline', gfx)).not.to.exist;
+      }
+    ));
+
+
     it('should create outline only once', inject(
       function(canvas, eventBus, selection, elementRegistry) {
 


### PR DESCRIPTION
Closes https://github.com/bpmn-io/diagram-js/issues/1092

### Proposed Changes

**Root cause:** since outlines are created lazily (15.19+), hovering the root appends a `.djs-outline` rect to the untransformed root layer. That rect pollutes `getActiveLayer().getBBox()` / `viewbox().inner`, feeding wrong content bounds to consumers like align-to-origin.

**Fix:** skip outline creation for root elements (`isRoot` guard).

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
