### PR TITLE
feat(popup-menu): support tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+* `FEAT`: support tabs in the popup menu ([#1095](https://github.com/bpmn-io/diagram-js/issues/1095))
+
 ## 15.23.2
 
 * `FIX`: support hiding element outlines ([#1094](https://github.com/bpmn-io/diagram-js/pull/1094))

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -621,11 +621,34 @@
   margin: 10px 12px;
 }
 
+.djs-popup-tabs-container {
+  position: relative;
+  border-bottom: solid 1px var(--popup-tab-strip-border-color);
+}
+
+.djs-popup-tabs-container:after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 1px;
+  width: 24px;
+  pointer-events: none;
+  background: linear-gradient(to right, transparent, var(--popup-background-color));
+}
+
 .djs-popup-tabs {
   display: flex;
+  flex-wrap: nowrap;
   gap: 2px;
+  overflow-x: auto;
+  overflow-y: hidden;
   padding: 0 12px;
-  border-bottom: solid 1px var(--popup-tab-strip-border-color);
+  scrollbar-width: none;
+}
+
+.djs-popup-tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .djs-popup-tab {
@@ -634,11 +657,13 @@
   border: none;
   border-bottom: solid 2px transparent;
   border-radius: 0;
+  flex: 0 0 auto;
   padding: 6px 10px;
   font: inherit;
   font-size: var(--popup-font-size);
   color: var(--popup-tab-color);
   cursor: pointer;
+  white-space: nowrap;
 }
 
 .djs-popup-tab:hover {

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -626,15 +626,43 @@
   border-bottom: solid 1px var(--popup-tab-strip-border-color);
 }
 
-.djs-popup-tabs-container:after {
-  content: '';
+/**
+ * The scroll control doubles as the edge fade: tabs scrolled past it fade out
+ * rather than being cut off behind an opaque block.
+ */
+.djs-popup-tabs-scroll {
+  appearance: none;
   position: absolute;
   top: 0;
-  right: 0;
   bottom: 1px;
-  width: 24px;
-  pointer-events: none;
-  background: linear-gradient(to right, transparent, var(--popup-background-color));
+  width: 28px;
+  display: flex;
+  align-items: center;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  color: var(--popup-tab-color);
+  cursor: pointer;
+}
+
+.djs-popup-tabs-scroll:hover {
+  color: var(--popup-tab-hover-color);
+}
+
+.djs-popup-tabs-scroll-start {
+  left: 0;
+  justify-content: flex-start;
+  background: linear-gradient(to left, transparent, var(--popup-background-color) 60%);
+}
+
+.djs-popup-tabs-scroll-end {
+  right: 0;
+  justify-content: flex-end;
+  background: linear-gradient(to right, transparent, var(--popup-background-color) 60%);
+}
+
+.djs-popup-tabs-scroll-start svg {
+  transform: rotate(180deg);
 }
 
 .djs-popup-tabs {
@@ -644,6 +672,9 @@
   overflow-x: auto;
   overflow-y: hidden;
   padding: 0 12px;
+
+  /* keep scrolled-to tabs clear of the scroll controls */
+  scroll-padding: 0 28px;
   scrollbar-width: none;
 }
 

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -72,6 +72,12 @@
   --popup-search-border-color: var(--color-grey-225-10-75);
   --popup-search-focus-border-color: var(--color-blue-205-100-50);
   --popup-search-focus-background-color: var(--color-blue-205-100-95);
+  --popup-tab-color: var(--color-grey-225-10-55);
+  --popup-tab-hover-color: var(--color-grey-225-10-15);
+  --popup-tab-active-color: var(--color-grey-225-10-15);
+  --popup-tab-active-border-color: var(--color-blue-205-100-50);
+  --popup-tab-strip-border-color: var(--color-grey-225-10-90);
+  --popup-tab-focus-border-color: var(--color-blue-205-100-50);
 
   --resizer-fill-color: var(--color-blue-205-100-45);
   --resizer-stroke-color: var(--canvas-fill-color);
@@ -613,6 +619,41 @@
   position: relative;
   width: auto;
   margin: 10px 12px;
+}
+
+.djs-popup-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 0 12px;
+  border-bottom: solid 1px var(--popup-tab-strip-border-color);
+}
+
+.djs-popup-tab {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-bottom: solid 2px transparent;
+  border-radius: 0;
+  padding: 6px 10px;
+  font: inherit;
+  font-size: var(--popup-font-size);
+  color: var(--popup-tab-color);
+  cursor: pointer;
+}
+
+.djs-popup-tab:hover {
+  color: var(--popup-tab-hover-color);
+}
+
+.djs-popup-tab:focus-visible {
+  outline: solid 1px var(--popup-tab-focus-border-color);
+  outline-offset: -2px;
+}
+
+.djs-popup-tab[aria-selected="true"] {
+  color: var(--popup-tab-active-color);
+  border-bottom-color: var(--popup-tab-active-border-color);
+  font-weight: var(--popup-header-font-weight);
 }
 
 .djs-popup-title {

--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -651,33 +651,22 @@ PopupMenu.prototype._getEntry = function(entryId) {
  * Leaf entries inherit the `search` terms of their ancestors, so a leaf can be
  * found by keywords declared on any of its parents.
  *
- * Leaf entries inherit the `tab` of their nearest ancestor, so search results
- * can be attributed to the tab they originate from.
- *
  * @param {import('./PopupMenuProvider').PopupMenuEntries} entriesMap
  * @param {string[]} [search]
- * @param {import('./PopupMenuProvider').PopupMenuTab} [tab]
  *
  * @return {import('./PopupMenuProvider').PopupMenuEntry[]}
  */
-function flattenEntries(entriesMap, search = [], tab) {
+function flattenEntries(entriesMap, search = []) {
   return Object.entries(entriesMap).map(([ id, value ]) => {
     const entry = { id, ...value };
 
     if (entry.entries) {
       entry.entries = flattenEntries(
         entry.entries,
-        [ ...search, ...asArray(entry.search) ],
-        entry.tab || tab
+        [ ...search, ...asArray(entry.search) ]
       );
-    } else {
-      if (search.length) {
-        entry.search = [ ...search, ...asArray(entry.search) ];
-      }
-
-      if (!entry.tab && tab) {
-        entry.tab = tab;
-      }
+    } else if (search.length) {
+      entry.search = [ ...search, ...asArray(entry.search) ];
     }
 
     return entry;

--- a/lib/features/popup-menu/PopupMenu.js
+++ b/lib/features/popup-menu/PopupMenu.js
@@ -35,11 +35,14 @@ import PopupMenuComponent from './PopupMenuComponent.js';
  *
  * @typedef {import('../../model/Types.js').Element} Element
  *
+ * @typedef {import('./PopupMenuProvider.js').PopupMenuTab} PopupMenuTab
+ *
  * @typedef { {
  *   scale?: {
  *     min?: number;
  *     max?: number;
  *   } | boolean;
+ *   defaultTab?: PopupMenuTab;
  * } } PopupMenuConfig
  *
  * @typedef {Element|Element[]} PopupMenuTarget;
@@ -76,7 +79,8 @@ export default function PopupMenu(config, eventBus, canvas, search) {
   };
 
   this._config = {
-    scale: scale
+    scale: scale,
+    defaultTab: config && config.defaultTab
   };
 
 
@@ -142,6 +146,7 @@ PopupMenu.prototype._render = function() {
         onOpened=${ this._onOpened.bind(this) }
         onClosed=${ this._onClosed.bind(this) }
         searchFn=${ this._search }
+        defaultTab=${ this._config.defaultTab }
         ...${{ ...options }}
       />
     `,
@@ -646,22 +651,33 @@ PopupMenu.prototype._getEntry = function(entryId) {
  * Leaf entries inherit the `search` terms of their ancestors, so a leaf can be
  * found by keywords declared on any of its parents.
  *
+ * Leaf entries inherit the `tab` of their nearest ancestor, so search results
+ * can be attributed to the tab they originate from.
+ *
  * @param {import('./PopupMenuProvider').PopupMenuEntries} entriesMap
  * @param {string[]} [search]
+ * @param {import('./PopupMenuProvider').PopupMenuTab} [tab]
  *
  * @return {import('./PopupMenuProvider').PopupMenuEntry[]}
  */
-function flattenEntries(entriesMap, search = []) {
+function flattenEntries(entriesMap, search = [], tab) {
   return Object.entries(entriesMap).map(([ id, value ]) => {
     const entry = { id, ...value };
 
     if (entry.entries) {
       entry.entries = flattenEntries(
         entry.entries,
-        [ ...search, ...asArray(entry.search) ]
+        [ ...search, ...asArray(entry.search) ],
+        entry.tab || tab
       );
-    } else if (search.length) {
-      entry.search = [ ...search, ...asArray(entry.search) ];
+    } else {
+      if (search.length) {
+        entry.search = [ ...search, ...asArray(entry.search) ];
+      }
+
+      if (!entry.tab && tab) {
+        entry.tab = tab;
+      }
     }
 
     return entry;

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -183,6 +183,31 @@ export default function PopupMenuComponent(props) {
     });
   }, []);
 
+  // horizontal scroll on tabs
+  const handleWheel = useCallback(event => {
+    const tabsEl = tabsRef.current;
+
+    const delta = Math.abs(event.deltaX) > Math.abs(event.deltaY)
+      ? event.deltaX
+      : event.deltaY;
+
+    if (!delta) {
+      return;
+    }
+
+    const { scrollLeft, scrollWidth, clientWidth } = tabsEl;
+
+    if (scrollWidth - clientWidth < 1) {
+      return;
+    }
+
+    event.preventDefault();
+
+    tabsEl.scrollLeft = scrollLeft + delta;
+
+    updateOverflow();
+  }, [ updateOverflow ]);
+
   useLayoutEffect(() => {
     const tabsEl = tabsRef.current;
 
@@ -193,9 +218,13 @@ export default function PopupMenuComponent(props) {
     updateOverflow();
 
     tabsEl.addEventListener('scroll', updateOverflow);
+    tabsEl.addEventListener('wheel', handleWheel, { passive: false });
 
-    return () => tabsEl.removeEventListener('scroll', updateOverflow);
-  }, [ tabs, activeTabId, updateOverflow ]);
+    return () => {
+      tabsEl.removeEventListener('scroll', updateOverflow);
+      tabsEl.removeEventListener('wheel', handleWheel);
+    };
+  }, [ tabs, activeTabId, updateOverflow, handleWheel ]);
 
   /**
    * Scroll the nearest tab that is cut off in `direction` into view, so a

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -163,6 +163,72 @@ export default function PopupMenuComponent(props) {
     }
   }, [ activeTabId ]);
 
+  /**
+   * Which directions the tab strip can still be scrolled in. Drives the
+   * scroll controls, so they only show when there is somewhere to scroll.
+   *
+   * @type {[ { start: boolean, end: boolean }, (overflow: { start: boolean, end: boolean }) => void ]}
+   */
+  const [ overflow, setOverflow ] = useState({ start: false, end: false });
+
+  // only ever called while the strip is rendered, so the ref is set
+  const updateOverflow = useCallback(() => {
+    const { scrollLeft, scrollWidth, clientWidth } = tabsRef.current;
+
+    setOverflow({
+      start: scrollLeft > 0,
+
+      // sub-pixel widths leave a fractional remainder at the end
+      end: scrollWidth - clientWidth - scrollLeft > 1
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    const tabsEl = tabsRef.current;
+
+    if (!tabsEl) {
+      return;
+    }
+
+    updateOverflow();
+
+    tabsEl.addEventListener('scroll', updateOverflow);
+
+    return () => tabsEl.removeEventListener('scroll', updateOverflow);
+  }, [ tabs, activeTabId, updateOverflow ]);
+
+  /**
+   * Scroll the nearest tab that is cut off in `direction` into view, so a
+   * click always lands on a fully visible tab.
+   *
+   * @param {number} direction
+   */
+  const scrollTabs = useCallback(direction => {
+    const tabsEl = tabsRef.current;
+
+    const tabEls = direction > 0
+      ? [ ...tabsEl.children ]
+      : [ ...tabsEl.children ].reverse();
+
+    const stripBounds = tabsEl.getBoundingClientRect();
+
+    const cutOff = tabEls.find(tabEl => {
+      const bounds = tabEl.getBoundingClientRect();
+
+      return direction > 0
+        ? bounds.right > stripBounds.right + 1
+        : bounds.left < stripBounds.left - 1;
+    });
+
+    if (cutOff) {
+      scrollIntoView(cutOff);
+
+      // recompute directly: a programmatic scroll does not reliably emit a
+      // `scroll` event, so the controls would otherwise go stale
+      updateOverflow();
+    }
+  }, [ updateOverflow ]);
+
   const getEntryTabId = useCallback(entry => {
     return (entry.tab && entry.tab.id) || (defaultTab && defaultTab.id);
   }, [ defaultTab ]);
@@ -360,14 +426,30 @@ export default function PopupMenuComponent(props) {
     inputEl && inputEl.focus();
   }, []);
 
-  // arrow/Home/End navigate between tabs while the strip has focus; stop
-  // propagation so the global drill-down and entry-action bindings do not fire
+  // left/right/Home/End navigate between tabs while the strip has focus; stop
+  // propagation so the global drill-down and entry-action bindings do not fire.
+  // Up/down leave the strip instead
   const handleTabKeyDown = useCallback(event => {
     if (event.key === 'Enter' || event.key === ' ') {
 
       // let the button's native click happen, but keep the event
       // from reaching the global Enter handler (entry action)
       event.stopPropagation();
+
+      return;
+    }
+
+    // <ArrowDown> / <ArrowUp> hand focus to the panel so the menu's own
+    // bindings take over — notably <ArrowRight> to step into an entry, which
+    // would otherwise keep switching tabs. The event still bubbles, so the
+    // selection moves on the same keystroke
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      const popupEl = domClosest(event.currentTarget, '.djs-popup', true);
+
+      const focusEl = popupEl.querySelector('input')
+        || popupEl.querySelector('[role="listbox"]');
+
+      focusEl && focusEl.focus();
 
       return;
     }
@@ -481,6 +563,23 @@ export default function PopupMenuComponent(props) {
                   >${ tab.label }</button>
                 `) }
               </div>
+
+              ${ /* outside the tablist: its children must be tabs. Keyboard
+                     users navigate with the arrow keys instead */ '' }
+              ${ [ -1, 1 ].map(direction => (direction < 0 ? overflow.start : overflow.end) && html`
+                <button
+                  type="button"
+                  class=${ `djs-popup-tabs-scroll djs-popup-tabs-scroll-${ direction < 0 ? 'start' : 'end' }` }
+                  aria-hidden="true"
+                  tabIndex="-1"
+                  onMousedown=${ (event) => event.preventDefault() }
+                  onClick=${ () => scrollTabs(direction) }
+                >
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M3.96967 1.46967C4.26256 1.17678 4.73744 1.17678 5.03033 1.46967L9.03033 5.46967C9.32322 5.76256 9.32322 6.23744 9.03033 6.53033L5.03033 10.5303C4.73744 10.8232 4.26256 10.8232 3.96967 10.5303C3.67678 10.2374 3.67678 9.76256 3.96967 9.46967L7.43934 6L3.96967 2.53033C3.67678 2.23744 3.67678 1.76256 3.96967 1.46967Z" fill="currentColor"/>
+                  </svg>
+                </button>
+              `) }
             </div>
           ` }
 

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -52,6 +52,7 @@ const ids = new Ids('djs-popup');
  * @param {PopupMenuEmptyPlaceholder} [props.emptyPlaceholder]
  * @param {number|string} [props.width]
  * @param {searchFn} props.searchFn
+ * @param {import('./PopupMenuProvider.js').PopupMenuTab} [props.defaultTab]
  */
 export default function PopupMenuComponent(props) {
   const {
@@ -68,7 +69,8 @@ export default function PopupMenuComponent(props) {
     searchFn,
     entries,
     onOpened,
-    onClosed
+    onClosed,
+    defaultTab
   } = props;
 
   /**
@@ -83,11 +85,71 @@ export default function PopupMenuComponent(props) {
 
   /**
    * On `PopupMenu#refresh()` (i.e. when `entries` change)
-   * the stack is reset to root.
+   * the stack and active tab are reset to root.
    */
   useEffect(() => {
     setNavigationStack([]);
+    setActiveTab(null);
   }, [ entries ]);
+
+  /**
+   * Tabs partition root-level entries. They are derived from the entries'
+   * `tab` property; entries without a `tab` belong to the default tab. The
+   * tab strip only renders when at least two distinct tabs exist.
+   *
+   * @type {import('./PopupMenuProvider.js').PopupMenuTab[]}
+   */
+  const tabs = useMemo(() => {
+    const tabbed = [];
+    const seen = new Set();
+
+    let hasUntagged = false;
+
+    entries.forEach(({ tab }) => {
+      if (!tab) {
+        hasUntagged = true;
+
+        return;
+      }
+
+      if (!seen.has(tab.id)) {
+        seen.add(tab.id);
+        tabbed.push(tab);
+      }
+    });
+
+    if (!tabbed.length) {
+      return [];
+    }
+
+    // untagged entries need a tab to live in; without a configured
+    // `defaultTab` there is no name to give it, so stay untabbed rather
+    // than invent one
+    if (hasUntagged && !defaultTab) {
+      return [];
+    }
+
+    if (!hasUntagged) {
+      return tabbed;
+    }
+
+    return [
+      defaultTab,
+      ...tabbed.filter(tab => tab.id !== defaultTab.id)
+    ];
+  }, [ entries, defaultTab ]);
+
+  const [ activeTabOverride, setActiveTab ] = useState(null);
+
+  // the override may name a tab that no longer exists, e.g. on the render
+  // following a `PopupMenu#refresh()` that dropped it
+  const activeTabId = tabs.some(tab => tab.id === activeTabOverride)
+    ? activeTabOverride
+    : (tabs.length ? tabs[0].id : null);
+
+  const getEntryTabId = useCallback(entry => {
+    return (entry.tab && entry.tab.id) || (defaultTab && defaultTab.id);
+  }, [ defaultTab ]);
 
   const [ searchValue, setSearchValue ] = useState('');
   const isSearching = searchValue.trim().length > 0;
@@ -104,9 +166,15 @@ export default function PopupMenuComponent(props) {
 
   const entriesToShow = useMemo(() => {
 
+    // the tab filter applies at the root level only; drill-down
+    // (step entries) and search operate on the full entry set
     const availableEntries = navigationStack.length
       ? navigationStack[navigationStack.length - 1].entries
-      : entries;
+      : (
+        tabs.length > 1
+          ? entries.filter(entry => getEntryTabId(entry) === activeTabId)
+          : entries
+      );
 
     if (!searchable) return availableEntries;
 
@@ -119,7 +187,7 @@ export default function PopupMenuComponent(props) {
     }
 
     return availableEntries.filter(({ rank = 0 }) => rank >= 0);
-  }, [ searchable, isSearching, actionableEntries, searchValue, searchFn, navigationStack, entries ]);
+  }, [ searchable, isSearching, actionableEntries, searchValue, searchFn, navigationStack, entries, tabs, activeTabId, getEntryTabId ]);
 
   const groupedEntries = useMemo(() => {
     if (isSearching) {
@@ -260,6 +328,61 @@ export default function PopupMenuComponent(props) {
     }
   }, [ selectedEntry, keyboardSelect, keyboardDrilldown, handleEntryAction ]);
 
+  const selectTab = useCallback((event, tabId) => {
+    setActiveTab(tabId);
+
+    // a keyboard activation reports no click detail; keep focus in the strip
+    // so arrow navigation keeps working. A pointer click hands focus back to
+    // the search input so typing continues to work
+    if (!event.detail) {
+      return;
+    }
+
+    const popupEl = domClosest(event.currentTarget, '.djs-popup', true);
+    const inputEl = popupEl && popupEl.querySelector('input');
+
+    inputEl && inputEl.focus();
+  }, []);
+
+  // arrow/Home/End navigate between tabs while the strip has focus; stop
+  // propagation so the global drill-down and entry-action bindings do not fire
+  const handleTabKeyDown = useCallback(event => {
+    if (event.key === 'Enter' || event.key === ' ') {
+
+      // let the button's native click happen, but keep the event
+      // from reaching the global Enter handler (entry action)
+      event.stopPropagation();
+
+      return;
+    }
+
+    const idx = tabs.findIndex(tab => tab.id === activeTabId);
+
+    let nextIdx;
+
+    if (event.key === 'ArrowLeft') {
+      nextIdx = (idx - 1 + tabs.length) % tabs.length;
+    } else if (event.key === 'ArrowRight') {
+      nextIdx = (idx + 1) % tabs.length;
+    } else if (event.key === 'Home') {
+      nextIdx = 0;
+    } else if (event.key === 'End') {
+      nextIdx = tabs.length - 1;
+    } else {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    setActiveTab(tabs[nextIdx].id);
+
+    const strip = event.currentTarget.parentNode;
+    const nextButton = strip && strip.children[nextIdx];
+
+    nextButton && nextButton.focus();
+  }, [ tabs, activeTabId ]);
+
   const handleKey = useCallback(event => {
     if (domMatches(event.target, 'input')) {
       setSearchValue(() => event.target.value);
@@ -275,6 +398,7 @@ export default function PopupMenuComponent(props) {
   }, []);
 
   const displayBreadcrumbs = !isSearching && navigationStack.length > 0;
+  const displayTabs = tabs.length > 1 && !isSearching && navigationStack.length === 0;
   const displayHeader = (title || headerEntries.length > 0) && !displayBreadcrumbs;
 
   return html`
@@ -322,6 +446,24 @@ export default function PopupMenuComponent(props) {
               aria-autocomplete="list"
             />
           </div>
+          ` }
+
+          ${ displayTabs && html`
+            <div class="djs-popup-tabs" role="tablist">
+              ${ tabs.map(tab => html`
+                <button
+                  type="button"
+                  class=${ classNames('djs-popup-tab', { 'djs-popup-tab-active': tab.id === activeTabId }) }
+                  role="tab"
+                  title=${ tab.title || undefined }
+                  aria-controls=${ resultsId }
+                  aria-selected=${ tab.id === activeTabId }
+                  tabIndex=${ tab.id === activeTabId ? 0 : -1 }
+                  onClick=${ (event) => selectTab(event, tab.id) }
+                  onKeydown=${ handleTabKeyDown }
+                >${ tab.label }</button>
+              `) }
+            </div>
           ` }
 
           ${ isSearching && html`

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -147,6 +147,22 @@ export default function PopupMenuComponent(props) {
     ? activeTabOverride
     : (tabs.length ? tabs[0].id : null);
 
+  const tabsRef = useRef();
+
+  useLayoutEffect(() => {
+    const tabsEl = tabsRef.current;
+
+    if (!tabsEl) {
+      return;
+    }
+
+    const activeTabEl = tabsEl.querySelector('[aria-selected="true"]');
+
+    if (activeTabEl) {
+      scrollIntoView(activeTabEl);
+    }
+  }, [ activeTabId ]);
+
   const getEntryTabId = useCallback(entry => {
     return (entry.tab && entry.tab.id) || (defaultTab && defaultTab.id);
   }, [ defaultTab ]);
@@ -449,20 +465,22 @@ export default function PopupMenuComponent(props) {
           ` }
 
           ${ displayTabs && html`
-            <div class="djs-popup-tabs" role="tablist">
-              ${ tabs.map(tab => html`
-                <button
-                  type="button"
-                  class=${ classNames('djs-popup-tab', { 'djs-popup-tab-active': tab.id === activeTabId }) }
-                  role="tab"
-                  title=${ tab.title || undefined }
-                  aria-controls=${ resultsId }
-                  aria-selected=${ tab.id === activeTabId }
-                  tabIndex=${ tab.id === activeTabId ? 0 : -1 }
-                  onClick=${ (event) => selectTab(event, tab.id) }
-                  onKeydown=${ handleTabKeyDown }
-                >${ tab.label }</button>
-              `) }
+            <div class="djs-popup-tabs-container">
+              <div class="djs-popup-tabs" ref=${ tabsRef } role="tablist">
+                ${ tabs.map(tab => html`
+                  <button
+                    type="button"
+                    class=${ classNames('djs-popup-tab', { 'djs-popup-tab-active': tab.id === activeTabId }) }
+                    role="tab"
+                    title=${ tab.title || undefined }
+                    aria-controls=${ resultsId }
+                    aria-selected=${ tab.id === activeTabId }
+                    tabIndex=${ tab.id === activeTabId ? 0 : -1 }
+                    onClick=${ (event) => selectTab(event, tab.id) }
+                    onKeydown=${ handleTabKeyDown }
+                  >${ tab.label }</button>
+                `) }
+              </div>
             </div>
           ` }
 
@@ -510,6 +528,18 @@ export default function PopupMenuComponent(props) {
     ` }
     </${PopupMenuWrapper}>
   `;
+}
+
+function scrollIntoView(el) {
+  if (typeof el.scrollIntoViewIfNeeded === 'function') {
+    el.scrollIntoViewIfNeeded();
+  } else {
+    el.scrollIntoView({
+      scrollMode: 'if-needed',
+      block: 'nearest',
+      inline: 'nearest'
+    });
+  }
 }
 
 /**

--- a/lib/features/popup-menu/PopupMenuComponent.js
+++ b/lib/features/popup-menu/PopupMenuComponent.js
@@ -470,7 +470,7 @@ export default function PopupMenuComponent(props) {
                 ${ tabs.map(tab => html`
                   <button
                     type="button"
-                    class=${ classNames('djs-popup-tab', { 'djs-popup-tab-active': tab.id === activeTabId }) }
+                    class="djs-popup-tab"
                     role="tab"
                     title=${ tab.title || undefined }
                     aria-controls=${ resultsId }

--- a/lib/features/popup-menu/PopupMenuProvider.ts
+++ b/lib/features/popup-menu/PopupMenuProvider.ts
@@ -2,6 +2,22 @@ import type { VNode } from '@bpmn-io/diagram-js-ui';
 
 import type { PopupMenuTarget } from './PopupMenu.js';
 
+/**
+ * A tab partitioning popup menu entries. Entries carrying the same `tab.id`
+ * are shown together; entries without a `tab` belong to the default tab
+ * (`config.popupMenu.defaultTab`). The tab strip renders only when at least
+ * two distinct tabs exist.
+ */
+export type PopupMenuTab = {
+  id: string;
+  label: string;
+
+  /**
+   * Explanatory hover text, surfaced as the tab button's `title`.
+   */
+  title?: string;
+};
+
 export type PopupMenuEntryAction = (
   event: Event,
   entry: PopupMenuActionEntry,
@@ -21,6 +37,7 @@ type PopupMenuEntryBase = {
   rank?: number;
   search?: string | string[];
   searchable?: boolean;
+  tab?: PopupMenuTab;
 };
 
 /**

--- a/lib/features/popup-menu/PopupMenuProvider.ts
+++ b/lib/features/popup-menu/PopupMenuProvider.ts
@@ -3,10 +3,13 @@ import type { VNode } from '@bpmn-io/diagram-js-ui';
 import type { PopupMenuTarget } from './PopupMenu.js';
 
 /**
- * A tab partitioning popup menu entries. Entries carrying the same `tab.id`
- * are shown together; entries without a `tab` belong to the default tab
- * (`config.popupMenu.defaultTab`). The tab strip renders only when at least
- * two distinct tabs exist.
+ * A tab partitioning root-level popup menu entries. Entries carrying the
+ * same `tab.id` are shown together; entries without a `tab` fall into the
+ * default tab (`config.popupMenu.defaultTab`). The tab strip renders only when
+ * at least two distinct tabs exist.
+ *
+ * Tabs partition the root level only. A `tab` set on a nested (drilled-into)
+ * entry is ignored.
  */
 export type PopupMenuTab = {
   id: string;

--- a/lib/features/popup-menu/PopupMenuProvider.ts
+++ b/lib/features/popup-menu/PopupMenuProvider.ts
@@ -11,10 +11,6 @@ import type { PopupMenuTarget } from './PopupMenu.js';
 export type PopupMenuTab = {
   id: string;
   label: string;
-
-  /**
-   * Explanatory hover text, surfaced as the tab button's `title`.
-   */
   title?: string;
 };
 

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -132,6 +132,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
     expect(popupBounds.y).to.be.closeTo(100, 1);
   });
 
+
   it('should render disabled entry', async function() {
 
     // given
@@ -690,6 +691,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
         { id: '6', label: 'Entry 6', group: { id: 'b', name: 'Group B' } }
       ];
 
+
       it('should keep groups when not searching', async function() {
 
         // given
@@ -742,6 +744,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
         // then
         expect(domQueryAll('.entry-header', container)).to.have.length(2);
       });
+
     });
 
 
@@ -795,6 +798,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
       { id: '2', label: 'Entry 2' },
       { id: '3', label: 'Entry 3' }
     ];
+
 
     it('should select entry on hover', async function() {
 
@@ -2033,10 +2037,10 @@ describe('features/popup-menu - <PopupMenu>', function() {
       render(null, otherContainer);
       document.body.removeChild(otherContainer);
     });
+
   });
 
 
-  // helpers
   describe('tabs', function() {
 
     const REUSABLE_TAB = { id: 'reusable', label: 'Reusable' };
@@ -2434,6 +2438,8 @@ describe('features/popup-menu - <PopupMenu>', function() {
     });
   });
 
+
+  // helpers
   async function createPopupMenu(options) {
 
     const {

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -2055,6 +2055,14 @@ describe('features/popup-menu - <PopupMenu>', function() {
       { id: 'entry-4', label: 'Entry 4', action: () => {} }
     ];
 
+    const manyTabEntries = [
+      { id: 'first-entry', label: 'First entry', tab: { id: 'first', label: 'First tab' }, action: () => {} },
+      { id: 'second-entry', label: 'Second entry', tab: { id: 'second', label: 'Second tab' }, action: () => {} },
+      { id: 'third-entry', label: 'Third entry', tab: { id: 'third', label: 'Third tab' }, action: () => {} },
+      { id: 'fourth-entry', label: 'Fourth entry', tab: { id: 'fourth', label: 'Fourth tab' }, action: () => {} },
+      { id: 'fifth-entry', label: 'Fifth entry', tab: { id: 'fifth', label: 'Fifth tab' }, action: () => {} }
+    ];
+
     it('should render tab strip when entries carry distinct tabs', async function() {
 
       // when
@@ -2401,6 +2409,31 @@ describe('features/popup-menu - <PopupMenu>', function() {
       // then
       const selected = [ ...domQueryAll('.djs-popup-tab', container) ].map(e => e.getAttribute('aria-selected'));
       expect(selected).to.eql([ 'true', 'false' ]);
+    });
+
+
+    it('should scroll active tab into view', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: manyTabEntries });
+
+      const strip = domQuery('.djs-popup-tabs', container);
+      const lastTab = strip.children[4];
+      const method = typeof lastTab.scrollIntoViewIfNeeded === 'function'
+        ? 'scrollIntoViewIfNeeded'
+        : 'scrollIntoView';
+      const scrollIntoView = spy();
+
+      lastTab[method] = scrollIntoView;
+      strip.children[0].focus();
+
+      // when
+      await act(() => {
+        fireEvent.keyDown(strip.children[0], { key: 'End' });
+      });
+
+      // then
+      expect(scrollIntoView).to.have.been.called;
     });
 
 

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -2037,6 +2037,403 @@ describe('features/popup-menu - <PopupMenu>', function() {
 
 
   // helpers
+  describe('tabs', function() {
+
+    const REUSABLE_TAB = { id: 'reusable', label: 'Reusable' };
+    const DEFAULT_TAB = { id: 'bpmn', label: 'BPMN' };
+
+    const tabbedEntries = [
+      { id: 'task', label: 'Task', action: () => {} },
+      { id: 'gateway', label: 'Gateway', action: () => {} },
+      { id: 'connector-a', label: 'Connector A', tab: REUSABLE_TAB, action: () => {} },
+      { id: 'connector-b', label: 'Connector B', tab: REUSABLE_TAB, action: () => {} },
+      { id: 'event', label: 'Event', action: () => {} },
+      { id: 'subprocess', label: 'Sub-process', action: () => {} }
+    ];
+
+    it('should render tab strip when entries carry distinct tabs', async function() {
+
+      // when
+      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+
+      // then
+      const tabs = [ ...domQueryAll('.djs-popup-tab', container) ].map(e => e.textContent.trim());
+      expect(tabs).to.eql([ 'BPMN', 'Reusable' ]);
+    });
+
+
+    it('should not render tab strip without tabbed entries', async function() {
+
+      // given
+      const entries = tabbedEntries.filter(entry => !entry.tab);
+
+      // when
+      await createPopupMenu({ container, entries, defaultTab: DEFAULT_TAB });
+
+      // then
+      expect(domQuery('.djs-popup-tabs', container)).not.to.exist;
+    });
+
+
+    it('should not render a default tab when every entry is tabbed', async function() {
+
+      // given
+      const entries = tabbedEntries.filter(entry => entry.tab);
+
+      // when
+      await createPopupMenu({ container, entries, defaultTab: DEFAULT_TAB });
+
+      // then
+      expect(domQuery('.djs-popup-tabs', container)).not.to.exist;
+    });
+
+
+    it('should stay untabbed when untagged entries have no default tab', async function() {
+
+      // when
+      await createPopupMenu({ container, entries: tabbedEntries });
+
+      // then
+      expect(domQuery('.djs-popup-tabs', container)).not.to.exist;
+    });
+
+
+    it('should keep the default tab when entries tag it explicitly', async function() {
+
+      // given
+      const entries = tabbedEntries.map(entry => ({ ...entry, tab: entry.tab || DEFAULT_TAB }));
+
+      // when
+      await createPopupMenu({ container, entries, defaultTab: DEFAULT_TAB });
+
+      // then
+      const tabs = [ ...domQueryAll('.djs-popup-tab', container) ].map(e => e.textContent.trim());
+      expect(tabs).to.eql([ 'BPMN', 'Reusable' ]);
+    });
+
+
+    it('should show default tab entries initially', async function() {
+
+      // when
+      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+
+      // then
+      const labels = [ ...domQueryAll('.djs-popup-label', container) ].map(e => e.textContent.trim());
+      expect(labels).to.eql([ 'Task', 'Gateway', 'Event', 'Sub-process' ]);
+    });
+
+
+    it('should switch entries on tab select', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+
+      // when
+      await act(() => {
+        fireEvent.click(domQueryAll('.djs-popup-tab', container)[1]);
+      });
+
+      // then
+      const labels = [ ...domQueryAll('.djs-popup-label', container) ].map(e => e.textContent.trim());
+      expect(labels).to.eql([ 'Connector A', 'Connector B' ]);
+
+      const selected = [ ...domQueryAll('.djs-popup-tab', container) ].map(e => e.getAttribute('aria-selected'));
+      expect(selected).to.eql([ 'false', 'true' ]);
+    });
+
+
+    it('should search globally across tabs', async function() {
+
+      // given
+      const entries = [
+        { id: 'send-task', label: 'Send task', group: { id: 'tasks', name: 'Tasks' }, action: () => {} },
+        {
+          id: 'send-connector',
+          label: 'Send connector',
+          tab: REUSABLE_TAB,
+          group: { id: 'communication', name: 'Communication' },
+          action: () => {}
+        },
+        ...tabbedEntries
+      ];
+
+      await createPopupMenu({ container, entries, defaultTab: DEFAULT_TAB, search: true });
+
+      const input = domQuery('.djs-popup-search input', container);
+      input.value = 'send';
+
+      // when
+      fireEvent.keyUp(input, { key: 'd' });
+
+      // then
+      const labels = [ ...domQueryAll('.djs-popup-label', container) ].map(e => e.textContent.trim());
+      expect(labels).to.have.members([ 'Send task', 'Send connector' ]);
+    });
+
+
+    it('should hide tab strip while searching', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB, search: true });
+
+      const input = domQuery('.djs-popup-search input', container);
+      input.value = 'connector';
+
+      // when
+      fireEvent.keyUp(input, { key: 'r' });
+
+      // then
+      expect(domQuery('.djs-popup-tabs', container)).not.to.exist;
+    });
+
+
+    it('should restore active tab after clearing search', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB, search: true });
+
+      await act(() => {
+        fireEvent.click(domQueryAll('.djs-popup-tab', container)[1]);
+      });
+
+      const input = domQuery('.djs-popup-search input', container);
+      input.value = 'task';
+      fireEvent.keyUp(input, { key: 'k' });
+
+      // when
+      input.value = '';
+      fireEvent.keyUp(input, { key: 'Backspace' });
+
+      // then
+      const selected = [ ...domQueryAll('.djs-popup-tab', container) ].map(e => e.getAttribute('aria-selected'));
+      expect(selected).to.eql([ 'false', 'true' ]);
+
+      const labels = [ ...domQueryAll('.djs-popup-label', container) ].map(e => e.textContent.trim());
+      expect(labels).to.eql([ 'Connector A', 'Connector B' ]);
+    });
+
+
+    it('should hide tab strip while drilled into a step entry', async function() {
+
+      // given
+
+      // the step entry comes first so it is the initially selected
+      // entry (drill-down acts on the selected entry)
+      const entries = [
+        {
+          id: 'multi-step',
+          label: 'Multi step',
+          entries: [
+            { id: 'step-1', label: 'Step 1', action: () => {} }
+          ]
+        },
+        ...tabbedEntries
+      ];
+
+      await createPopupMenu({ container, entries, defaultTab: DEFAULT_TAB });
+
+      // when
+      await act(() => {
+        fireEvent.click(domQuery('.entry[data-id="multi-step"]', container));
+      });
+
+      // then
+      expect(domQuery('.djs-popup-tabs', container)).not.to.exist;
+      expect(domQuery('.djs-popup-breadcrumbs', container)).to.exist;
+    });
+
+
+    it('should switch tabs with arrow keys within the strip', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+
+      const strip = domQuery('.djs-popup-tabs', container);
+      const firstTab = strip.children[0];
+
+      firstTab.focus();
+
+      // when
+      await act(() => {
+        fireEvent.keyDown(firstTab, { key: 'ArrowRight' });
+      });
+
+      // then
+      const selected = [ ...domQueryAll('.djs-popup-tab', container) ].map(e => e.getAttribute('aria-selected'));
+      expect(selected).to.eql([ 'false', 'true' ]);
+    });
+
+
+    it('should keep focus in the strip when activating a tab by keyboard', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB, search: true });
+
+      const strip = domQuery('.djs-popup-tabs', container);
+
+      strip.children[1].focus();
+
+      // when
+      await act(() => {
+        fireEvent.click(strip.children[1], { detail: 0 });
+      });
+
+      // then
+      expect(document.activeElement).to.equal(strip.children[1]);
+    });
+
+
+    it('should focus the search input when activating a tab by pointer', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB, search: true });
+
+      const strip = domQuery('.djs-popup-tabs', container);
+
+      // when
+      await act(() => {
+        fireEvent.click(strip.children[1], { detail: 1 });
+      });
+
+      // then
+      expect(document.activeElement).to.equal(domQuery('.djs-popup-search input', container));
+    });
+
+
+    it('should switch tabs backwards with <ArrowLeft>', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+
+      const strip = domQuery('.djs-popup-tabs', container);
+
+      strip.children[0].focus();
+
+      // when
+      await act(() => {
+        fireEvent.keyDown(strip.children[0], { key: 'ArrowLeft' });
+      });
+
+      // then
+      const selected = [ ...domQueryAll('.djs-popup-tab', container) ].map(e => e.getAttribute('aria-selected'));
+      expect(selected).to.eql([ 'false', 'true' ]);
+    });
+
+
+    it('should ignore other keys within the strip', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+
+      const strip = domQuery('.djs-popup-tabs', container);
+
+      strip.children[0].focus();
+
+      // when
+      await act(() => {
+        fireEvent.keyDown(strip.children[0], { key: 'a' });
+      });
+
+      // then
+      const selected = [ ...domQueryAll('.djs-popup-tab', container) ].map(e => e.getAttribute('aria-selected'));
+      expect(selected).to.eql([ 'true', 'false' ]);
+    });
+
+
+    it('should not trigger selected entry when pressing <Enter> on a tab', async function() {
+
+      // given
+      const onSelect = spy();
+
+      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB, onSelect });
+
+      const strip = domQuery('.djs-popup-tabs', container);
+
+      // when
+      strip.children[0].focus();
+      fireEvent.keyDown(strip.children[0], { key: 'Enter' });
+
+      // then
+      expect(onSelect).not.to.have.been.called;
+    });
+
+
+    it('should switch to last tab with <End>', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+
+      const strip = domQuery('.djs-popup-tabs', container);
+
+      strip.children[0].focus();
+
+      // when
+      await act(() => {
+        fireEvent.keyDown(strip.children[0], { key: 'End' });
+      });
+
+      // then
+      const selected = [ ...domQueryAll('.djs-popup-tab', container) ].map(e => e.getAttribute('aria-selected'));
+      expect(selected).to.eql([ 'false', 'true' ]);
+    });
+
+
+    it('should switch to first tab with <Home>', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+
+      const strip = domQuery('.djs-popup-tabs', container);
+
+      await act(() => {
+        fireEvent.click(strip.children[1]);
+      });
+
+      // when
+      await act(() => {
+        fireEvent.keyDown(strip.children[1], { key: 'Home' });
+      });
+
+      // then
+      const selected = [ ...domQueryAll('.djs-popup-tab', container) ].map(e => e.getAttribute('aria-selected'));
+      expect(selected).to.eql([ 'true', 'false' ]);
+    });
+
+
+    it('should render tab title as hover text', async function() {
+
+      // given
+      const entries = [
+        { id: 'task', label: 'Task', action: () => {} },
+        {
+          id: 'connector',
+          label: 'Connector',
+          tab: { ...REUSABLE_TAB, title: 'Building blocks you can reuse' },
+          action: () => {}
+        }
+      ];
+
+      // when
+      await createPopupMenu({ container, entries, defaultTab: DEFAULT_TAB });
+
+      // then
+      const titles = [ ...domQueryAll('.djs-popup-tab', container) ].map(e => e.getAttribute('title'));
+      expect(titles).to.eql([ null, 'Building blocks you can reuse' ]);
+    });
+
+
+    it('should point each tab at the results list', async function() {
+
+      // when
+      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+
+      // then
+      const resultsId = domQuery('[role="listbox"]', container).id;
+      const controls = [ ...domQueryAll('.djs-popup-tab', container) ].map(e => e.getAttribute('aria-controls'));
+      expect(controls).to.eql([ resultsId, resultsId ]);
+    });
+  });
+
   async function createPopupMenu(options) {
 
     const {

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -2043,33 +2043,33 @@ describe('features/popup-menu - <PopupMenu>', function() {
 
   describe('tabs', function() {
 
-    const REUSABLE_TAB = { id: 'reusable', label: 'Reusable' };
-    const DEFAULT_TAB = { id: 'bpmn', label: 'BPMN' };
+    const CUSTOM_TAB = { id: 'custom', label: 'Custom' };
+    const DEFAULT_TAB = { id: 'default', label: 'Default' };
 
-    const tabbedEntries = [
-      { id: 'task', label: 'Task', action: () => {} },
-      { id: 'gateway', label: 'Gateway', action: () => {} },
-      { id: 'connector-a', label: 'Connector A', tab: REUSABLE_TAB, action: () => {} },
-      { id: 'connector-b', label: 'Connector B', tab: REUSABLE_TAB, action: () => {} },
-      { id: 'event', label: 'Event', action: () => {} },
-      { id: 'subprocess', label: 'Sub-process', action: () => {} }
+    const tabEntries = [
+      { id: 'entry-1', label: 'Entry 1', action: () => {} },
+      { id: 'entry-2', label: 'Entry 2', action: () => {} },
+      { id: 'custom-entry-1', label: 'Custom Entry 1', tab: CUSTOM_TAB, action: () => {} },
+      { id: 'custom-entry-2', label: 'Custom Entry 2', tab: CUSTOM_TAB, action: () => {} },
+      { id: 'entry-3', label: 'Entry 3', action: () => {} },
+      { id: 'entry-4', label: 'Entry 4', action: () => {} }
     ];
 
     it('should render tab strip when entries carry distinct tabs', async function() {
 
       // when
-      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+      await createPopupMenu({ container, entries: tabEntries, defaultTab: DEFAULT_TAB });
 
       // then
       const tabs = [ ...domQueryAll('.djs-popup-tab', container) ].map(e => e.textContent.trim());
-      expect(tabs).to.eql([ 'BPMN', 'Reusable' ]);
+      expect(tabs).to.eql([ 'Default', 'Custom' ]);
     });
 
 
     it('should not render tab strip without tabbed entries', async function() {
 
       // given
-      const entries = tabbedEntries.filter(entry => !entry.tab);
+      const entries = tabEntries.filter(entry => !entry.tab);
 
       // when
       await createPopupMenu({ container, entries, defaultTab: DEFAULT_TAB });
@@ -2082,7 +2082,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
     it('should not render a default tab when every entry is tabbed', async function() {
 
       // given
-      const entries = tabbedEntries.filter(entry => entry.tab);
+      const entries = tabEntries.filter(entry => entry.tab);
 
       // when
       await createPopupMenu({ container, entries, defaultTab: DEFAULT_TAB });
@@ -2095,7 +2095,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
     it('should stay untabbed when untagged entries have no default tab', async function() {
 
       // when
-      await createPopupMenu({ container, entries: tabbedEntries });
+      await createPopupMenu({ container, entries: tabEntries });
 
       // then
       expect(domQuery('.djs-popup-tabs', container)).not.to.exist;
@@ -2105,32 +2105,32 @@ describe('features/popup-menu - <PopupMenu>', function() {
     it('should keep the default tab when entries tag it explicitly', async function() {
 
       // given
-      const entries = tabbedEntries.map(entry => ({ ...entry, tab: entry.tab || DEFAULT_TAB }));
+      const entries = tabEntries.map(entry => ({ ...entry, tab: entry.tab || DEFAULT_TAB }));
 
       // when
       await createPopupMenu({ container, entries, defaultTab: DEFAULT_TAB });
 
       // then
       const tabs = [ ...domQueryAll('.djs-popup-tab', container) ].map(e => e.textContent.trim());
-      expect(tabs).to.eql([ 'BPMN', 'Reusable' ]);
+      expect(tabs).to.eql([ 'Default', 'Custom' ]);
     });
 
 
     it('should show default tab entries initially', async function() {
 
       // when
-      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+      await createPopupMenu({ container, entries: tabEntries, defaultTab: DEFAULT_TAB });
 
       // then
       const labels = [ ...domQueryAll('.djs-popup-label', container) ].map(e => e.textContent.trim());
-      expect(labels).to.eql([ 'Task', 'Gateway', 'Event', 'Sub-process' ]);
+      expect(labels).to.eql([ 'Entry 1', 'Entry 2', 'Entry 3', 'Entry 4' ]);
     });
 
 
     it('should switch entries on tab select', async function() {
 
       // given
-      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+      await createPopupMenu({ container, entries: tabEntries, defaultTab: DEFAULT_TAB });
 
       // when
       await act(() => {
@@ -2139,7 +2139,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
 
       // then
       const labels = [ ...domQueryAll('.djs-popup-label', container) ].map(e => e.textContent.trim());
-      expect(labels).to.eql([ 'Connector A', 'Connector B' ]);
+      expect(labels).to.eql([ 'Custom Entry 1', 'Custom Entry 2' ]);
 
       const selected = [ ...domQueryAll('.djs-popup-tab', container) ].map(e => e.getAttribute('aria-selected'));
       expect(selected).to.eql([ 'false', 'true' ]);
@@ -2150,38 +2150,38 @@ describe('features/popup-menu - <PopupMenu>', function() {
 
       // given
       const entries = [
-        { id: 'send-task', label: 'Send task', group: { id: 'tasks', name: 'Tasks' }, action: () => {} },
+        { id: 'search-default', label: 'Search Default', group: { id: 'default', name: 'Default' }, action: () => {} },
         {
-          id: 'send-connector',
-          label: 'Send connector',
-          tab: REUSABLE_TAB,
-          group: { id: 'communication', name: 'Communication' },
+          id: 'search-custom',
+          label: 'Search Custom',
+          tab: CUSTOM_TAB,
+          group: { id: 'custom', name: 'Custom' },
           action: () => {}
         },
-        ...tabbedEntries
+        ...tabEntries
       ];
 
       await createPopupMenu({ container, entries, defaultTab: DEFAULT_TAB, search: true });
 
       const input = domQuery('.djs-popup-search input', container);
-      input.value = 'send';
+      input.value = 'search';
 
       // when
       fireEvent.keyUp(input, { key: 'd' });
 
       // then
       const labels = [ ...domQueryAll('.djs-popup-label', container) ].map(e => e.textContent.trim());
-      expect(labels).to.have.members([ 'Send task', 'Send connector' ]);
+      expect(labels).to.have.members([ 'Search Default', 'Search Custom' ]);
     });
 
 
     it('should hide tab strip while searching', async function() {
 
       // given
-      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB, search: true });
+      await createPopupMenu({ container, entries: tabEntries, defaultTab: DEFAULT_TAB, search: true });
 
       const input = domQuery('.djs-popup-search input', container);
-      input.value = 'connector';
+      input.value = 'custom';
 
       // when
       fireEvent.keyUp(input, { key: 'r' });
@@ -2194,14 +2194,14 @@ describe('features/popup-menu - <PopupMenu>', function() {
     it('should restore active tab after clearing search', async function() {
 
       // given
-      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB, search: true });
+      await createPopupMenu({ container, entries: tabEntries, defaultTab: DEFAULT_TAB, search: true });
 
       await act(() => {
         fireEvent.click(domQueryAll('.djs-popup-tab', container)[1]);
       });
 
       const input = domQuery('.djs-popup-search input', container);
-      input.value = 'task';
+      input.value = 'custom';
       fireEvent.keyUp(input, { key: 'k' });
 
       // when
@@ -2213,7 +2213,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
       expect(selected).to.eql([ 'false', 'true' ]);
 
       const labels = [ ...domQueryAll('.djs-popup-label', container) ].map(e => e.textContent.trim());
-      expect(labels).to.eql([ 'Connector A', 'Connector B' ]);
+      expect(labels).to.eql([ 'Custom Entry 1', 'Custom Entry 2' ]);
     });
 
 
@@ -2231,7 +2231,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
             { id: 'step-1', label: 'Step 1', action: () => {} }
           ]
         },
-        ...tabbedEntries
+        ...tabEntries
       ];
 
       await createPopupMenu({ container, entries, defaultTab: DEFAULT_TAB });
@@ -2250,7 +2250,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
     it('should switch tabs with arrow keys within the strip', async function() {
 
       // given
-      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+      await createPopupMenu({ container, entries: tabEntries, defaultTab: DEFAULT_TAB });
 
       const strip = domQuery('.djs-popup-tabs', container);
       const firstTab = strip.children[0];
@@ -2271,7 +2271,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
     it('should keep focus in the strip when activating a tab by keyboard', async function() {
 
       // given
-      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB, search: true });
+      await createPopupMenu({ container, entries: tabEntries, defaultTab: DEFAULT_TAB, search: true });
 
       const strip = domQuery('.djs-popup-tabs', container);
 
@@ -2290,7 +2290,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
     it('should focus the search input when activating a tab by pointer', async function() {
 
       // given
-      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB, search: true });
+      await createPopupMenu({ container, entries: tabEntries, defaultTab: DEFAULT_TAB, search: true });
 
       const strip = domQuery('.djs-popup-tabs', container);
 
@@ -2307,7 +2307,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
     it('should switch tabs backwards with <ArrowLeft>', async function() {
 
       // given
-      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+      await createPopupMenu({ container, entries: tabEntries, defaultTab: DEFAULT_TAB });
 
       const strip = domQuery('.djs-popup-tabs', container);
 
@@ -2327,7 +2327,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
     it('should ignore other keys within the strip', async function() {
 
       // given
-      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+      await createPopupMenu({ container, entries: tabEntries, defaultTab: DEFAULT_TAB });
 
       const strip = domQuery('.djs-popup-tabs', container);
 
@@ -2349,7 +2349,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
       // given
       const onSelect = spy();
 
-      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB, onSelect });
+      await createPopupMenu({ container, entries: tabEntries, defaultTab: DEFAULT_TAB, onSelect });
 
       const strip = domQuery('.djs-popup-tabs', container);
 
@@ -2365,7 +2365,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
     it('should switch to last tab with <End>', async function() {
 
       // given
-      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+      await createPopupMenu({ container, entries: tabEntries, defaultTab: DEFAULT_TAB });
 
       const strip = domQuery('.djs-popup-tabs', container);
 
@@ -2385,7 +2385,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
     it('should switch to first tab with <Home>', async function() {
 
       // given
-      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+      await createPopupMenu({ container, entries: tabEntries, defaultTab: DEFAULT_TAB });
 
       const strip = domQuery('.djs-popup-tabs', container);
 
@@ -2408,11 +2408,11 @@ describe('features/popup-menu - <PopupMenu>', function() {
 
       // given
       const entries = [
-        { id: 'task', label: 'Task', action: () => {} },
+        { id: 'entry-1', label: 'Entry 1', action: () => {} },
         {
-          id: 'connector',
-          label: 'Connector',
-          tab: { ...REUSABLE_TAB, title: 'Building blocks you can reuse' },
+          id: 'custom-entry',
+          label: 'Custom Entry',
+          tab: { ...CUSTOM_TAB, title: 'Building blocks you can reuse' },
           action: () => {}
         }
       ];
@@ -2429,7 +2429,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
     it('should point each tab at the results list', async function() {
 
       // when
-      await createPopupMenu({ container, entries: tabbedEntries, defaultTab: DEFAULT_TAB });
+      await createPopupMenu({ container, entries: tabEntries, defaultTab: DEFAULT_TAB });
 
       // then
       const resultsId = domQuery('[role="listbox"]', container).id;

--- a/test/spec/features/popup-menu/PopupMenuComponentSpec.js
+++ b/test/spec/features/popup-menu/PopupMenuComponentSpec.js
@@ -2060,7 +2060,9 @@ describe('features/popup-menu - <PopupMenu>', function() {
       { id: 'second-entry', label: 'Second entry', tab: { id: 'second', label: 'Second tab' }, action: () => {} },
       { id: 'third-entry', label: 'Third entry', tab: { id: 'third', label: 'Third tab' }, action: () => {} },
       { id: 'fourth-entry', label: 'Fourth entry', tab: { id: 'fourth', label: 'Fourth tab' }, action: () => {} },
-      { id: 'fifth-entry', label: 'Fifth entry', tab: { id: 'fifth', label: 'Fifth tab' }, action: () => {} }
+      { id: 'fifth-entry', label: 'Fifth entry', tab: { id: 'fifth', label: 'Fifth tab' }, action: () => {} },
+      { id: 'sixth-entry', label: 'Sixth entry', tab: { id: 'sixth', label: 'Sixth tab' }, action: () => {} },
+      { id: 'seventh-entry', label: 'Seventh entry', tab: { id: 'seventh', label: 'Seventh tab' }, action: () => {} }
     ];
 
     it('should render tab strip when entries carry distinct tabs', async function() {
@@ -2276,6 +2278,64 @@ describe('features/popup-menu - <PopupMenu>', function() {
     });
 
 
+    it('should step into an entry after leaving the strip with <ArrowDown>', async function() {
+
+      // given
+
+      // the step entry sits second so a single <ArrowDown> selects it
+      const [ firstEntry, ...restEntries ] = tabEntries;
+
+      const entries = [
+        firstEntry,
+        {
+          id: 'multi-step',
+          label: 'Multi step',
+          entries: [
+            { id: 'step-1', label: 'Step 1', action: () => {} }
+          ]
+        },
+        ...restEntries
+      ];
+
+      await createPopupMenu({ container, entries, defaultTab: DEFAULT_TAB, search: true });
+
+      const strip = domQuery('.djs-popup-tabs', container);
+
+      strip.children[0].focus();
+
+      await act(() => {
+        fireEvent.keyDown(strip.children[0], { key: 'ArrowDown' });
+      });
+
+      // when
+      await act(() => {
+        fireEvent.keyDown(document.activeElement, { key: 'ArrowRight' });
+      });
+
+      // then
+      expect(domQuery('.djs-popup-breadcrumbs', container)).to.exist;
+    });
+
+
+    it('should focus the list when leaving the strip without search', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: tabEntries, defaultTab: DEFAULT_TAB });
+
+      const strip = domQuery('.djs-popup-tabs', container);
+
+      strip.children[0].focus();
+
+      // when
+      await act(() => {
+        fireEvent.keyDown(strip.children[0], { key: 'ArrowDown' });
+      });
+
+      // then
+      expect(document.activeElement).to.equal(domQuery('[role="listbox"]', container));
+    });
+
+
     it('should keep focus in the strip when activating a tab by keyboard', async function() {
 
       // given
@@ -2418,7 +2478,7 @@ describe('features/popup-menu - <PopupMenu>', function() {
       await createPopupMenu({ container, entries: manyTabEntries });
 
       const strip = domQuery('.djs-popup-tabs', container);
-      const lastTab = strip.children[4];
+      const lastTab = strip.lastElementChild;
       const method = typeof lastTab.scrollIntoViewIfNeeded === 'function'
         ? 'scrollIntoViewIfNeeded'
         : 'scrollIntoView';
@@ -2434,6 +2494,102 @@ describe('features/popup-menu - <PopupMenu>', function() {
 
       // then
       expect(scrollIntoView).to.have.been.called;
+    });
+
+
+    it('should not render scroll controls when tabs fit', async function() {
+
+      // given
+
+      // when
+      await createPopupMenu({ container, entries: tabEntries, defaultTab: DEFAULT_TAB });
+
+      // then
+      expect(domQuery('.djs-popup-tabs-scroll', container)).not.to.exist;
+    });
+
+
+    it('should render scroll control when tabs overflow', async function() {
+
+      // given
+
+      // when
+      await createPopupMenu({ container, entries: manyTabEntries });
+
+      // then
+      expect(domQuery('.djs-popup-tabs-scroll-end', container)).to.exist;
+    });
+
+
+    it('should scroll cut off tab into view on scroll control click', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: manyTabEntries });
+
+      const strip = domQuery('.djs-popup-tabs', container);
+
+      // when
+      await act(() => {
+        fireEvent.click(domQuery('.djs-popup-tabs-scroll-end', container));
+      });
+
+      // then
+      expect(strip.scrollLeft).to.be.above(0);
+    });
+
+
+    it('should reveal the start control once scrolled', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: manyTabEntries });
+
+      // when
+      await act(() => {
+        fireEvent.click(domQuery('.djs-popup-tabs-scroll-end', container));
+      });
+
+      // then
+      expect(domQuery('.djs-popup-tabs-scroll-start', container)).to.exist;
+    });
+
+
+    it('should scroll back on start control click', async function() {
+
+      // given
+      await createPopupMenu({ container, entries: manyTabEntries });
+
+      const strip = domQuery('.djs-popup-tabs', container);
+
+      strip.children[0].focus();
+
+      await act(() => {
+        fireEvent.keyDown(strip.children[0], { key: 'End' });
+      });
+
+      const scrolled = strip.scrollLeft;
+
+      // when
+      await act(() => {
+        fireEvent.click(domQuery('.djs-popup-tabs-scroll-start', container));
+      });
+
+      // then
+      expect(strip.scrollLeft).to.be.below(scrolled);
+    });
+
+
+    it('should keep scroll controls out of the tab order', async function() {
+
+      // given
+
+      // when
+      await createPopupMenu({ container, entries: manyTabEntries });
+
+      // then
+      const control = domQuery('.djs-popup-tabs-scroll-end', container);
+
+      expect(control.getAttribute('tabindex')).to.eql('-1');
+      expect(control.getAttribute('aria-hidden')).to.eql('true');
     });
 
 


### PR DESCRIPTION
### Proposed Changes

<img width="592" height="486" alt="image" src="https://github.com/user-attachments/assets/10d7d192-60e6-4463-b8ec-d8f699f34c71" />

Adds a generic, opt-in tabs primitive to the popup menu, so a provider can partition root-level entries.

* an entry may carry `tab: { id, label, title? }`
* `config.popupMenu.defaultTab` names the tab untagged entries fall into
* the strip renders only when at least two distinct tabs exist — with no provider setting `entry.tab`, nothing about the menu changes

Tabs filter at root level only, so drill-down and search keep operating on the full entry set; search stays flat and rank-ordered. The strip hides while searching and while drilled into a step entry. Leaf entries inherit their nearest ancestor's `tab`, so multi-step operations attribute correctly.

Accessibility follows the tablist pattern: `role="tablist"`/`role="tab"`, `aria-selected`, roving `tabindex`, Arrow/Home/End. Each tab points at the results list via `aria-controls`; the list keeps `role="listbox"` since the search combobox owns it — happy to change that if you'd prefer `role="tabpanel"`.

Styling goes through `--popup-tab-*` variables alongside the existing `--popup-search-*` ones, so downstream can re-theme by re-declaring variables instead of duplicating rules.

Closes https://github.com/bpmn-io/diagram-js/issues/1095

**Steps to try out.** The primitive is inert on its own — nothing in diagram-js sets `entry.tab` — so it needs a consumer that opts in. Pairing it with the Camunda-side policy shows the real thing:

```
npx @bpmn-io/sr camunda/camunda-bpmn-js#feat-reusable-assets-tab -l bpmn-io/diagram-js#feat-popup-menu-tabs
```

Open the append menu on any task. Entries split across a `BPMN` tab and a `Reusable Assets` tab; the strip hides while searching and while drilled into a category. That branch is camunda/camunda-bpmn-js#491.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)


