### PR TITLE
fix(keep-selection-visible): cancel scheduled update on destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+* `FIX`: do not keep selection visible after diagram destroy ([#1098](https://github.com/bpmn-io/diagram-js/pull/1098))
+
 ## 15.24.0
 
 * `FEAT`: support tabs in the popup menu ([#1095](https://github.com/bpmn-io/diagram-js/issues/1095))

--- a/lib/features/keep-selection-visible/KeepSelectionVisible.js
+++ b/lib/features/keep-selection-visible/KeepSelectionVisible.js
@@ -29,6 +29,11 @@ export default function KeepSelectionVisible(eventBus, canvas, selection) {
   eventBus.on('canvas.viewbox.changed', updateSelectionVisible);
   eventBus.on('selection.changed', updateSelectionVisible);
 
+  // a pending update would compute the viewbox of a torn down canvas
+  eventBus.on('diagram.destroy', () => {
+    updateSelectionVisible.cancel();
+  });
+
   eventBus.on('canvas.resized', () => {
     var selected = selection.get();
 

--- a/test/spec/features/keep-selection-visible/KeepSelectionVisibleSpec.js
+++ b/test/spec/features/keep-selection-visible/KeepSelectionVisibleSpec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { spy } from 'sinon';
 
 import {
   bootstrapDiagram,
@@ -12,6 +13,8 @@ import keepSelectionVisibleModule from 'lib/features/keep-selection-visible';
 
 import { getBBox } from 'lib/util/Elements';
 import { asTRBL } from 'lib/layout/LayoutUtil';
+
+var UPDATE_DEBOUNCE_INTERVAL = 300;
 
 
 describe('features/keep-selection-visible', function() {
@@ -276,6 +279,29 @@ describe('features/keep-selection-visible', function() {
 
   });
 
+
+  describe('teardown', function() {
+
+    it('should cancel scheduled update when diagram is destroyed', inject(
+      async function(canvas, selection) {
+
+        // given
+        selection.select(shape1);
+
+        var viewboxSpy = spy(canvas, 'viewbox');
+
+        // when
+        getDiagramJS().destroy();
+
+        await wait(UPDATE_DEBOUNCE_INTERVAL * 2);
+
+        // then
+        expect(viewboxSpy).not.to.have.been.called;
+      }
+    ));
+
+  });
+
 });
 
 
@@ -321,4 +347,8 @@ function act(fn) {
       keepSelectionVisible._flush();
     }
   });
+}
+
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/test/spec/features/keep-selection-visible/KeepSelectionVisibleSpec.js
+++ b/test/spec/features/keep-selection-visible/KeepSelectionVisibleSpec.js
@@ -293,10 +293,12 @@ describe('features/keep-selection-visible', function() {
         // when
         getDiagramJS().destroy();
 
+        var viewboxCallCount = viewboxSpy.callCount;
+
         await wait(UPDATE_DEBOUNCE_INTERVAL * 2);
 
         // then
-        expect(viewboxSpy).not.to.have.been.called;
+        expect(viewboxSpy.callCount).to.equal(viewboxCallCount);
       }
     ));
 


### PR DESCRIPTION
The debounced visibility update outlived the diagram, computing the viewbox of an already torn down canvas and throwing.

Related to https://github.com/camunda/camunda-modeler/issues/5957

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
