### PR TITLE
Give handles a border radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 
 _**Note:** Yet to be released changes appear here._
 
+* `FEAT`: give resize handle a border radius ([#1100](https://github.com/bpmn-io/diagram-js/pull/1100))
 * `FEAT`: add `--accent-color` theming token ([#1099](https://github.com/bpmn-io/diagram-js/pull/1099))
 * `FIX`: use WCAG AA compliant primary accent color ([#1099](https://github.com/bpmn-io/diagram-js/pull/1099))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [diagram-js](https://github.com/bpmn-io/diagram-js) are d
 _**Note:** Yet to be released changes appear here._
 
 * `FEAT`: give resize handle a border radius ([#1100](https://github.com/bpmn-io/diagram-js/pull/1100))
+* `FEAT`: give segment dragger a border radius ([#1100](https://github.com/bpmn-io/diagram-js/pull/1100))
 * `FEAT`: add `--accent-color` theming token ([#1099](https://github.com/bpmn-io/diagram-js/pull/1099))
 * `FIX`: use WCAG AA compliant primary accent color ([#1099](https://github.com/bpmn-io/diagram-js/pull/1099))
 

--- a/lib/features/bendpoints/BendpointUtil.js
+++ b/lib/features/bendpoints/BendpointUtil.js
@@ -112,6 +112,7 @@ function createParallelDragger(parentGfx, segmentStart, segmentEnd, alignment) {
   svgAttr(visual, {
     x: -width / 2,
     y: -height / 2,
+    rx: 3,
     width: width,
     height: height
   });

--- a/lib/features/resize/ResizeHandles.js
+++ b/lib/features/resize/ResizeHandles.js
@@ -118,6 +118,7 @@ ResizeHandles.prototype._createResizer = function(element, x, y, direction) {
   svgAttr(visual, {
     x: -HANDLE_SIZE / 2 + offset.x,
     y: -HANDLE_SIZE / 2 + offset.y,
+    rx: 2,
     width: HANDLE_SIZE,
     height: HANDLE_SIZE
   });


### PR DESCRIPTION
### Proposed Changes

Give resize and bendpoint handles a slight border radius - complying with our "rounded" overall theme:

<img width="1507" height="892" alt="capture Bnq8MQ_optimized" src="https://github.com/user-attachments/assets/87aaaaaa-153c-4a3e-af11-d137ee3f47a4" />

Functionality unchanged - just a slight visual tuning.

### Checklist

Ensure you provide everything we need to review your contribution:

<!--
Do not alter this checklist beyond checking items; provide context above.
-->

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
