### PR TITLE
feat: add themeable, WCAG AA compliant primary accent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+* `FEAT`: add `--accent-color` theming token ([#1099](https://github.com/bpmn-io/diagram-js/pull/1099))
+* `FIX`: use WCAG AA compliant primary accent color ([#1099](https://github.com/bpmn-io/diagram-js/pull/1099))
+
 ## 15.24.1
 
 * `FIX`: do not keep selection visible after diagram destroy ([#1098](https://github.com/bpmn-io/diagram-js/pull/1098))

--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -12,6 +12,7 @@
   --color-grey-225-10-95: hsl(225, 10%, 95%);
   --color-grey-225-10-97: hsl(225, 10%, 97%);
 
+  --color-blue-205-100-40: hsl(205, 100%, 40%);
   --color-blue-205-100-45: hsl(205, 100%, 45%);
   --color-blue-205-100-45-opacity-30: hsla(205, 100%, 45%, 30%);
   --color-blue-205-100-50: hsl(205, 100%, 50%);
@@ -33,15 +34,17 @@
 
   --canvas-fill-color: var(--color-white);
 
+  --accent-color: var(--color-blue-205-100-40);
+
   --bendpoint-fill-color: var(--color-blue-205-100-45);
   --bendpoint-stroke-color: var(--canvas-fill-color);
 
   --context-pad-entry-background-color: var(--color-white);
   --context-pad-entry-hover-background-color: var(--color-grey-225-10-95);
 
-  --element-dragger-color: var(--color-blue-205-100-50);
+  --element-dragger-color: var(--accent-color);
   --element-hover-outline-fill-color: var(--color-blue-205-100-45);
-  --element-selected-outline-stroke-color: var(--color-blue-205-100-50);
+  --element-selected-outline-stroke-color: var(--accent-color);
   --element-selected-outline-secondary-stroke-color: var(--color-blue-205-100-70);
 
   --lasso-fill-color: var(--color-blue-205-100-50-opacity-15);
@@ -49,7 +52,7 @@
 
   --palette-entry-color: var(--color-grey-225-10-15);
   --palette-entry-hover-color: var(--color-blue-205-100-45);
-  --palette-entry-selected-color: var(--color-blue-205-100-50);
+  --palette-entry-selected-color: var(--accent-color);
   --palette-separator-color: var(--color-grey-225-10-75);
   --palette-toggle-hover-background-color: var(--color-grey-225-10-55);
   --palette-background-color: var(--color-grey-225-10-97);
@@ -58,7 +61,7 @@
   --popup-font-family: "IBM Plex Sans", sans-serif;
   --popup-font-size: 14px;
   --popup-secondary-font-size: .9em;
-  --popup-header-entry-selected-color: var(--color-blue-205-100-50);
+  --popup-header-entry-selected-color: var(--accent-color);
   --popup-header-font-weight: bolder;
   --popup-header-group-divider-color: var(--color-grey-225-10-75);
   --popup-background-color: var(--color-white);
@@ -70,14 +73,14 @@
   --popup-entry-title-color: var(--color-grey-225-10-55);
   --popup-entry-hover-color:  var(--color-grey-225-10-95);
   --popup-search-border-color: var(--color-grey-225-10-75);
-  --popup-search-focus-border-color: var(--color-blue-205-100-50);
+  --popup-search-focus-border-color: var(--accent-color);
   --popup-search-focus-background-color: var(--color-blue-205-100-95);
   --popup-tab-color: var(--color-grey-225-10-55);
   --popup-tab-hover-color: var(--color-grey-225-10-15);
   --popup-tab-active-color: var(--color-grey-225-10-15);
-  --popup-tab-active-border-color: var(--color-blue-205-100-50);
+  --popup-tab-active-border-color: var(--accent-color);
   --popup-tab-strip-border-color: var(--color-grey-225-10-90);
-  --popup-tab-focus-border-color: var(--color-blue-205-100-50);
+  --popup-tab-focus-border-color: var(--accent-color);
 
   --resizer-fill-color: var(--color-blue-205-100-45);
   --resizer-stroke-color: var(--canvas-fill-color);
@@ -87,17 +90,17 @@
   --search-container-background-color: var(--color-white);
   --search-shadow-color: var(--color-black-opacity-30);
   --search-input-border-color: var(--color-grey-225-10-75);
-  --search-input-focus-border-color: var(--color-blue-205-100-50);
+  --search-input-focus-border-color: var(--accent-color);
   --search-input-focus-background-color: var(--color-blue-205-100-95);
   --search-result-hover-background-color: var(--color-grey-225-10-95);
   --search-result-secondary-color: var(--color-grey-225-10-55);
   --search-preselected-background-color: var(--color-blue-205-100-50-opacity-15);
 
-  --shape-attach-allowed-stroke-color: var(--color-blue-205-100-50);
+  --shape-attach-allowed-stroke-color: var(--accent-color);
   --shape-connect-allowed-fill-color: var(--color-grey-225-10-97);
   --shape-drop-allowed-fill-color: var(--color-grey-225-10-97);
   --shape-drop-not-allowed-fill-color: var(--color-red-360-100-97);
-  --shape-resize-preview-stroke-color: var(--color-blue-205-100-50);
+  --shape-resize-preview-stroke-color: var(--accent-color);
 
   --snap-line-stroke-color: var(--color-blue-205-100-45-opacity-30);
 


### PR DESCRIPTION
### Proposed Changes

Re-anchor the shared primary accent from `--color-blue-205-100-50` (**3.12:1** on white — fails WCAG AA [1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)) to the accessible `--color-blue-205-100-40` (**4.66:1**) across the canvas accents: selection outline, dragger, palette entry, popup header/tab/search, and shape attach/resize previews:

<img width="1630" height="999" alt="capture VCbDXa_optimized" src="https://github.com/user-attachments/assets/a18680a3-49b2-4615-81cb-dd71a4e9699e" />

- Add the `--color-blue-205-100-40` palette primitive and a semantic `--accent-color` hook (matching the accent layer in properties-panel, so every package exposes one themeable accent).
- Route the **primary / active / focus-border** accents (selection outline, dragger, palette entry, popup header/tab/search, shape attach/resize) through `--accent-color`.
- **Keep** the secondary `-45` hover / bendpoint / resizer step and all translucent tints (lasso, snap line, preselect) unchanged.
- `-50` primitive retained for theme back-compat.

At `-40` the selection outline stays ≥ 3:1 against both the white canvas (4.66:1) and the near-black element stroke (4.51:1), so the "selected" affordance is preserved while downstream text/label reuse of the accent (links, badges) becomes AA-compliant.

Related to https://github.com/camunda/camunda-modeler/issues/6135

Part of a coordinated cross-repo rollout, released bottom-up: diagram-js → bpmn-js → properties-panel → element-templates.

### Steps to try out

```
npx @bpmn-io/sr bpmn-io/diagram-js#accessible-primary-accent
```

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
