### PR TITLE
fix: support hiding element outlines

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -153,6 +153,10 @@
   display: block;
 }
 
+.djs-outline-hidden .djs-outline {
+  display: none !important;
+}
+
 .djs-shape.connect-ok .djs-visual > :nth-child(1) {
   fill: var(--shape-connect-allowed-fill-color) !important;
 }


### PR DESCRIPTION
### Proposed Changes

Adds a Canvas API to temporarily hide element outlines (toggles a `djs-outline-hidden` class on the canvas root). 

Lets consumers measure or serialize the diagram without lazily-created outlines skewing the bounds.

Related to https://github.com/bpmn-io/diagram-js/pull/1064

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
